### PR TITLE
Shadow Chamber Issues Fix (#140)

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
@@ -138,79 +138,11 @@ simulated function BindLibraryItem()
 
 			break;
 		default:
-			/*********************************** Issue #140 ***********************************
-			* The code for this default case replaces the call to super.BindLibraryItem(). It's actually just a copy/paste
-			* of the super.BindLibraryItem() function with the below 2 lines taken out:
-			*     ShadowChamber = Spawn(class'UIAlertShadowChamberPanel', LibraryPanel);
-			*     ShadowChamber.InitPanel('UIAlertShadowChamberPanel', 'Alert_ShadowChamber');
-			*
-			* This is done so that normal missionss (gops, suply raids etc..) do not show shadow chamber information as
-			* this behavior is what vanilla LW2 implemented.
-		    **********************************************************************************/
-			AlertLibID = GetLibraryID();
+			super.BindLibraryItem();
 
-			if( AlertLibID != '' )
-			{
-				LibraryPanel = Spawn(class'UIPanel', self);
-				LibraryPanel.bAnimateOnInit = false;
-				LibraryPanel.InitPanel('LibraryPanel', AlertLibID);
-		
-				ButtonGroup = Spawn(class'UIPanel', LibraryPanel);
-				ButtonGroup.InitPanel('ButtonGroup', '');
-		
-				Button1 = Spawn(class'UIButton', ButtonGroup);
-				Button2 = Spawn(class'UIButton', ButtonGroup);
-		
-				Button3 = Spawn(class'UIButton', ButtonGroup);
-				Button3.SetResizeToText( false );
-				Button3.InitButton('Button2', "",, eUIButtonStyle_NONE);
-				Button3.OnSizeRealized = OnButtonSizeRealized;
-		
-				ConfirmButton = Spawn(class'UIButton', LibraryPanel);
-		
-				if( `ISCONTROLLERACTIVE == false )
-				{
-					ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked);
-					Button1.InitButton('Button0', "",, eUIButtonStyle_NONE);
-					Button2.InitButton('Button1', "",, eUIButtonStyle_NONE);
-					ConfirmButton.SetResizeToText(false);
-					Button1.SetResizeToText( false );
-					Button2.SetResizeToText(false);
-					Button1.OnSizeRealized = OnButtonSizeRealized;
-					Button2.OnSizeRealized = OnButtonSizeRealized;
-				}
-				else
-				{
-					//bsg-jneal (5.11.17): fix buttons styles on UIMissions
-					Button1.InitButton('Button0', "", OnLaunchClicked, eUIButtonStyle_NONE);
-					Button1.SetGamepadIcon(class'UIUtilities_Input'.static.GetAdvanceButtonIcon());
-					Button1.OnSizeRealized = OnButtonSizeRealized;
-					Button1.SetResizeToText(false);
-					
-					Button2.InitButton('Button1', "", OnCancelClicked, eUIButtonStyle_NONE);
-					Button2.SetGamepadIcon(class'UIUtilities_Input'.static.GetBackButtonIcon());
-					Button2.OnSizeRealized = OnButtonSizeRealized;
-					Button2.SetResizeToText(false);
-					//bsg-jneal (5.11.17): end
-		
-					ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked, eUIButtonStyle_HOTLINK_WHEN_SANS_MOUSE);
-					ConfirmButton.SetGamepadIcon(class'UIUtilities_Input'.static.GetAdvanceButtonIcon());
-					ConfirmButton.OnSizeRealized = OnButtonSizeRealized;
-					ConfirmButton.SetX(1450.0);
-					ConfirmButton.SetY(617.0);
-					ConfirmButton.SetWidth(300);
-				}
-		
-				ConfirmButton.DisableNavigation();
-		
-				SitrepPanel = Spawn(class'UIAlertSitRepPanel', LibraryPanel);
-				SitrepPanel.InitPanel('SitRep', 'Alert_SitRep');
-				SitrepPanel.SetTitle(m_strSitrepTitle);
-		
-				ChosenPanel = Spawn(class'UIPanel', LibraryPanel).InitPanel(, 'Alert_ChosenRegionInfo');
-				ChosenPanel.DisableNavigation();
-			}
-
+			//Issue #140 Hide the Shadow Chamber panel. Do not want to show for anything other than
+			//Golden Path missions.
+			ShadowChamber.Hide();
 		    break;
 	}
 }
@@ -425,8 +357,8 @@ simulated function UpdateData()
 	}
 	
 	/*********************************** Issue #140 ***********************************
-	* THe below code is replacing the call to super.UpdateData(). The code from the parent
-	* class verion of UpdateData() is pasted here except the call to UpdateMissionSchedules()
+	* The below code is replacing the call to super.UpdateData(). The code from the parent
+	* class version of UpdateData() is pasted here except the call to UpdateMissionSchedules()
 	* was removed as it was doing something to the mission schedules where it would create
 	* a new schedule for the mission with alert level of 1 so all missions would have
 	* much lower alert levels than they should causing baseline enemy activity to be wrong.

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
@@ -135,10 +135,83 @@ simulated function BindLibraryItem()
 				ShadowChamber = Spawn(class'UIAlertShadowChamberPanel', LibraryPanel);
 				ShadowChamber.InitPanel('ShadowChamber');
 			}
+
 			break;
 		default:
-			super.BindLibraryItem();
-			break;
+			/*********************************** Issue #140 ***********************************
+			* The code for this default case replaces the call to super.BindLibraryItem(). It's actually just a copy/paste
+			* of the super.BindLibraryItem() function with the below 2 lines taken out:
+			*     ShadowChamber = Spawn(class'UIAlertShadowChamberPanel', LibraryPanel);
+			*     ShadowChamber.InitPanel('UIAlertShadowChamberPanel', 'Alert_ShadowChamber');
+			*
+			* This is done so that normal missionss (gops, suply raids etc..) do not show shadow chamber information as
+			* this behavior is what vanilla LW2 implemented.
+		    **********************************************************************************/
+			AlertLibID = GetLibraryID();
+
+			if( AlertLibID != '' )
+			{
+				LibraryPanel = Spawn(class'UIPanel', self);
+				LibraryPanel.bAnimateOnInit = false;
+				LibraryPanel.InitPanel('LibraryPanel', AlertLibID);
+		
+				ButtonGroup = Spawn(class'UIPanel', LibraryPanel);
+				ButtonGroup.InitPanel('ButtonGroup', '');
+		
+				Button1 = Spawn(class'UIButton', ButtonGroup);
+				Button2 = Spawn(class'UIButton', ButtonGroup);
+		
+				Button3 = Spawn(class'UIButton', ButtonGroup);
+				Button3.SetResizeToText( false );
+				Button3.InitButton('Button2', "",, eUIButtonStyle_NONE);
+				Button3.OnSizeRealized = OnButtonSizeRealized;
+		
+				ConfirmButton = Spawn(class'UIButton', LibraryPanel);
+		
+				if( `ISCONTROLLERACTIVE == false )
+				{
+					ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked);
+					Button1.InitButton('Button0', "",, eUIButtonStyle_NONE);
+					Button2.InitButton('Button1', "",, eUIButtonStyle_NONE);
+					ConfirmButton.SetResizeToText(false);
+					Button1.SetResizeToText( false );
+					Button2.SetResizeToText(false);
+					Button1.OnSizeRealized = OnButtonSizeRealized;
+					Button2.OnSizeRealized = OnButtonSizeRealized;
+				}
+				else
+				{
+					//bsg-jneal (5.11.17): fix buttons styles on UIMissions
+					Button1.InitButton('Button0', "", OnLaunchClicked, eUIButtonStyle_NONE);
+					Button1.SetGamepadIcon(class'UIUtilities_Input'.static.GetAdvanceButtonIcon());
+					Button1.OnSizeRealized = OnButtonSizeRealized;
+					Button1.SetResizeToText(false);
+					
+					Button2.InitButton('Button1', "", OnCancelClicked, eUIButtonStyle_NONE);
+					Button2.SetGamepadIcon(class'UIUtilities_Input'.static.GetBackButtonIcon());
+					Button2.OnSizeRealized = OnButtonSizeRealized;
+					Button2.SetResizeToText(false);
+					//bsg-jneal (5.11.17): end
+		
+					ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked, eUIButtonStyle_HOTLINK_WHEN_SANS_MOUSE);
+					ConfirmButton.SetGamepadIcon(class'UIUtilities_Input'.static.GetAdvanceButtonIcon());
+					ConfirmButton.OnSizeRealized = OnButtonSizeRealized;
+					ConfirmButton.SetX(1450.0);
+					ConfirmButton.SetY(617.0);
+					ConfirmButton.SetWidth(300);
+				}
+		
+				ConfirmButton.DisableNavigation();
+		
+				SitrepPanel = Spawn(class'UIAlertSitRepPanel', LibraryPanel);
+				SitrepPanel.InitPanel('SitRep', 'Alert_SitRep');
+				SitrepPanel.SetTitle(m_strSitrepTitle);
+		
+				ChosenPanel = Spawn(class'UIPanel', LibraryPanel).InitPanel(, 'Alert_ChosenRegionInfo');
+				ChosenPanel.DisableNavigation();
+			}
+
+		    break;
 	}
 }
 
