### PR TITLE
Faceless Spawn Fix v2 #749

### DIFF
--- a/LongWarOfTheChosen/Config/XComSchedules.ini
+++ b/LongWarOfTheChosen/Config/XComSchedules.ini
@@ -262,9 +262,8 @@
 					PrePlacedEncounters[3]=(EncounterID="ADVx2_Standard_LW",				EncounterZoneOffsetAlongLOP=4.0,	EncounterZoneWidth=44.0), \\
 					PrePlacedEncounters[4]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=0.0,	EncounterZoneWidth=45.0, EncounterZoneDepthOverride=45.0), \\
 					PrePlacedEncounters[5]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=20.0,	EncounterZoneWidth=45.0, EncounterZoneDepthOverride=45.0), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0,	EncounterZoneWidth=44.0), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid",					EncounterZoneOffsetAlongLOP=-11.0,	EncounterZoneWidth=10.0, EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid",					EncounterZoneOffsetAlongLOP=-11.0,	EncounterZoneWidth=10.0, EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					)
 
 ; 12
@@ -385,11 +384,10 @@
 					PrePlacedEncounters[3]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=0.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
 					PrePlacedEncounters[4]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=15.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
 					PrePlacedEncounters[5]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=10.0,	EncounterZoneWidth=65.0,	EncounterZoneDepthOverride=45.0), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, EncounterZoneWidth=25.0), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_D5_4_LW", \\
@@ -506,13 +504,12 @@
 					PrePlacedEncounters[4]=(EncounterID="ALNx3_Bucket_Standard_LW",			EncounterZoneOffsetAlongLOP=-6.0,	EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[5]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=0.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
 					PrePlacedEncounters[6]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=15.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0,	EncounterZoneWidth=44.0), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[10]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[11]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[10]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_D7_2_LW", \\
