### PR TITLE
Disable reusable weapon upgrades breakthrough

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -763,6 +763,9 @@ INSTANT_BUILD_TIMES=TRUE
 ALIEN_FACILITY_LEAD_RP_INCREMENT=1200
 ALIEN_FACILITY_LEAD_INTEL=5
 
+;Disable redundant WOTC techs/breakthroughs
++TechTable=(TechTemplateName="BreakthroughReuseWeaponUpgrades",	ProvingGround=false,	ModPointsToCompleteOnly=False,	PrereqTech1="", PrereqTech2="",	PrereqTech3="",	RequiredScienceScore=99999)
+
 ; Repeatedable permanent improvement projects; the increased cost for repeating is in DGD.ini
 +TechTable=(TechTemplateName="BasicResearchProject",			ProvingGround=false,	ResearchPointCost = 5200, ModPointsToCompleteOnly=true)
 +TechTable=(TechTemplateName="BasicEngineeringProject",			ProvingGround=false,	ResearchPointCost = 5200, ModPointsToCompleteOnly=true)


### PR DESCRIPTION
Make the reusable weapon upgrades tech unresearchable as it is a base feature in LW. Fixes #179.