### PR TITLE
Str 2 SnG schedule fix

### DIFF
--- a/LongWarOfTheChosen/Config/XComSchedules.ini
+++ b/LongWarOfTheChosen/Config/XComSchedules.ini
@@ -1766,7 +1766,7 @@
 				  DefaultEncounterLeaderSpawnList = "DefaultLeaders", \\
 				  DefaultEncounterFollowerSpawnList = "DefaultFollowers", \\
 				  PrePlacedEncounters[0]=(EncounterID="ADVx4_Standard_LW",				EncounterZoneOffsetAlongLOP=-7.0, EncounterZoneWidth=44.0), \\
-				  PrePlacedEncounters[1]=(EncounterID="OPNx3_Standard_LW",				EncounterZoneOffsetAlongLOP=0.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
+				  PrePlacedEncounters[1]=(EncounterID="OPNx2_Standard_LW",				EncounterZoneOffsetAlongLOP=0.0, EncounterZoneWidth=6.0, EncounterZoneDepthOverride=6.0), \\
 				  PrePlacedEncounters[2]=(EncounterID="ADVx2_Standard_LW",				EncounterZoneOffsetAlongLOP=14.0, EncounterZoneWidth=44.0), \\
 				  PrePlacedEncounters[3]=(EncounterID="DKVx1_Chryssalid",				EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=10.0, \\
 				  						 EncounterZoneDepthOverride=36.0,				EncounterZoneOffsetFromLOP=0.0, IncludeTacticalTag="DarkEvent_InfiltratorChryssalid"), \\


### PR DESCRIPTION
Guerilla_Revealed_D2_2_LW previously had 10 enemies due to a lone drone at the bottom of the list. Changed OPNx3_Standard_LW to OPNx2_Standard_LW to keep difficulty in line with other str2 schedules.