@@ -218,6 +291,7 @@ simulated function OnRemoved()
 
 	class'UIUtilities_Sound'.static.PlayCloseSound();
 }
+
 
 simulated function BuildMissionPanel()
 {
@@ -344,7 +418,24 @@ simulated function UpdateData()
 	BuildMissionPanel();
 	//RefreshNavigation();
 
-	super.UpdateData();
+	// Region Panel
+	if( LibraryPanel == none )
+	{
+		UpdateTitle('Region', GetRegion().GetMyTemplate().DisplayName, GetLabelColor(), 50);
+	}
+	
+	/*********************************** Issue #140 ***********************************
+	* THe below code is replacing the call to super.UpdateData(). The code from the parent
+	* class verion of UpdateData() is pasted here except the call to UpdateMissionSchedules()
+	* was removed as it was doing something to the mission schedules where it would create
+	* a new schedule for the mission with alert level of 1 so all missions would have
+	* much lower alert levels than they should causing baseline enemy activity to be wrong.
+	**********************************************************************************/
+	UpdateMissionTacticalTags();
+	AddMissionTacticalTags();
+	UpdateShadowChamber();
+	UpdateSitreps();
+	UpdateChosen();
 }
 
 simulated function bool CanBackOut()

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
@@ -131,7 +131,6 @@ simulated function BindLibraryItem()
 				Button3.SetResizeToText(false);
 				Button3.InitButton('Button2', "");
 
