### PR TITLE
GTS Slot Power cost from 2 to 1, Issue #802

### DIFF
--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2StrategyElement_LW_OTS_OfficerStaffSlot.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2StrategyElement_LW_OTS_OfficerStaffSlot.uc
@@ -108,7 +108,7 @@ static function X2DataTemplate CreateOTS_OfficerTrainingSecondSlotUpgradeTemplat
 
 static function OTS_LWOfficerTrainingUpgradeAdded(XComGameState NewGameState, XComGameState_FacilityUpgrade Upgrade, XComGameState_FacilityXCom Facility)
 {
-	Facility.PowerOutput += Upgrade.GetMyTemplate().iPower;
+	//Facility.PowerOutput += Upgrade.GetMyTemplate().iPower;
 	Facility.UpkeepCost += Upgrade.GetMyTemplate().UpkeepCost;
 	Facility.UnlockStaffSlot(NewGameState);
 }

--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2StrategyElement_LW_OTS_OfficerStaffSlot.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2StrategyElement_LW_OTS_OfficerStaffSlot.uc
@@ -108,7 +108,6 @@ static function X2DataTemplate CreateOTS_OfficerTrainingSecondSlotUpgradeTemplat
 
 static function OTS_LWOfficerTrainingUpgradeAdded(XComGameState NewGameState, XComGameState_FacilityUpgrade Upgrade, XComGameState_FacilityXCom Facility)
 {
-	//Facility.PowerOutput += Upgrade.GetMyTemplate().iPower;
 	Facility.UpkeepCost += Upgrade.GetMyTemplate().UpkeepCost;
 	Facility.UnlockStaffSlot(NewGameState);
 }


### PR DESCRIPTION
OTS staff slots were previously both costing 1 power themselves (from lines 66 and 92 that each read `Template.iPower = -1`) and increasing the GTS' base facility cost by 1. I simply commented out the line that increased the base facility's power cost.