### PR TITLE
Haven Adviser Fix (#159)

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTacticalMissionUnitSpawner.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTacticalMissionUnitSpawner.uc
@@ -412,6 +412,7 @@ static function LoadLiaisonFromOutpost(XComGameState_LWOutpost Outpost,
 	local XComGameState_Item ItemState;
 	local XComGameState_BattleData BattleData;
 	local bool FoundTile;
+	local int NumAbilities;
 
 	if (!Outpost.HasLiaison())
 	{
@@ -447,6 +448,8 @@ static function LoadLiaisonFromOutpost(XComGameState_LWOutpost Outpost,
 		NewGameStateContext = class'XComGameStateContext_TacticalGameRule'.static.BuildContextFromGameRule(eGameRule_UnitAdded);
 		NewGameState = History.CreateNewGameState(true, NewGameStateContext);
 		Unit = XComGameState_Unit(NewGameState.ModifyStateObject(class'XComGameState_Unit', Unit.ObjectID));
+		//Issue #159, this is needed now for loading units from avenger to properly update gamestate.
+		Unit.BeginTacticalPlay(NewGameState);
 
 		PlayerState = class'Utilities_LW'.static.FindPlayer(Team);
 		class'Utilities_LW'.static.AddUnitToXComGroup(NewGameState, Unit, PlayerState, History);
@@ -477,6 +480,8 @@ static function LoadLiaisonFromOutpost(XComGameState_LWOutpost Outpost,
 		{
 			ItemState = XComGameState_Item(NewGameState.CreateStateObject(class'XComGameState_Item', ItemReference.ObjectID));
 			NewGameState.AddStateObject(ItemState);
+			//Issue #159, this is needed now for loading units from avenger to properly update gamestate.
+			ItemState.BeginTacticalPlay(NewGameState);
 
 			// add any cosmetic items that might exists
 			ItemState.CreateCosmeticItemUnit(NewGameState);
@@ -499,7 +504,11 @@ static function LoadLiaisonFromOutpost(XComGameState_LWOutpost Outpost,
 		{
 			ItemState = XComGameState_Item(NewGameState.CreateStateObject(class'XComGameState_Item', ItemReference.ObjectID));
 			NewGameState.AddStateObject(ItemState);
+			//Issue #159, this is needed now for loading units from avenger to properly update gamestate.
+			ItemState.BeginTacticalPlay(NewGameState);
 		}
+		//NumAbilities = Unit.GatherUnitAbilitiesForInit(NewGameState, PlayerState).Length;
+		//`Log("Number of unit abilities: " $ NumAbilities);
 		Rules.InitializeUnitAbilities(NewGameState, Unit);
 
 		// make the unit concealed, if they have Phantom

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTacticalMissionUnitSpawner.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTacticalMissionUnitSpawner.uc
@@ -412,7 +412,6 @@ static function LoadLiaisonFromOutpost(XComGameState_LWOutpost Outpost,
 	local XComGameState_Item ItemState;
 	local XComGameState_BattleData BattleData;
 	local bool FoundTile;
-	local int NumAbilities;
 
 	if (!Outpost.HasLiaison())
 	{

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTacticalMissionUnitSpawner.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTacticalMissionUnitSpawner.uc
@@ -478,8 +478,7 @@ static function LoadLiaisonFromOutpost(XComGameState_LWOutpost Outpost,
 
 		foreach Unit.InventoryItems(ItemReference)
 		{
-			ItemState = XComGameState_Item(NewGameState.CreateStateObject(class'XComGameState_Item', ItemReference.ObjectID));
-			NewGameState.AddStateObject(ItemState);
+			ItemState = XComGameState_Item(NewGameState.ModifyStateObject(class'XComGameState_Item', ItemReference.ObjectID));
 			//Issue #159, this is needed now for loading units from avenger to properly update gamestate.
 			ItemState.BeginTacticalPlay(NewGameState);
 
@@ -502,13 +501,11 @@ static function LoadLiaisonFromOutpost(XComGameState_LWOutpost Outpost,
 		// add the items to the gamestate for ammo merging
 		foreach Unit.InventoryItems(ItemReference)
 		{
-			ItemState = XComGameState_Item(NewGameState.CreateStateObject(class'XComGameState_Item', ItemReference.ObjectID));
-			NewGameState.AddStateObject(ItemState);
+			ItemState = XComGameState_Item(NewGameState.ModifyStateObject(class'XComGameState_Item', ItemReference.ObjectID));
 			//Issue #159, this is needed now for loading units from avenger to properly update gamestate.
 			ItemState.BeginTacticalPlay(NewGameState);
 		}
-		//NumAbilities = Unit.GatherUnitAbilitiesForInit(NewGameState, PlayerState).Length;
-		//`Log("Number of unit abilities: " $ NumAbilities);
+
 		Rules.InitializeUnitAbilities(NewGameState, Unit);
 
 		// make the unit concealed, if they have Phantom


### PR DESCRIPTION
This fix is for fixing the issue of haven advisers not getting any
abilities at all (not from perks, weapons, items, etc..). Looks like
Firaxis added a BeginTacticalPlay() function to some of the XCGS
classes that has to be called to properly load in the abilities.
This fifx just added the function calls in the proper places.