### PR TITLE
#461 Shaken soldiers can no longer serve as haven advisers

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIPersonnel_Liaison.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIPersonnel_Liaison.uc
@@ -47,6 +47,7 @@ function bool UnitAvailableForLiaisonDuty(StateObjectReference UnitRef)
 		    && !Unit.IsPsiAbilityTraining()
 		    && !Unit.CanRankUpSoldier()
 			&& !Unit.IsRobotic()
+			&& Unit.GetMentalState() != eMentalState_Shaken
             // Need minimum rank to qualify for liaison duty
 		    && HasEligibleRegularRank
             //On mission handles existing liaisons and people currently infiltrating.

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
@@ -251,12 +251,9 @@ static protected function EventListenerReturn OnOverridePersonnelStatus(Object E
 		{
 			SetStatusTupleData(OverrideTuple, class'UIUtilities_Strategy'.default.m_strOnMissionStatus, "", "", 0, eUIState_Highlight, true);
 		}
-		else if (UnitState.GetRank() < class'XComGameState_LWOutpost'.default.REQUIRED_RANK_FOR_LIAISON_DUTY)
+		else if (UnitState.GetRank() < class'XComGameState_LWOutpost'.default.REQUIRED_RANK_FOR_LIAISON_DUTY && GetScreenOrChild('UIPersonnel_Liaison') != none)
 		{
-			if (GetScreenOrChild('UIPersonnel_Liaison') != none)
-			{
-				SetStatusTupleData(OverrideTuple, default.RankTooLow, "", "", 0, eUIState_Bad, true);
-			}
+			SetStatusTupleData(OverrideTuple, default.RankTooLow, "", "", 0, eUIState_Bad, true);
 		}
 		else if (SquadMgr != none && SquadMgr.UnitIsInAnySquad(UnitState.GetReference(), Squad))
 		{

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
@@ -251,11 +251,18 @@ static protected function EventListenerReturn OnOverridePersonnelStatus(Object E
 		{
 			SetStatusTupleData(OverrideTuple, class'UIUtilities_Strategy'.default.m_strOnMissionStatus, "", "", 0, eUIState_Highlight, true);
 		}
+		else if (UnitState.GetRank() < class'XComGameState_LWOutpost'.default.REQUIRED_RANK_FOR_LIAISON_DUTY)
+		{
+			if (GetScreenOrChild('UIPersonnel_Liaison') != none)
+			{
+				SetStatusTupleData(OverrideTuple, default.RankTooLow, "", "", 0, eUIState_Bad, true);
+			}
+		}
 		else if (SquadMgr != none && SquadMgr.UnitIsInAnySquad(UnitState.GetReference(), Squad))
 		{
 			if (SquadMgr.LaunchingMissionSquad.ObjectID != Squad.ObjectID)
 			{
-				if (UnitState.GetStatus() != eStatus_Healing && UnitState.GetStatus() != eStatus_Training)
+				if (UnitState.GetStatus() != eStatus_Healing && UnitState.GetStatus() != eStatus_Training && UnitState.GetMentalState() != eMentalState_Shaken)
 				{
 					if (GetScreenOrChild('UISquadSelect') != none)
 					{
@@ -266,13 +273,6 @@ static protected function EventListenerReturn OnOverridePersonnelStatus(Object E
 						SetStatusTupleData(OverrideTuple, default.UnitInSquad, "", "", 0, eUIState_Warning, true);
 					}
 				}
-			}
-		}
-		else if (UnitState.GetRank() < class'XComGameState_LWOutpost'.default.REQUIRED_RANK_FOR_LIAISON_DUTY)
-		{
-			if (GetScreenOrChild('UIPersonnel_Liaison') != none)
-			{
-				SetStatusTupleData(OverrideTuple, default.RankTooLow, "", "", 0, eUIState_Bad, true);
 			}
 		}
 	}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
@@ -719,9 +719,9 @@ function bool UpdatePostMission(XComGameState_MissionSite MissionSite, XComGameS
 			// Liaison didn't make it. Remove them from the haven and optionally capture them.
 			RemoveAndCaptureLiaison(NewGameState);
 		}
-		else if (Unit.IsInjured())
+		else if (Unit.IsInjured() || Unit.GetMentalState() == eMentalState_Shaken)
 		{
-			// Injured units are removed from the haven but remain on the avenger.
+			// Injured and shaken units are removed from the haven but remain on the avenger.
 			SetLiaison(EmptyRef, NewGameState);
 		}
 	}


### PR DESCRIPTION
- Can no longer select shaken soldiers to be advisers
- If an adviser becomes shaken on/after a mission, they will be removed as an adviser
- Shaken and Rank Too Low soldier statuses now have higher priority than Unit in Squad when on the select adviser screen