-				// WOTC TODO: Changed `UIPanel` to `UIAlertShadowChamberPanel` - check it works!
 				ShadowChamber = Spawn(class'UIAlertShadowChamberPanel', LibraryPanel);
 				ShadowChamber.InitPanel('ShadowChamber');
 			}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
@@ -5,6 +5,11 @@
 //---------------------------------------------------------------------------------------
 class UIMission_LWLaunchDelayedMission extends UIMission config(LW_InfiltrationSettings);
 
+//Issue #140
+//This needs to be here for the function BindLibraryItem() so that it can behave the same
+//as the BindLibraryItem() function in class UIMission_LWCustomMission().
+var EMissionUIType MissionUIType;
+
 var UITextContainer InfiltrationInfoText;
 var UITextContainer MissionInfoText;
 
@@ -50,6 +55,138 @@ simulated function InitScreen(XComPlayerController InitController, UIMovie InitM
 simulated function Name GetLibraryID()
 {
 	return 'Alert_GuerrillaOpsBlades';
+}
+
+/*********************************** Issue #140 ***********************************
+* This function needs to be here because this is the function that displays the
+* shadow chamber information on the top right of the mission information panel.
+* have to do the same thing that was done in class UIMission_LWCustomMission for
+* the BindLibraryItem() fucntion there.
+**********************************************************************************/
+simulated function BindLibraryItem()
+{
+	local Name AlertLibID;
+	local UIPanel DefaultPanel;
+
+	switch(MissionUIType)
+	{
+		case eMissionUI_AlienFacility:
+		case eMissionUI_GoldenPath:
+			AlertLibID = GetLibraryID();
+			if( AlertLibID != '' )
+			{
+				LibraryPanel = Spawn(class'UIPanel', self);
+				LibraryPanel.bAnimateOnInit = false;
+				LibraryPanel.InitPanel('', AlertLibID);
+				LibraryPanel.SetSelectedNavigation();
+
+				DefaultPanel = Spawn(class'UIPanel', LibraryPanel);
+				DefaultPanel.bAnimateOnInit = false;
+				DefaultPanel.bCascadeFocus = false;
+				DefaultPanel.InitPanel('DefaultPanel');
+				DefaultPanel.SetSelectedNavigation();
+
+				ConfirmButton = Spawn(class'UIButton', DefaultPanel);
+				ConfirmButton.SetResizeToText(false);
+				ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked);
+
+				ButtonGroup = Spawn(class'UIPanel', DefaultPanel);
+				ButtonGroup.InitPanel('ButtonGroup', '');
+
+				Button1 = Spawn(class'UIButton', ButtonGroup);
+				Button1.SetResizeToText(false);
+				Button1.InitButton('Button0', "");
+
+				Button2 = Spawn(class'UIButton', ButtonGroup);
+				Button2.SetResizeToText(false);
+				Button2.InitButton('Button1', "");
+
+				Button3 = Spawn(class'UIButton', ButtonGroup);
+				Button3.SetResizeToText(false);
+				Button3.InitButton('Button2', "");
+
+				// WOTC TODO: Changed `UIPanel` to `UIAlertShadowChamberPanel` - check it works!
+				ShadowChamber = Spawn(class'UIAlertShadowChamberPanel', LibraryPanel);
+				ShadowChamber.InitPanel('ShadowChamber');
+			}
+
+			break;
+		default:
+			/*********************************** Issue #140 ***********************************
+			* The code for this default case replaces the call to super.BindLibraryItem(). It's actually just a copy/paste
+			* of the super.BindLibraryItem() function with the below 2 lines taken out:
+			*     ShadowChamber = Spawn(class'UIAlertShadowChamberPanel', LibraryPanel);
+			*     ShadowChamber.InitPanel('UIAlertShadowChamberPanel', 'Alert_ShadowChamber');
+			*
+			* This is done so that normal missionss (gops, suply raids etc..) do not show shadow chamber information as
+			* this behavior is what vanilla LW2 implemented.
+		    **********************************************************************************/
+			AlertLibID = GetLibraryID();
+
+			if( AlertLibID != '' )
+			{
+				LibraryPanel = Spawn(class'UIPanel', self);
+				LibraryPanel.bAnimateOnInit = false;
+				LibraryPanel.InitPanel('LibraryPanel', AlertLibID);
+		
+				ButtonGroup = Spawn(class'UIPanel', LibraryPanel);
+				ButtonGroup.InitPanel('ButtonGroup', '');
+		
+				Button1 = Spawn(class'UIButton', ButtonGroup);
+				Button2 = Spawn(class'UIButton', ButtonGroup);
+		
+				Button3 = Spawn(class'UIButton', ButtonGroup);
+				Button3.SetResizeToText( false );
+				Button3.InitButton('Button2', "",, eUIButtonStyle_NONE);
+				Button3.OnSizeRealized = OnButtonSizeRealized;
+		
+				ConfirmButton = Spawn(class'UIButton', LibraryPanel);
+		
+				if( `ISCONTROLLERACTIVE == false )
+				{
+					ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked);
+					Button1.InitButton('Button0', "",, eUIButtonStyle_NONE);
+					Button2.InitButton('Button1', "",, eUIButtonStyle_NONE);
+					ConfirmButton.SetResizeToText(false);
+					Button1.SetResizeToText( false );
+					Button2.SetResizeToText(false);
+					Button1.OnSizeRealized = OnButtonSizeRealized;
+					Button2.OnSizeRealized = OnButtonSizeRealized;
+				}
+				else
+				{
+					//bsg-jneal (5.11.17): fix buttons styles on UIMissions
+					Button1.InitButton('Button0', "", OnLaunchClicked, eUIButtonStyle_NONE);
+					Button1.SetGamepadIcon(class'UIUtilities_Input'.static.GetAdvanceButtonIcon());
+					Button1.OnSizeRealized = OnButtonSizeRealized;
+					Button1.SetResizeToText(false);
+					
+					Button2.InitButton('Button1', "", OnCancelClicked, eUIButtonStyle_NONE);
+					Button2.SetGamepadIcon(class'UIUtilities_Input'.static.GetBackButtonIcon());
+					Button2.OnSizeRealized = OnButtonSizeRealized;
+					Button2.SetResizeToText(false);
+					//bsg-jneal (5.11.17): end
+		
+					ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked, eUIButtonStyle_HOTLINK_WHEN_SANS_MOUSE);
+					ConfirmButton.SetGamepadIcon(class'UIUtilities_Input'.static.GetAdvanceButtonIcon());
+					ConfirmButton.OnSizeRealized = OnButtonSizeRealized;
+					ConfirmButton.SetX(1450.0);
+					ConfirmButton.SetY(617.0);
+					ConfirmButton.SetWidth(300);
+				}
+		
+				ConfirmButton.DisableNavigation();
+		
+				SitrepPanel = Spawn(class'UIAlertSitRepPanel', LibraryPanel);
+				SitrepPanel.InitPanel('SitRep', 'Alert_SitRep');
+				SitrepPanel.SetTitle(m_strSitrepTitle);
+		
+				ChosenPanel = Spawn(class'UIPanel', LibraryPanel).InitPanel(, 'Alert_ChosenRegionInfo');
+				ChosenPanel.DisableNavigation();
+			}
+
+		    break;
+	}
 }
 
 simulated function BuildScreen()
@@ -371,7 +508,18 @@ simulated function UpdateData()
 	BuildMissionPanel();
 	//RefreshNavigation();
 
-	super.UpdateData();
+	/*********************************** Issue #140 ***********************************
+	* THe below code is replacing the call to super.UpdateData(). The code from the parent
+	* class verion of UpdateData() is pasted here except the call to UpdateMissionSchedules()
+	* was removed as it was doing something to the mission schedules where it would create
+	* a new schedule for the mission with alert level of 1 so all missions would have
+	* much lower alert levels than they should causing baseline enemy activity to be wrong.
+	**********************************************************************************/
+	UpdateMissionTacticalTags();
+	AddMissionTacticalTags();
+	UpdateShadowChamber();
+	UpdateSitreps();
+	UpdateChosen();
 }
 
 simulated function XComGameState_LWPersistentSquad GetInfiltratingSquad()

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
@@ -65,26 +65,15 @@ simulated function Name GetLibraryID()
 **********************************************************************************/
 simulated function BindLibraryItem()
 {
-	local Name AlertLibID;
-	local UIPanel DefaultPanel;
-	
 	super.BindLibraryItem();
 	
-	switch(MissionUIType)
+	if(MissionUIType != eMissionUI_GoldenPath)
 	{
-		case eMissionUI_GuerrillaOps:
-		case eMissionUI_SupplyRaid:
-		case eMissionUI_LandedUFO:
-		case eMissionUI_GPIntel:
-		case eMissionUI_Council:
-		case eMissionUI_Retaliation:
-		case eMissionUI_Rendezvous:
-		case eMissionUI_Invasion:
-			//Issue #140 Hide the Shadow Chamber panel. Do not want to show for anything other than
-			//Golden Path missions.
-			ShadowChamber.Hide();
+		//Issue #140 Hide the Shadow Chamber panel. Do not want to show for anything other than
+		//Golden Path missions.
+		ShadowChamber.Hide();
 
-		    break;
+		break;
 	}
 }
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
@@ -112,78 +112,11 @@ simulated function BindLibraryItem()
 
 			break;
 		default:
-			/*********************************** Issue #140 ***********************************
-			* The code for this default case replaces the call to super.BindLibraryItem(). It's actually just a copy/paste
-			* of the super.BindLibraryItem() function with the below 2 lines taken out:
-			*     ShadowChamber = Spawn(class'UIAlertShadowChamberPanel', LibraryPanel);
-			*     ShadowChamber.InitPanel('UIAlertShadowChamberPanel', 'Alert_ShadowChamber');
-			*
-			* This is done so that normal missionss (gops, suply raids etc..) do not show shadow chamber information as
-			* this behavior is what vanilla LW2 implemented.
-		    **********************************************************************************/
-			AlertLibID = GetLibraryID();
+			super.BindLibraryItem();
 
-			if( AlertLibID != '' )
-			{
-				LibraryPanel = Spawn(class'UIPanel', self);
-				LibraryPanel.bAnimateOnInit = false;
-				LibraryPanel.InitPanel('LibraryPanel', AlertLibID);
-		
-				ButtonGroup = Spawn(class'UIPanel', LibraryPanel);
-				ButtonGroup.InitPanel('ButtonGroup', '');
-		
-				Button1 = Spawn(class'UIButton', ButtonGroup);
-				Button2 = Spawn(class'UIButton', ButtonGroup);
-		
-				Button3 = Spawn(class'UIButton', ButtonGroup);
-				Button3.SetResizeToText( false );
-				Button3.InitButton('Button2', "",, eUIButtonStyle_NONE);
-				Button3.OnSizeRealized = OnButtonSizeRealized;
-		
-				ConfirmButton = Spawn(class'UIButton', LibraryPanel);
-		
-				if( `ISCONTROLLERACTIVE == false )
-				{
-					ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked);
-					Button1.InitButton('Button0', "",, eUIButtonStyle_NONE);
-					Button2.InitButton('Button1', "",, eUIButtonStyle_NONE);
-					ConfirmButton.SetResizeToText(false);
-					Button1.SetResizeToText( false );
-					Button2.SetResizeToText(false);
-					Button1.OnSizeRealized = OnButtonSizeRealized;
-					Button2.OnSizeRealized = OnButtonSizeRealized;
-				}
-				else
-				{
-					//bsg-jneal (5.11.17): fix buttons styles on UIMissions
-					Button1.InitButton('Button0', "", OnLaunchClicked, eUIButtonStyle_NONE);
-					Button1.SetGamepadIcon(class'UIUtilities_Input'.static.GetAdvanceButtonIcon());
-					Button1.OnSizeRealized = OnButtonSizeRealized;
-					Button1.SetResizeToText(false);
-					
-					Button2.InitButton('Button1', "", OnCancelClicked, eUIButtonStyle_NONE);
-					Button2.SetGamepadIcon(class'UIUtilities_Input'.static.GetBackButtonIcon());
-					Button2.OnSizeRealized = OnButtonSizeRealized;
-					Button2.SetResizeToText(false);
-					//bsg-jneal (5.11.17): end
-		
-					ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked, eUIButtonStyle_HOTLINK_WHEN_SANS_MOUSE);
-					ConfirmButton.SetGamepadIcon(class'UIUtilities_Input'.static.GetAdvanceButtonIcon());
-					ConfirmButton.OnSizeRealized = OnButtonSizeRealized;
-					ConfirmButton.SetX(1450.0);
-					ConfirmButton.SetY(617.0);
-					ConfirmButton.SetWidth(300);
-				}
-		
-				ConfirmButton.DisableNavigation();
-		
-				SitrepPanel = Spawn(class'UIAlertSitRepPanel', LibraryPanel);
-				SitrepPanel.InitPanel('SitRep', 'Alert_SitRep');
-				SitrepPanel.SetTitle(m_strSitrepTitle);
-		
-				ChosenPanel = Spawn(class'UIPanel', LibraryPanel).InitPanel(, 'Alert_ChosenRegionInfo');
-				ChosenPanel.DisableNavigation();
-			}
+			//Issue #140 Hide the Shadow Chamber panel. Do not want to show for anything other than
+			//Golden Path missions.
+			ShadowChamber.Hide();
 
 		    break;
 	}
