### PR TITLE
Changed SMG Weapon Category (#317)

### DIFF
--- a/LongWarOfTheChosen/Config/XComClassData.ini
+++ b/LongWarOfTheChosen/Config/XComClassData.ini
@@ -52,6 +52,7 @@ NumInDeck=0
 +KillAssistsPerKill=5
 +SquaddieLoadout="SquaddieLWS_Technical"
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="rifle")
++AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="smg")
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="shotgun")
 +AllowedWeapons=(SlotType=eInvSlot_SecondaryWeapon, WeaponType="gauntlet")
 +AllowedWeapons=(SlotType=eInvSlot_HeavyWeapon, WeaponType="heavyammo")
@@ -226,6 +227,7 @@ NumInDeck=0
 +SquaddieLoadout="SquaddieLWS_Specialist"
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="rifle")
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="shotgun")
++AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="smg")
 +AllowedWeapons=(SlotType=eInvSlot_SecondaryWeapon, WeaponType="gremlin")
 +AllowedWeapons=(SlotType=eInvSlot_HeavyWeapon, WeaponType="heavy")
 +AllowedArmors="soldier"
@@ -401,6 +403,7 @@ NumInDeck=0
 +SquaddieLoadout="SquaddieLWS_Grenadier"
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="rifle")
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="shotgun")
++AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="smg")
 +AllowedWeapons=(SlotType=eInvSlot_SecondaryWeapon, WeaponType="grenade_launcher")
 +AllowedWeapons=(SlotType=eInvSlot_HeavyWeapon, WeaponType="heavy")
 +AllowedArmors="soldier"
@@ -733,6 +736,7 @@ NumInDeck=0
 +SquaddieLoadout="SquaddieLWS_Ranger"
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="rifle")
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="shotgun")
++AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="smg")
 +AllowedWeapons=(SlotType=eInvSlot_SecondaryWeapon, WeaponType="sawedoffshotgun")
 +AllowedWeapons=(SlotType=eInvSlot_HeavyWeapon, WeaponType="heavy")
 +AllowedArmors="soldier"
@@ -1050,6 +1054,7 @@ NumInDeck=0
 +SquaddieLoadout="SquaddieLWS_Assault"
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="shotgun")
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="rifle")
++AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="smg")
 +AllowedWeapons=(SlotType=eInvSlot_SecondaryWeapon, WeaponType="arcthrower")
 +AllowedWeapons=(SlotType=eInvSlot_HeavyWeapon, WeaponType="heavy")
 +AllowedArmors="soldier"
@@ -1212,6 +1217,7 @@ NumInDeck=0
 +SquaddieLoadout="SquaddieLWS_Shinobi"
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="rifle")
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="shotgun")
++AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="smg")
 +AllowedWeapons=(SlotType=eInvSlot_SecondaryWeapon, WeaponType="sword")
 +AllowedWeapons=(SlotType=eInvSlot_HeavyWeapon, WeaponType="heavy")
 +AllowedArmors="soldier"
@@ -1368,6 +1374,7 @@ NumInDeck=0
 [PsiOperative X2SoldierClassTemplate]
 
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="shotgun")
++AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="smg")
 +AllowedWeapons=(SlotType=eInvSlot_HeavyWeapon, WeaponType="heavy")
 
 +RandomAbilityDecks=(DeckName="Tier1_XComAbilities", \\
@@ -1590,6 +1597,9 @@ bHasClassMovie=true
 				aStatProgression=((StatType=eStat_Offense,StatAmount=3), (StatType=eStat_HP,StatAmount=0), (StatType=eStat_Strength,StatAmount=1), (StatType=eStat_Hacking,StatAmount=5), (StatType=eStat_CombatSims,StatAmount=0)),\\
 			)
 
+[Rookie X2SoldierClassTemplate]
++AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="smg")
+
 ;************************************************************************************************************
 ;***                                      Rebel Personnel Class Data                                      ***
 ;************************************************************************************************************
@@ -1598,6 +1608,7 @@ bHasClassMovie=true
 +NumInDeck=0
 +NumInForcedDeck=0
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="rifle")
++AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="smg")
 +AllowedWeapons=(SlotType=eInvSlot_PrimaryWeapon, WeaponType="shotgun")
 +bBlockRankingUp=true
 +bHideInCharacterPool=true

--- a/LongWarOfTheChosen/Config/XComGameData.ini
+++ b/LongWarOfTheChosen/Config/XComGameData.ini
@@ -709,6 +709,7 @@ REPEAT_BASIC_ENGINEERING_INCREASE = 2800
 +WeaponCategories="combatknife"
 +WeaponCategories="gauntlet"
 +WeaponCategories="heavyammo"
