### PR TITLE
#578 Slash and Knife Fighter can now target mind-controlled units

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GunnerAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GunnerAbilitySet.uc
@@ -282,6 +282,7 @@ static function X2AbilityTemplate AddKnifeFighter()
 	AdjacencyCondition = new class'X2Condition_UnitProperty';
 	AdjacencyCondition.RequireWithinRange = true;
 	AdjacencyCondition.WithinRange = 144; //1.5 tiles in Unreal units, allows attacks on the diag
+	AdjacencyCondition.TreatMindControlledSquadmateAsHostile = true;
 	Template.AbilityTargetConditions.AddItem(AdjacencyCondition);
 
 	// Shooter Conditions

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet.uc
@@ -3575,6 +3575,7 @@ static function X2AbilityTemplate AddSlash_LWAbility()
 	AdjacencyCondition = new class'X2Condition_UnitProperty';
 	AdjacencyCondition.RequireWithinRange = true;
 	AdjacencyCondition.WithinRange = 144; //1.5 tiles in Unreal units, allows attacks on the diag
+	AdjacencyCondition.TreatMindControlledSquadmateAsHostile = true;
 	Template.AbilityTargetConditions.AddItem(AdjacencyCondition);
 
 	// Shooter Conditions


### PR DESCRIPTION
Slash and Knife Fighter can now target enemies whom you have mind-controlled. Closes #578