@@ -509,8 +442,8 @@ simulated function UpdateData()
 	//RefreshNavigation();
 
 	/*********************************** Issue #140 ***********************************
-	* THe below code is replacing the call to super.UpdateData(). The code from the parent
-	* class verion of UpdateData() is pasted here except the call to UpdateMissionSchedules()
+	* The below code is replacing the call to super.UpdateData(). The code from the parent
+	* class version of UpdateData() is pasted here except the call to UpdateMissionSchedules()
 	* was removed as it was doing something to the mission schedules where it would create
 	* a new schedule for the mission with alert level of 1 so all missions would have
 	* much lower alert levels than they should causing baseline enemy activity to be wrong.

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
@@ -67,53 +67,19 @@ simulated function BindLibraryItem()
 {
 	local Name AlertLibID;
 	local UIPanel DefaultPanel;
-
+	
+	super.BindLibraryItem();
+	
 	switch(MissionUIType)
 	{
-		case eMissionUI_AlienFacility:
-		case eMissionUI_GoldenPath:
-			AlertLibID = GetLibraryID();
-			if( AlertLibID != '' )
-			{
-				LibraryPanel = Spawn(class'UIPanel', self);
-				LibraryPanel.bAnimateOnInit = false;
-				LibraryPanel.InitPanel('', AlertLibID);
-				LibraryPanel.SetSelectedNavigation();
-
-				DefaultPanel = Spawn(class'UIPanel', LibraryPanel);
-				DefaultPanel.bAnimateOnInit = false;
-				DefaultPanel.bCascadeFocus = false;
-				DefaultPanel.InitPanel('DefaultPanel');
-				DefaultPanel.SetSelectedNavigation();
-
-				ConfirmButton = Spawn(class'UIButton', DefaultPanel);
-				ConfirmButton.SetResizeToText(false);
-				ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked);
-
-				ButtonGroup = Spawn(class'UIPanel', DefaultPanel);
-				ButtonGroup.InitPanel('ButtonGroup', '');
-
-				Button1 = Spawn(class'UIButton', ButtonGroup);
-				Button1.SetResizeToText(false);
-				Button1.InitButton('Button0', "");
-
-				Button2 = Spawn(class'UIButton', ButtonGroup);
-				Button2.SetResizeToText(false);
-				Button2.InitButton('Button1', "");
-
-				Button3 = Spawn(class'UIButton', ButtonGroup);
-				Button3.SetResizeToText(false);
-				Button3.InitButton('Button2', "");
-
-				// WOTC TODO: Changed `UIPanel` to `UIAlertShadowChamberPanel` - check it works!
-				ShadowChamber = Spawn(class'UIAlertShadowChamberPanel', LibraryPanel);
-				ShadowChamber.InitPanel('ShadowChamber');
-			}
-
-			break;
-		default:
-			super.BindLibraryItem();
-
+		case eMissionUI_GuerrillaOps:
+		case eMissionUI_SupplyRaid:
+		case eMissionUI_LandedUFO:
+		case eMissionUI_GPIntel:
+		case eMissionUI_Council:
+		case eMissionUI_Retaliation:
+        case eMissionUI_Rendezvous:
+		case eMissionUI_Invasion:
 			//Issue #140 Hide the Shadow Chamber panel. Do not want to show for anything other than
 			//Golden Path missions.
 			ShadowChamber.Hide();

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
@@ -72,8 +72,6 @@ simulated function BindLibraryItem()
 		//Issue #140 Hide the Shadow Chamber panel. Do not want to show for anything other than
 		//Golden Path missions.
 		ShadowChamber.Hide();
-
-		break;
 	}
 }
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
@@ -78,7 +78,7 @@ simulated function BindLibraryItem()
 		case eMissionUI_GPIntel:
 		case eMissionUI_Council:
 		case eMissionUI_Retaliation:
-        case eMissionUI_Rendezvous:
+		case eMissionUI_Rendezvous:
 		case eMissionUI_Invasion:
 			//Issue #140 Hide the Shadow Chamber panel. Do not want to show for anything other than
 			//Golden Path missions.


### PR DESCRIPTION
The Shadow Chamber had 2 issues. The first was that it displayed
information for missions that were not Golden Path missions or Alien
Facility missions which it was not supposed to do. The second issue
was that it set alert level to all missions to 1 which caused baseline
enemy activity to be wrong (too low) for a lot of the regions come late
game.