@@ -568,13 +565,12 @@
 					PrePlacedEncounters[1]=(EncounterID="OPNx4_Standard_LW",			EncounterZoneOffsetAlongLOP=-3.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
 					PrePlacedEncounters[2]=(EncounterID="OPNx4_Standard_LW",			EncounterZoneOffsetAlongLOP=22.0, EncounterZoneWidth=44.0), \\
 					PrePlacedEncounters[3]=(EncounterID="OPNx4_Standard_LW",			EncounterZoneOffsetAlongLOP=6.0, EncounterZoneWidth=44.0), \\
-					PrePlacedEncounters[4]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[4]=(EncounterID="DKVx1_Chryssalid",				EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid",				EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid",				EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
+					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					)
 
 ; 18
@@ -754,13 +750,12 @@
 					PrePlacedEncounters[1]=(EncounterID="OPNx5_Standard_LW",			EncounterZoneOffsetAlongLOP=10.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[2]=(EncounterID="ADVx5_Standard_LW",			EncounterZoneOffsetAlongLOP=-10.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[3]=(EncounterID="ALNx3_Bucket_Standard_LW",		EncounterZoneOffsetAlongLOP=25.0, EncounterZoneWidth=45.0), \\
-					PrePlacedEncounters[4]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[4]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 ; 21
@@ -780,7 +775,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_D10_2_LW", \\
@@ -959,13 +953,12 @@
 					PrePlacedEncounters[2]=(EncounterID="ADVx4_Standard_LW", EncounterZoneOffsetAlongLOP=4.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
 					PrePlacedEncounters[3]=(EncounterID="ADVx3_Standard_LW", EncounterZoneOffsetAlongLOP=25.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[4]=(EncounterID="ALNx3_Bucket_Standard_LW", EncounterZoneOffsetAlongLOP=16.0, EncounterZoneWidth=45.0), \\
-					PrePlacedEncounters[5]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 ; 24
@@ -982,14 +975,12 @@
 					PrePlacedEncounters[4]=(EncounterID="Lone_Drone_LW",		EncounterZoneOffsetAlongLOP=0.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
 					PrePlacedEncounters[5]=(EncounterID="Lone_Drone_LW",		EncounterZoneOffsetAlongLOP=15.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
 					PrePlacedEncounters[6]=(EncounterID="Lone_Drone_LW",	 EncounterZoneOffsetAlongLOP=10.0,	EncounterZoneWidth=65.0,	EncounterZoneDepthOverride=45.0), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=-5.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-12.0, EncounterZoneWidth=10.0, \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-12.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[10]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+					PrePlacedEncounters[8]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[11]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[12]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[10]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_D12_2_LW", \\
@@ -1158,13 +1149,12 @@
 					PrePlacedEncounters[2]=(EncounterID="OPNx5_Standard_LW", EncounterZoneOffsetAlongLOP=-12.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[3]=(EncounterID="OPNx6_Standard_LW", EncounterZoneOffsetAlongLOP=22.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[4]=(EncounterID="ADVx6_Standard_LW", EncounterZoneOffsetAlongLOP=-4.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
-					PrePlacedEncounters[5]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					)
 
 ;27
@@ -1285,7 +1275,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_D15_2_LW", \\
@@ -1357,13 +1346,12 @@
 					PrePlacedEncounters[2]=(EncounterID="OPNx6_Standard_LW", EncounterZoneOffsetAlongLOP=-12.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[3]=(EncounterID="OPNx6_Standard_LW", EncounterZoneOffsetAlongLOP=22.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[4]=(EncounterID="ADVx4_Standard_LW", EncounterZoneOffsetAlongLOP=-4.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
-					PrePlacedEncounters[5]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=15.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					)
 
 ;30
@@ -1403,7 +1391,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 ;31-32
@@ -1424,7 +1411,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_D17_2_LW", \\
@@ -1464,7 +1450,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 ; 33
@@ -1499,13 +1484,12 @@
 					PrePlacedEncounters[2]=(EncounterID="OPNx8_Standard_LW", EncounterZoneOffsetAlongLOP=-12.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[3]=(EncounterID="OPNx8_Standard_LW", EncounterZoneOffsetAlongLOP=22.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[4]=(EncounterID="ADVx2_Standard_LW", EncounterZoneOffsetAlongLOP=-4.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
-					PrePlacedEncounters[5]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=0.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_D19_2_LW", \\
@@ -1583,7 +1567,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_D21_2_LW", \\
@@ -1663,7 +1646,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[10]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 ; 42
@@ -2329,7 +2311,6 @@
 					PrePlacedEncounters[1]=(EncounterID="OPNx5_Standard_LW",	EncounterZoneOffsetAlongLOP=10.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[2]=(EncounterID="ADVx5_Standard_LW",	EncounterZoneOffsetAlongLOP=-10.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[3]=(EncounterID="ALNx3_Bucket_Standard_LW",	EncounterZoneOffsetAlongLOP=25.0, EncounterZoneWidth=45.0), \\
-					PrePlacedEncounters[4]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
 					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
@@ -3441,13 +3422,12 @@
 					PrePlacedEncounters[0]=(EncounterID="ADVx5_Standard_LW",				EncounterZoneOffsetAlongLOP=22.0, EncounterZoneWidth=44.0), \\
 					PrePlacedEncounters[1]=(EncounterID="OPNx4_Standard_LW",				EncounterZoneOffsetAlongLOP=10.0, EncounterZoneWidth=60.0), \\
 					PrePlacedEncounters[2]=(EncounterID="OPNx4_Standard_LW",				EncounterZoneOffsetAlongLOP=4.0, EncounterZoneWidth=9.0, EncounterZoneDepthOverride=4.0), \\
-					PrePlacedEncounters[3]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[3]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[4]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[5]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 +MissionSchedules=(ScheduleID="Extract_D5_2_LW", \\
@@ -3600,13 +3580,12 @@
 					PrePlacedEncounters[1]=(EncounterID="OPNx5_Standard_LW",				EncounterZoneOffsetAlongLOP=1.0, EncounterZoneWidth=9.0, EncounterZoneDepthOverride=4.0), \\
 					PrePlacedEncounters[2]=(EncounterID="ADVx3_Standard_LW",				EncounterZoneOffsetAlongLOP=7.0, EncounterZoneWidth=44.0), \\
 					PrePlacedEncounters[3]=(EncounterID="ADVx3_Standard_LW",				EncounterZoneOffsetAlongLOP=-10.0, EncounterZoneWidth=44.0), \\
-					PrePlacedEncounters[4]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[4]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 +MissionSchedules=(ScheduleID="Extract_D7_2_LW", \\
@@ -3778,13 +3757,12 @@
 					PrePlacedEncounters[1]=(EncounterID="OPNx5_Standard_LW", EncounterZoneOffsetAlongLOP=4.0, EncounterZoneWidth=9.0, EncounterZoneDepthOverride=4.0), \\
 					PrePlacedEncounters[2]=(EncounterID="ADVx5_Standard_LW", EncounterZoneOffsetAlongLOP=-5.0, EncounterZoneWidth=60.0), \\
 					PrePlacedEncounters[3]=(EncounterID="OPNx5_Standard_LW", EncounterZoneOffsetAlongLOP=7.0, EncounterZoneWidth=44.0), \\
-					PrePlacedEncounters[4]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, EncounterZoneWidth=45.0, EncounterZoneDepthOverride=50.0), \\
+					PrePlacedEncounters[4]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 +MissionSchedules=(ScheduleID="Extract_D9_3_LW", \\
@@ -5814,9 +5792,8 @@
 					PrePlacedEncounters[3]=(EncounterID="ADVx2_Standard_LW",				EncounterZoneOffsetAlongLOP=4.0,	EncounterZoneWidth=44.0), \\
 					PrePlacedEncounters[4]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=0.0,	EncounterZoneWidth=45.0, EncounterZoneDepthOverride=45.0), \\
 					PrePlacedEncounters[5]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=18.0,	EncounterZoneWidth=45.0, EncounterZoneDepthOverride=45.0), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0,	EncounterZoneWidth=44.0), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid",					EncounterZoneOffsetAlongLOP=-11.0,	EncounterZoneWidth=10.0, EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid",					EncounterZoneOffsetAlongLOP=-11.0,	EncounterZoneWidth=10.0, EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					)
 
 ; 12
@@ -5934,11 +5911,10 @@
 					PrePlacedEncounters[2]=(EncounterID="OPNx4_Standard_LW",				EncounterZoneOffsetAlongLOP=-10.0, EncounterZoneWidth=44.0), \\
 					PrePlacedEncounters[3]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=0.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
 					PrePlacedEncounters[4]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=15.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
-					PrePlacedEncounters[5]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, EncounterZoneWidth=25.0), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_Vehicle_D5_4_LW", \\
@@ -6052,13 +6028,12 @@
 					PrePlacedEncounters[4]=(EncounterID="ALNx3_Bucket_Standard_LW",				EncounterZoneOffsetAlongLOP=-6.0,	EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[5]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=0.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
 					PrePlacedEncounters[6]=(EncounterID="Lone_Drone_LW",					EncounterZoneOffsetAlongLOP=15.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0,	EncounterZoneWidth=44.0), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[10]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[11]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[10]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_Vehicle_D7_2_LW", \\
@@ -6112,13 +6087,12 @@
 					PrePlacedEncounters[1]=(EncounterID="OPNx4_Standard_LW",			EncounterZoneOffsetAlongLOP=-3.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
 					PrePlacedEncounters[2]=(EncounterID="OPNx4_Standard_LW",			EncounterZoneOffsetAlongLOP=15.0, EncounterZoneWidth=44.0), \\
 					PrePlacedEncounters[3]=(EncounterID="OPNx4_Standard_LW",			EncounterZoneOffsetAlongLOP=6.0, EncounterZoneWidth=44.0), \\
-					PrePlacedEncounters[4]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[4]=(EncounterID="DKVx1_Chryssalid",				EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid",				EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid",				EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
+					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					)
 
 ; 18
@@ -6294,13 +6268,12 @@
 					PrePlacedEncounters[1]=(EncounterID="OPNx5_Standard_LW",	EncounterZoneOffsetAlongLOP=10.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[2]=(EncounterID="ADVx5_Standard_LW",	EncounterZoneOffsetAlongLOP=-10.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[3]=(EncounterID="ALNx3_Bucket_Standard_LW",	EncounterZoneOffsetAlongLOP=18.0, EncounterZoneWidth=45.0), \\
-					PrePlacedEncounters[4]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[4]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 ; 21
@@ -6320,7 +6293,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_Vehicle_D10_2_LW", \\
@@ -6495,13 +6467,12 @@
 					PrePlacedEncounters[2]=(EncounterID="ADVx4_Standard_LW", EncounterZoneOffsetAlongLOP=4.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
 					PrePlacedEncounters[3]=(EncounterID="ADVx3_Standard_LW", EncounterZoneOffsetAlongLOP=18.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[4]=(EncounterID="ALNx3_Bucket_Standard_LW", EncounterZoneOffsetAlongLOP=16.0, EncounterZoneWidth=45.0), \\
-					PrePlacedEncounters[5]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 ; 24
@@ -6517,14 +6488,12 @@
 					PrePlacedEncounters[3]=(EncounterID="OPNx6_Standard_LW", EncounterZoneOffsetAlongLOP=-14.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[4]=(EncounterID="Lone_Drone_LW",		EncounterZoneOffsetAlongLOP=0.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
 					PrePlacedEncounters[5]=(EncounterID="Lone_Drone_LW",		EncounterZoneOffsetAlongLOP=15.0,	EncounterZoneWidth=45.0,	EncounterZoneDepthOverride=45.0), \\
-					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=-5.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-12.0, EncounterZoneWidth=10.0, \\
+					PrePlacedEncounters[9]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-12.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+					PrePlacedEncounters[10]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[10]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[11]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
+					PrePlacedEncounters[11]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
+					PrePlacedEncounters[12]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator") \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_Vehicle_D12_2_LW", \\
@@ -6692,13 +6661,12 @@
 					PrePlacedEncounters[2]=(EncounterID="OPNx5_Standard_LW", EncounterZoneOffsetAlongLOP=-12.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[3]=(EncounterID="OPNx6_Standard_LW", EncounterZoneOffsetAlongLOP=15.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[4]=(EncounterID="ADVx6_Standard_LW", EncounterZoneOffsetAlongLOP=-4.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
-					PrePlacedEncounters[5]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					)
 
 ;27
@@ -6819,7 +6787,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_Vehicle_D15_2_LW", \\
@@ -6891,13 +6858,12 @@
 					PrePlacedEncounters[2]=(EncounterID="OPNx6_Standard_LW", EncounterZoneOffsetAlongLOP=-12.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[3]=(EncounterID="OPNx6_Standard_LW", EncounterZoneOffsetAlongLOP=15.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[4]=(EncounterID="ADVx4_Standard_LW", EncounterZoneOffsetAlongLOP=-4.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
-					PrePlacedEncounters[5]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=15.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					)
 
 ;30
@@ -6937,7 +6903,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 ;31-32
@@ -6958,7 +6923,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_Vehicle_D17_2_LW", \\
@@ -6998,7 +6962,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 ; 33
@@ -7033,13 +6996,12 @@
 					PrePlacedEncounters[2]=(EncounterID="OPNx8_Standard_LW", EncounterZoneOffsetAlongLOP=-12.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[3]=(EncounterID="OPNx8_Standard_LW", EncounterZoneOffsetAlongLOP=15.0, EncounterZoneWidth=45.0), \\
 					PrePlacedEncounters[4]=(EncounterID="ADVx2_Standard_LW", EncounterZoneOffsetAlongLOP=-4.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
-					PrePlacedEncounters[5]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=0.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0), \\
+					PrePlacedEncounters[5]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
+											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[6]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
-					PrePlacedEncounters[7]=(EncounterID="DKVx1_Chryssalid", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
-											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
+					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_Vehicle_D19_2_LW", \\
@@ -7117,7 +7079,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[7]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 +MissionSchedules=(ScheduleID="Guerilla_Vehicle_D21_2_LW", \\
@@ -7197,7 +7158,6 @@
 											EncounterZoneDepthOverride=36.0, EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\
 					PrePlacedEncounters[8]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
 					PrePlacedEncounters[9]=(EncounterID="DKVx2_FacelessAndCivilians_LW", EncounterZoneOffsetAlongLOP=5.0, IncludeTacticalTag="DarkEvent_Infiltrator"), \\
-					PrePlacedEncounters[10]=(EncounterID="DKVx2_FacelessAndCivilians_LW",	EncounterZoneOffsetAlongLOP=12.0, EncounterZoneWidth=80.0, EncounterZoneDepthOverride=80.0) \\
 					)
 
 ; 42


### PR DESCRIPTION
As per #749 , faceless spawn schedules have been removed from guerrilla ops, guerrilla vehicle, and extract schedules, leaving the dark event spawns intact.

Other lines had to be updated to keep array index values sequential.