### PR TITLE
Classify Blazing Pinions as Explosive Type #482

### DIFF
--- a/LongWarOfTheChosen/Config/XComGameData_WeaponData.ini
+++ b/LongWarOfTheChosen/Config/XComGameData_WeaponData.ini
@@ -321,7 +321,7 @@ Avatar_AI_PsiAmp_AbilityDamage =			(Damage=8, Spread=2, PlusOne=0, Crit=0, Pierc
 Avatar_AI_PsiAmp_AbilityDamage =			(Damage=8, Spread=2, PlusOne=0, Crit=2, Pierce=0, Shred=0, Tag = "VoidRift", DamageType="Psi")
 Andromedon_AcidBlob_BaseDamage=				(Damage=5, Spread=1, PlusOne=0, Crit=0, Pierce=0, Shred=3, Rupture=1, Tag = "", DamageType="Acid")
 AndromedonRobot_EmitAcidCloud_BaseDamage=	(Damage=1, Spread=0, PlusOne=50, Crit=0, Pierce=3, Shred=0, Rupture=1, Tag = "", DamageType="Acid")
-Archon_BlazingPinions_BaseDamage=			(Damage=5, Spread=1, PlusOne=50, Crit=0, Pierce=0, Shred=0, Tag = "", DamageType="BlazingPinions")
+Archon_BlazingPinions_BaseDamage=			(Damage=5, Spread=1, PlusOne=50, Crit=0, Pierce=0, Shred=0, Tag = "", DamageType="Explosion")
 Chryssalid_ParthenogenicPoison_BaseDamage=	(Damage=2, Spread=1, PlusOne=0, Crit=0, Pierce=99, Shred=0, Tag = "", DamageType="Poison")
 Cyberus_Psi_Bomb_BaseDamage=				(Damage=6, Spread=1, PlusOne=50, Crit=0, Pierce=0, Shred=0, Tag = "", DamageType="Psi")
 Gatekeeper_AnimaConsume_BaseDamage=			(Damage=8, Spread=2, PlusOne=66, Crit=0, Pierce=0, Shred=0, Tag = "", DamageType="Psi")
@@ -1625,7 +1625,7 @@ VIPERKING_IDEALRANGE=6
 
 ARCHONKING_WPN_BASEDAMAGE=(Damage=8, Spread = 1, PlusOne = 50, Crit = 3, Pierce = 0, Shred = 2, Tag = "", DamageType="Projectile_BeamAlien")
 ARCHONKING_IDEALRANGE=6
-ARCHONKING_BLAZINGPINIONS_BASEDAMAGE=(Damage=4, Spread=2, PlusOne=0, Crit=0, Pierce=0, Shred=0, Tag = "", DamageType="BlazingPinions")
+ARCHONKING_BLAZINGPINIONS_BASEDAMAGE=(Damage=4, Spread=2, PlusOne=0, Crit=0, Pierce=0, Shred=0, Tag = "", DamageType="Explosion")
 ARCHONKING_ICARUS_DROP_BASEDAMAGE=(Damage=6, Spread=3, PlusOne=0, Crit=0, Pierce=0, Shred=0, Tag = "", DamageType="Melee")
 
 VIPERKING_BIND_BASEDAMAGE=(Damage=3, Spread=0, PlusOne=25, Crit=0, Pierce=-1, Shred=0, Tag = "", DamageType="Melee")


### PR DESCRIPTION
#482 

There has been confusion regarding the "Fortress" perk and its behavior regarding what it should and should not protect against. Given that the Blazing Pinions looks explosive in the game, I made this change to resolve any frustrating ambiguities during game play.

Referring to the second link in the issue, I did not make any changes to plasma or shredder blasters since those don't look like "explosions." (Kinda like the Sectopod wrath cannon)