### PR TITLE
Added ini tweak to fix MSGT abilities cost (#254)

### DIFF
--- a/LongWarOfTheChosen/Config/XComGameData.ini
+++ b/LongWarOfTheChosen/Config/XComGameData.ini
@@ -123,6 +123,9 @@ LandingRadius=0.015
 m_iMaxSoldiersOnMission=10
 VeteranSoldierRank=0
 
+;Added so MSGT skills don't cost 0 AP.
++AbilityPointCosts[7]=25
+
 CampaignDiffModOnMissionDiff[0]=0 ;Easy
 CampaignDiffModOnMissionDiff[1]=0 ;Normal
 CampaignDiffModOnMissionDiff[2]=0 ;Classic


### PR DESCRIPTION
With NPSBD being integrated it caused abilities at the MSGT rank to
cost 0 AP so a quick ini addition was made to fix.