### PR TITLE
#505 Added an Advanced Option to allow XCOM soldiers to purchase multiple perks per rank

### DIFF
--- a/LongWarOfTheChosen/Config/XComGame.ini
+++ b/LongWarOfTheChosen/Config/XComGame.ini
@@ -63,8 +63,12 @@ UseTeamSwapFix=true
 
 [BetterSecondWaveSupport.X2DownloadableContentInfo_BetterSecondWaveSupport]
 +AddSecondWave=(ID="EnableChosen", DifficultyValue=0)
++AddSecondWave=(ID="AllowSameRankAbilities", DifficultyValue=0)
 
 [EnableChosen SecondWaveOptionObject]
+CanChangeInCampaign=true
+
+[AllowSameRankAbilities SecondWaveOptionObject]
 CanChangeInCampaign=true
 
 [robojumperSquadSelect.X2DownloadableContentInfo_robojumperSquadSelect]

--- a/LongWarOfTheChosen/Localization/BetterSecondWaveSupport.int
+++ b/LongWarOfTheChosen/Localization/BetterSecondWaveSupport.int
@@ -1,11 +1,11 @@
 ; LWOTC Needs Translation
 [EnableChosen SecondWaveOptionObject]
 Tooltip="Enables the Chosen, who will activate after you complete the first network tower mission."
-Description="The Chosen: Enables the Chosen"
+Description="The Chosen: Enables the Chosen."
 ; End Translation
 
 ; LWOTC Needs Translation
 [AllowSameRankAbilities SecondWaveOptionObject]
-Tooltip="Allows XCOM soldiers to purchase multiple perks of the same rank with AP"
-Description="Allow Same Rank Abilities: XCOM soldiers can purchase multiple perks of the same rank with AP once the Training Center has been built."
+Tooltip="Allows XCOM soldiers to purchase multiple class abilities of the same rank with AP."
+Description="Allow Same Rank Abilities: Allows XCOM soldiers to purchase multiple class abilities of the same rank with AP once the Training Center has been built."
 ; End Translation

--- a/LongWarOfTheChosen/Localization/BetterSecondWaveSupport.int
+++ b/LongWarOfTheChosen/Localization/BetterSecondWaveSupport.int
@@ -1,3 +1,11 @@
+; LWOTC Needs Translation
 [EnableChosen SecondWaveOptionObject]
-Tooltip="Enables the Chosen, who will activate after you complete the first network tower mission"
+Tooltip="Enables the Chosen, who will activate after you complete the first network tower mission."
 Description="The Chosen: Enables the Chosen"
+; End Translation
+
+; LWOTC Needs Translation
+[AllowSameRankAbilities SecondWaveOptionObject]
+Tooltip="Allows XCOM soldiers to purchase multiple perks of the same rank with AP"
+Description="Allow Same Rank Abilities: XCOM soldiers can purchase multiple perks of the same rank with AP once the Training Center has been built."
+; End Translation

--- a/LongWarOfTheChosen/Src/NewPromotionScreenByDefault_Integrated/Classes/NPSBDP_UIArmory_PromotionHero.uc
+++ b/LongWarOfTheChosen/Src/NewPromotionScreenByDefault_Integrated/Classes/NPSBDP_UIArmory_PromotionHero.uc
@@ -566,8 +566,8 @@ function bool CanPurchaseAbility(int Rank, int Branch, name AbilityName)
 		return false;
 	}
 
-	// LWOTC: Don't allow purchase of other class abilities at same rank as an already picked one
-	if (!UnitState.IsResistanceHero() && UnitState.HasPurchasedPerkAtRank(Rank) && Branch < AbilityRanks)
+	// LWOTC: Don't allow purchase of other class abilities at same rank as an already picked one (unless second wave option enabled)
+	if (!UnitState.IsResistanceHero() && !`SecondWaveEnabled('AllowSameRankAbilities') && UnitState.HasPurchasedPerkAtRank(Rank) && Branch < AbilityRanks)
 	{
 		return false;
 	}


### PR DESCRIPTION
Added an Advanced Option to allow XCOM soldiers to purchase multiple perks per rank, as long as the Training Center has been built. Closes #505