### PR TITLE
Rebalance XCOM (random) abilities

### DIFF
--- a/LongWarOfTheChosen/Config/XComClassData.ini
+++ b/LongWarOfTheChosen/Config/XComClassData.ini
@@ -167,7 +167,7 @@ NumInDeck=0
 +SoldierRanks=( AbilitySlots=(	(AbilityType=(AbilityName="ConcussionRocket",	ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
 								(AbilityType=(AbilityName="Shredder",			ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
 								(AbilityType=(AbilityName="Burnout",				ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
-								(RandomDeckName="Tier2_XComAbilities"), \\
+								(RandomDeckName="Tier1_XComAbilities"), \\
 								(AbilityType=(AbilityName="ClutchShot",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_HP,StatAmount=1))\\
@@ -194,7 +194,7 @@ NumInDeck=0
 +SoldierRanks=( AbilitySlots=(	(AbilityType=(AbilityName="Salvo",				ApplyToWeaponSlot=eInvSlot_Unknown)), \\
 								(AbilityType=(AbilityName="TacticalSense"		)), \\
 								(AbilityType=(AbilityName="Quickburn",			ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
-								(RandomDeckName="Tier3_XComAbilities"), \\
+								(RandomDeckName="Tier2_XComAbilities"), \\
 								(AbilityType=(AbilityName="Faceoff",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0))\\
@@ -342,7 +342,7 @@ NumInDeck=0
 +SoldierRanks=( AbilitySlots=(	(AbilityType=(AbilityName="MedicalProtocol",		ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
 								(AbilityType=(AbilityName="ScanningProtocol",	ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
 								(AbilityType=(AbilityName="Trojan",				ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
-								(RandomDeckName="Tier2_XComAbilities"), \\
+								(RandomDeckName="Tier1_XComAbilities"), \\
 								(AbilityType=(AbilityName="ClutchShot",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_Hacking,StatAmount=5))\\
@@ -369,7 +369,7 @@ NumInDeck=0
 +SoldierRanks=( AbilitySlots=(	(AbilityType=(AbilityName="RescueProtocol",		ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
 								(AbilityType=(AbilityName="ThreatAssessment",	ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
 								(AbilityType=(AbilityName="FullOverride",		ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
-								(RandomDeckName="Tier3_XComAbilities"), \\
+								(RandomDeckName="Tier2_XComAbilities"), \\
 								(AbilityType=(AbilityName="Faceoff",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_Hacking,StatAmount=5))\\
@@ -511,7 +511,7 @@ NumInDeck=0
 +SoldierRanks=(	AbilitySlots=(	(AbilityType=(AbilityName="HeavyFrags"			)), \\
 								(AbilityType=(AbilityName="Formidable"			)), \\
 								(AbilityType=(AbilityName="BluescreenBombs",		ApplyToWeaponSlot=eInvSlot_Unknown)), \\
-								(RandomDeckName="Tier2_XComAbilities"), \\
+								(RandomDeckName="Tier1_XComAbilities"), \\
 								(AbilityType=(AbilityName="ClutchShot",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							 ), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_HP,StatAmount=1), (StatType=eStat_Strength,StatAmount=1)) \\
@@ -538,7 +538,7 @@ NumInDeck=0
 +SoldierRanks=( AbilitySlots=(	(AbilityType=(AbilityName="VolatileMix"		)), \\
  								(AbilityType=(AbilityName="Bombard_LW",		ApplyToWeaponSlot=eInvSlot_Unknown)), \\
 								(AbilityType=(AbilityName="Salvo",			ApplyToWeaponSlot=eInvSlot_Unknown)), \\
-								(RandomDeckName="Tier3_XComAbilities"), \\
+								(RandomDeckName="Tier2_XComAbilities"), \\
 								(AbilityType=(AbilityName="Faceoff",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_Strength,StatAmount=1)) \\
@@ -674,7 +674,7 @@ NumInDeck=0
 +SoldierRanks=(  AbilitySlots=(	(AbilityType=(AbilityName="HailofBullets",		ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
 								(AbilityType=(AbilityName="Shredder",			ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
 								(AbilityType=(AbilityName="Mayhem",				ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
-								(RandomDeckName="Tier2_XComAbilities"), \\
+								(RandomDeckName="Tier1_XComAbilities"), \\
 								(AbilityType=(AbilityName="ClutchShot",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							 ), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_Strength,StatAmount=1)) \\
@@ -701,7 +701,7 @@ NumInDeck=0
 +SoldierRanks=( AbilitySlots=(	(AbilityType=(AbilityName="BulletShred",			ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
  								(AbilityType=(AbilityName="RapidFire",			ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
 								(AbilityType=(AbilityName="Killzone",		ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
-								(RandomDeckName="Tier3_XComAbilities"), \\
+								(RandomDeckName="Tier2_XComAbilities"), \\
 								(AbilityType=(AbilityName="Faceoff",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_Strength,StatAmount=1)) \\
@@ -835,7 +835,7 @@ NumInDeck=0
 +SoldierRanks=(  AbilitySlots=(	(AbilityType=(AbilityName="Aggression",			ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
 								(AbilityType=(AbilityName="CenterMass",			ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
 								(AbilityType=(AbilityName="CoolUnderPressure",	ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
-								(RandomDeckName="Tier2_XComAbilities"), \\
+								(RandomDeckName="Tier1_XComAbilities"), \\
 								(AbilityType=(AbilityName="ClutchShot",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							 ), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0))\\
@@ -862,7 +862,7 @@ NumInDeck=0
 +SoldierRanks=( AbilitySlots=(	(AbilityType=(AbilityName="RapidFire",			ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
  								(AbilityType=(AbilityName="TacticalSense"		)), \\
 								(AbilityType=(AbilityName="RapidReaction",		ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
-								(RandomDeckName="Tier3_XComAbilities"), \\
+								(RandomDeckName="Tier2_XComAbilities"), \\
 								(AbilityType=(AbilityName="Faceoff",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=3), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_Strength,StatAmount=1)) \\
@@ -992,7 +992,7 @@ NumInDeck=0
 +SoldierRanks=(  AbilitySlots=(	(AbilityType=(AbilityName="PrecisionShot",		ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
 								(AbilityType=(AbilityName="HDHolo",				ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
 								(AbilityType=(AbilityName="LoneWolf",			ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
-								(RandomDeckName="Tier2_XComAbilities"), \\
+								(RandomDeckName="Tier1_XComAbilities"), \\
 								(AbilityType=(AbilityName="ClutchShot",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=3), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_HP,StatAmount=1)) \\
@@ -1019,7 +1019,7 @@ NumInDeck=0
 +SoldierRanks=( AbilitySlots=(	(AbilityType=(AbilityName="Kubikuri",				ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
  								(AbilityType=(AbilityName="Multitargeting",			ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
 								(AbilityType=(AbilityName="HuntersInstinct",			ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
-								(RandomDeckName="Tier3_XComAbilities"), \\
+								(RandomDeckName="Tier2_XComAbilities"), \\
 								(AbilityType=(AbilityName="Faceoff",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
                             ), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=3), (StatType=eStat_Will,StatAmount=0)) \\
@@ -1155,7 +1155,7 @@ NumInDeck=0
 +SoldierRanks=(  AbilitySlots=(	(AbilityType=(AbilityName="KillerInstinct",		ApplyToWeaponSlot=eInvSlot_Unknown)), \\
 								(AbilityType=(AbilityName="StunGunner",			ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
 								(AbilityType=(AbilityName="Fortify"				)), \\
-								(RandomDeckName="Tier2_XComAbilities"), \\
+								(RandomDeckName="Tier1_XComAbilities"), \\
 								(AbilityType=(AbilityName="ClutchShot",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							 ), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_HP,StatAmount=1), (StatType=eStat_Strength,StatAmount=1)) \\
@@ -1182,7 +1182,7 @@ NumInDeck=0
 +SoldierRanks=( AbilitySlots=(	(AbilityType=(AbilityName="BringEmOn",				ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
  								(AbilityType=(AbilityName="CloseCombatSpecialist",	ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
 								(AbilityType=(AbilityName="Untouchable"				)), \\
-								(RandomDeckName="Tier3_XComAbilities"), \\
+								(RandomDeckName="Tier2_XComAbilities"), \\
 								(AbilityType=(AbilityName="Faceoff",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
                             ), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_Strength,StatAmount=1)) \\
@@ -1323,7 +1323,7 @@ NumInDeck=0
 +SoldierRanks=(  AbilitySlots=(	(AbilityType=(AbilityName="Covert"				)), \\
 								(AbilityType=(AbilityName="HardTarget"			)), \\
 								(AbilityType=(AbilityName="Cutthroat",			ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
-								(RandomDeckName="Tier2_XComAbilities"), \\
+								(RandomDeckName="Tier1_XComAbilities"), \\
 								(AbilityType=(AbilityName="ClutchShot",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							 ), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_Dodge,StatAmount=1), (StatType=eStat_Strength,StatAmount=1), (StatType=eStat_Hacking,StatAmount=5)) \\
@@ -1350,7 +1350,7 @@ NumInDeck=0
 +SoldierRanks=( AbilitySlots=(	(AbilityType=(AbilityName="Tradecraft"			)), \\
  								(AbilityType=(AbilityName="HitAndRun",			ApplyToWeaponSlot=eInvSlot_PrimaryWeapon)), \\
 								(AbilityType=(AbilityName="Whirlwind2",			ApplyToWeaponSlot=eInvSlot_SecondaryWeapon)), \\
-								(RandomDeckName="Tier3_XComAbilities"), \\
+								(RandomDeckName="Tier2_XComAbilities"), \\
 								(AbilityType=(AbilityName="Faceoff",		ApplyToWeaponSlot=eInvSlot_Utility)), \\
 							), \\
 				aStatProgression=((StatType=eStat_Offense,StatAmount=2), (StatType=eStat_Will,StatAmount=0), (StatType=eStat_Dodge,StatAmount=1), (StatType=eStat_HP,StatAmount=1), (StatType=eStat_Hacking,StatAmount=5)) \\

--- a/LongWarOfTheChosen/Config/XComGameData.ini
+++ b/LongWarOfTheChosen/Config/XComGameData.ini
@@ -127,14 +127,14 @@ VeteranSoldierRank=0
 AbilityPointCosts[0]=0 ; Squaddie
 AbilityPointCosts[1]=10 ; LCpl
 AbilityPointCosts[2]=10 ; Cpl
-AbilityPointCosts[3]=15 ; Sgt
-AbilityPointCosts[4]=15 ; SSgt
-AbilityPointCosts[5]=15 ; TSgt
+AbilityPointCosts[3]=10 ; Sgt
+AbilityPointCosts[4]=20 ; SSgt
+AbilityPointCosts[5]=20 ; TSgt
 AbilityPointCosts[6]=20 ; GSgt
-AbilityPointCosts[7]=20 ; MSgt
+AbilityPointCosts[7]=40 ; MSgt
 
 ; Used for XCOM abilities gained by the Faction heroes which are really powerful
-PowerfulAbilityPointCost=20
+PowerfulAbilityPointCost=40
 
 ; Won't change these for now. Copying from the base game config for
 ; easier tuning later.


### PR DESCRIPTION
Soldier classes now have a choice of 3 T1, 3 T2, and 1 T3 ability, changed from 2 T1, 3 T2, and 2 T3. The costs of T1/T2/T3 have also changed to 10/20/40.

This means standard and above average combat intelligence can't cover a T3 ability alone. It also favours a bit more distinction between soldiers at the T1 level, because those are the ones most soldiers will be able to afford. And now it's a trade off of one T2 ability vs 2 T1 abilities.

Hopefully this will mean more disintictive, but not over-powered soldiers.