### PR TITLE
Found a fix to reduce healrate bonus

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -498,8 +498,7 @@ function UpdateStaffSlotTemplate(X2StrategyElementTemplate Template, int Difficu
 	StaffSlotTemplate = X2StaffSlotTemplate(Template);
 	if(StaffSlotTemplate == none)
 		return;
-	
-	/* WOTC TODO: Work out how to replace the AWC stuff
+
 	switch (StaffSlotTemplate.DataName)
 	{
 		case 'AWCScientistStaffSlot':
@@ -513,7 +512,6 @@ function UpdateStaffSlotTemplate(X2StrategyElementTemplate Template, int Difficu
 		default:
 			break;
 	}
-	*/
 }
 
 static function int GetAWCContribution_LW(XComGameState_Unit UnitState)
@@ -538,7 +536,7 @@ static function int GetAWCAvengerBonus_LW(XComGameState_Unit UnitState, optional
 	return Round(PercentIncrease);
 }
 
-static function FillAWCSciSlot_LW(XComGameState NewGameState, StateObjectReference SlotRef, StaffUnitInfo UnitInfo)
+static function FillAWCSciSlot_LW(XComGameState NewGameState, StateObjectReference SlotRef, StaffUnitInfo UnitInfo, optional bool bTemporary = false)
 {
 	local XComGameState_HeadquartersXCom NewXComHQ;
 	local XComGameState_Unit NewUnitState;
@@ -1945,7 +1943,7 @@ function GeneralCharacterMod(X2CharacterTemplate Template, int Difficulty)
 			Template.Abilities.AddItem('CoupdeGrace2');
 			Template.Abilities.AddItem('Whirlwind2');
 			break;
-		case 'Sectopod'
+		case 'Sectopod':
 			Template.Abilities.AddItem('Resilience');
 			break;
 		// Should turn off tick damage every action


### PR DESCRIPTION
Should fix https://github.com/long-war-2/lwotc/issues/481. The code was there but commented out because it was broken, but all that was needed to be done was edit the signature of FillAWCSciSlot_LW.

Was there a reason this wasn't done already or was it just that it was really low priority? If there was some other reason this was commented out let me now and I'll look into it.