### PR TITLE
Council Mission alert screen for HQ Assault

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Activities.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Activities.ini
@@ -393,7 +393,7 @@ BUSY_HAVENS_SLOW_VIGILANCE_DECAY=TRUE
             )
 
 +MissionSettings=(MissionOrFamilyName="AssaultAlienBase_LW", \\
-              AlertName=, \\
+              AlertName="eAlert_CouncilComm", \\
               MissionSound="GeoscapeFanfares_AlienFacility", \\
               EventTrigger="", \\
               MissionUIType=eMissionUI_AlienFacility, \\


### PR DESCRIPTION
Not sure what LW2 was doing here since it is also missing this bit of config and gives a Council Message alert with only one button. But this will fix the immediate issue in #251.