++WeaponCategories="smg"
 
 -UniqueEquipCategories="grenade"
 +UniqueEquipCategories="pistol"

--- a/LongWarOfTheChosen/Config/XComLW_InfiltrationSettings.ini
+++ b/LongWarOfTheChosen/Config/XComLW_InfiltrationSettings.ini
@@ -284,6 +284,7 @@ EMPTY_UTILITY_SLOT_WEIGHT=0.2f;
 +WeaponCategoryCovertness=(CategoryName="sparkbit",			CovertnessValue=100f, CovertnessWeight=0.5f)
 +WeaponCategoryCovertness=(CategoryName="sawedoffshotgun",	CovertnessValue=100f, CovertnessWeight=0.5f)
 +WeaponCategoryCovertness=(CategoryName="psiamp",			CovertnessValue=100f, CovertnessWeight=0.5f)
++WeaponCategoryCovertness=(CategoryName="smg",				CovertnessValue=80f, CovertnessWeight=1.0f)
 
 +WeaponCategoryCovertness=(CategoryName="pistol",			CovertnessValue=100f, CovertnessWeight=0.2f)
 

--- a/LongWarOfTheChosen/Config/XComLW_OfficerPack.ini
+++ b/LongWarOfTheChosen/Config/XComLW_OfficerPack.ini
@@ -161,6 +161,7 @@ VALIDWEAPONCATEGORIES[2]="cannon"
 VALIDWEAPONCATEGORIES[3]="sniper_rifle"
 VALIDWEAPONCATEGORIES[4]="pistol"
 VALIDWEAPONCATEGORIES[5]="sword"
+VALIDWEAPONCATEGORIES[5]="smg"
 
 [LW_OfficerPack_Integrated.X2Effect_Scavenger]
 ;bonus mission supplies from Scavenger ability

--- a/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Item_LWAlienWeapons.uc
+++ b/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Item_LWAlienWeapons.uc
@@ -467,7 +467,7 @@ static function X2DataTemplate CreateTemplate_Sidewinder_WPN(name TemplateName)
 	
 	Template.WeaponPanelImage = "_ConventionalRifle";                       // used by the UI. Probably determines iconview of the weapon.
 	Template.ItemCat = 'weapon';
-	Template.WeaponCat = 'rifle';
+	Template.WeaponCat = 'smg';
 	Template.WeaponTech = 'beam';
 	Template.strImage = "img:///LWSidewinderSMG.Textures.LWBeamSMG_Common"; 
 	Template.RemoveTemplateAvailablility(Template.BITFIELD_GAMEAREA_Multiplayer); //invalidates multiplayer availability

--- a/LongWarOfTheChosen/Src/LW_LaserPack_Integrated/Classes/X2Item_LaserWeapons.uc
+++ b/LongWarOfTheChosen/Src/LW_LaserPack_Integrated/Classes/X2Item_LaserWeapons.uc
@@ -6,8 +6,8 @@
 //---------------------------------------------------------------------------------------
 class X2Item_LaserWeapons extends X2Item config(GameData_WeaponData);
 
-// Variables from config - GameData_WeaponData.ini
-// ***** Damage arrays for attack actions  *****
+//ï¿½Variablesï¿½fromï¿½configï¿½-ï¿½GameData_WeaponData.ini
+//ï¿½*****ï¿½Damageï¿½arraysï¿½forï¿½attackï¿½actionsï¿½ï¿½*****
 
 var config WeaponDamageValue ASSAULTRIFLE_LASER_BASEDAMAGE;
 var config WeaponDamageValue SMG_LASER_BASEDAMAGE;
@@ -17,7 +17,7 @@ var config WeaponDamageValue SNIPERRIFLE_LASER_BASEDAMAGE;
 var config WeaponDamageValue PISTOL_LASER_BASEDAMAGE;
 var config WeaponDamageValue SWORD_LASER_BASEDAMAGE;
 
-// ***** Core properties and variables for weapons *****
+//ï¿½*****ï¿½Core properties and variablesï¿½forï¿½weaponsï¿½*****
 var config int ASSAULTRIFLE_LASER_AIM;
 var config int ASSAULTRIFLE_LASER_CRITCHANCE;
 var config int ASSAULTRIFLE_LASER_ICLIPSIZE;
