### PR TITLE
Fix officer slot in gts with NPSBD mod on

### DIFF
--- a/LongWarOfTheChosen/Config/XComPromotionUIMod.ini
+++ b/LongWarOfTheChosen/Config/XComPromotionUIMod.ini
@@ -1,0 +1,3 @@
+; Override which classes to ignore when showing the new promotion screen
+[NewPromotionScreenbyDefault.NewPromotionScreenByDefault_PromotionScreenListener]
+.IgnoreClassNames=UIArmory_LWOfficerPromotion


### PR DESCRIPTION
There was a bug with the New Promotion Screen By Default mod that made
it so that when you chose to put someone in officer training the game
would go to the soldier's ability page instead of the officer ability
page.

The credit for this fix goes to Martox.