### PR TITLE
Jm/issue 121 fix

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
@@ -97,10 +97,10 @@ static function CHEventListenerTemplate CreateTacticalListeners()
 // from UISoldierHeader was copied in here to calculate the defense stat of a soldier.
 static function EventListenerReturn OverrideSoldierHeader(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
 {
-    local XComSoldierHeader Header;
+	local XComSoldierHeader Header;
 	local string Defense;
 	local int DefenseBonus;
-    local X2EquipmentTemplate EquipmentTemplate;
+ 	local X2EquipmentTemplate EquipmentTemplate;
 	local XComGameState_Item TmpItem;
 	local XComSoldierHeaderElement DefenseElement;
 	local StateObjectReference NewItem;
@@ -110,7 +110,7 @@ static function EventListenerReturn OverrideSoldierHeader(Object EventData, Obje
 	local XComGameStateHistory History;
 	local XComGameState_Unit Unit;
 
-    DefenseElement = new class 'XComSoldierHeaderElement';
+	DefenseElement = new class 'XComSoldierHeaderElement';
 
 	History = `XCOMHISTORY;
 
@@ -174,8 +174,8 @@ static function EventListenerReturn OverrideSoldierHeader(Object EventData, Obje
 	
 	// If unit is a psi operative then replace their tech stat with the defense stat so Psi stat can be displayed where it
 	// normally is. Otherwise display defense stat where Psi stat would be.
-    if(Unit.IsPsiOperative())
-    {
+	if(Unit.IsPsiOperative())
+	{
 		Header.Elements[6] = DefenseElement;
 	}
 	else


### PR DESCRIPTION
Soldier defense was not being displayed in the armory like it was in
lw2. This uses a hook into a CHL event that allows overriding the
soldier header in the armory to display the defense stat.

The defense stat will be displayed at the bottom right corner of the
header where the psi stat normally goes unless the soldier is a psi
operative. In that case the defense stat replaces the hack stat and
the psi stat goes where it normally does.