@@ -182,7 +182,7 @@ static function X2DataTemplate CreateTemplate_SMG_Laser()
 
 	`CREATE_X2TEMPLATE(class'X2WeaponTemplate', Template, 'SMG_LS');
 
-	Template.WeaponCat = 'rifle';
+	Template.WeaponCat = 'smg';
 	Template.WeaponTech = 'laser_lw';
 	Template.ItemCat = 'weapon';
 	Template.strImage = "img:///" $ default.SMG_Laser_ImagePath; 

--- a/LongWarOfTheChosen/Src/LW_LaserPack_Integrated/Classes/X2Item_LaserWeapons.uc
+++ b/LongWarOfTheChosen/Src/LW_LaserPack_Integrated/Classes/X2Item_LaserWeapons.uc
@@ -6,8 +6,8 @@
 //---------------------------------------------------------------------------------------
 class X2Item_LaserWeapons extends X2Item config(GameData_WeaponData);
 
-//�Variables�from�config�-�GameData_WeaponData.ini
-//�*****�Damage�arrays�for�attack�actions��*****
+// Variables from config - GameData_WeaponData.ini
+// ***** Damage arrays for attack actions  *****
 
 var config WeaponDamageValue ASSAULTRIFLE_LASER_BASEDAMAGE;
 var config WeaponDamageValue SMG_LASER_BASEDAMAGE;
@@ -17,7 +17,7 @@ var config WeaponDamageValue SNIPERRIFLE_LASER_BASEDAMAGE;
 var config WeaponDamageValue PISTOL_LASER_BASEDAMAGE;
 var config WeaponDamageValue SWORD_LASER_BASEDAMAGE;
 
-//�*****�Core properties and variables�for�weapons�*****
+// ***** Core properties and variables for weapons *****
 var config int ASSAULTRIFLE_LASER_AIM;
 var config int ASSAULTRIFLE_LASER_CRITCHANCE;
 var config int ASSAULTRIFLE_LASER_ICLIPSIZE;

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Item_Coilguns.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Item_Coilguns.uc
@@ -117,7 +117,7 @@ static function X2DataTemplate CreateSMG_Coil_Template()
 
 	`CREATE_X2TEMPLATE(class'X2WeaponTemplate', Template, 'SMG_CG');
 
-	Template.WeaponCat = 'rifle';
+	Template.WeaponCat = 'smg';
 	Template.WeaponTech = 'coilgun_lw';
 	Template.ItemCat = 'weapon';
 	Template.strImage ="img:///" $ default.SMG_Coil_ImagePath;

--- a/LongWarOfTheChosen/Src/LW_SMGPack_Integrated/Classes/X2Item_SMGWeapon.uc
+++ b/LongWarOfTheChosen/Src/LW_SMGPack_Integrated/Classes/X2Item_SMGWeapon.uc
@@ -80,7 +80,7 @@ static function X2DataTemplate CreateTemplate_SMG_Conventional()
 	Template.EquipSound = "Conventional_Weapon_Equip";
 
 	Template.ItemCat = 'weapon';
-	Template.WeaponCat = 'rifle';
+	Template.WeaponCat = 'smg';
 	Template.WeaponTech = 'conventional';
 	Template.strImage = "img:///UILibrary_SMG.conventional.LWConvSMG_Base";
 	Template.WeaponPanelImage = "_ConventionalRifle";                       // used by the UI. Probably determines iconview of the weapon.
@@ -140,7 +140,7 @@ static function X2DataTemplate CreateTemplate_SMG_Magnetic()
 
 	`CREATE_X2TEMPLATE(class'X2WeaponTemplate', Template, 'SMG_MG');
 
-	Template.WeaponCat = 'rifle';
+	Template.WeaponCat = 'smg';
 	Template.WeaponTech = 'magnetic';
 	Template.ItemCat = 'weapon';
 	Template.strImage = "img:///UILibrary_SMG.magnetic.LWMagSMG_Base";
@@ -202,7 +202,7 @@ static function X2DataTemplate CreateTemplate_SMG_Beam()
 
 	`CREATE_X2TEMPLATE(class'X2WeaponTemplate', Template, 'SMG_BM');
 
-	Template.WeaponCat = 'rifle';
+	Template.WeaponCat = 'smg';
 	Template.WeaponTech = 'beam';
 	Template.ItemCat = 'weapon';
 	Template.strImage = "img:///UILibrary_SMG.Beam.LWBeamSMG_Base";


### PR DESCRIPTION
SMGs were getting the damage bonus from the assault rifle weapon
breakthrough. This was because their weapon category was 'rifle' which
is the same category as the assualt rifle. Changed the weapon category
to 'smg' and added the needed lines in XComClassData.ini to allow the
classes that could equipem them to continue to equip them.