### PR TITLE
Fix for burnout ability #233

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_TechnicalAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_TechnicalAbilitySet.uc
@@ -667,6 +667,11 @@ static function X2AbilityTemplate CreateBurnoutAbility()
 	WeaponEffect = new class'X2Effect_ApplySmokeGrenadeToWorld';
 	Template.AddTargetEffect (WeaponEffect);
 
+	// Fix for issue #233. Need to add a single target effect as well because for some
+	// reason the multi target effect for this does not update to give the smoke cover
+	// on the tile the soldier is on even though smoke is actually created there.
+	Template.AddTargetEffect(class'X2Item_DefaultGrenades'.static.SmokeGrenadeEffect());
+
 	Template.AddMultiTargetEffect(class'X2Item_DefaultGrenades'.static.SmokeGrenadeEffect());
 
 	Template.AdditionalAbilities.AddItem('BurnoutPassive');


### PR DESCRIPTION
The ability burnout was not updating the tile that the soldier was
standing in to give it the smoke cover bonus but was updating the tiles
adjacent to the unit. For some reeason the ability tempaltes multi
target effect for smoke only updated the adjacent tiles. This was fixed
by adding a single target effect that applied to the tile that the
soldier was on.