### PR TITLE
Make Darkclaw a Utility Item (#341)

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -2341,6 +2341,7 @@ function ReconfigGear(X2ItemTemplate Template, int Difficulty)
 
 		switch (EquipmentTemplate.DataName)
 		{
+			case 'ChosenSniperPistol_XCOM':
 			case 'AlienHunterPistol_CV':
 			case 'AlienHunterPistol_MG':
 			case 'AlienHunterPistol_BM':


### PR DESCRIPTION
Chosen Hunter pistol was not classified as a utility slot pistol. Added
the needed code in LWTemplateMods to change it. It does the same thing
that is done for the alien hunter pistol.