### PR TITLE
Miscellaneous bug fixes

### DIFF
--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -313,23 +313,23 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 
 
 ; AOE profiles are needed for the AI to perform any targeting with an AoE ability
-+AoEProfiles=( Profile=RocketLauncherProfile, Ability=RocketLauncher, bUsePrecomputePath=1, bFailOnFriendlyFire=1)
-+AoEProfiles=( Profile=RocketLauncherSingleProfile, Ability=RocketLauncher, bUsePrecomputePath=1, bFailOnFriendlyFire=1, MinTargets=1)
-+AoEProfiles=( Profile=RocketLauncherAggressiveProfile, Ability=RocketLauncher, bUsePrecomputePath=1)
-+AoEProfiles=( Profile=GrenadeLauncherProfile, Ability=LaunchGrenade, bUsePrecomputePath=1, bFailOnFriendlyFire=1)
-+AoEProfiles=( Profile=GrenadeLauncherSingleProfile, Ability=LaunchGrenade, bUsePrecomputePath=1, bFailOnFriendlyFire=1, MinTargets=1)
-+AoEProfiles=( Profile=MassReanimation_LWManyProfile, Ability=MassReanimation_LW, bTargetEnemy=0, bTargetCivilians=0, bTargetCorpses=1, bFailOnObjectiveFire=0, bFailOnFriendlyFire=0, MinTargets=4)
-+AoEProfiles=( Profile=MassReanimation_LWFewProfile, Ability=MassReanimation_LW, bTargetEnemy=0, bTargetCivilians=0, bTargetCorpses=1, bFailOnObjectiveFire=0, bFailOnFriendlyFire=0, MinTargets=2)
-+AoEProfiles=( Profile=MassMindspinManyProfile, Ability=MassMindspin, bFailOnObjectiveFire=0, bFailOnFriendlyFire=0, MinTargets=3)
-+AoEProfiles=( Profile=MassMindspinFewProfile, Ability=MassMindspin, bFailOnObjectiveFire=0, bFailOnFriendlyFire=0, MinTargets=1)
++AoEProfiles=( Profile=RocketLauncherProfile, Ability=RocketLauncher, bUsePrecomputePath=1, bFailOnFriendlyFire=1, bRequireLoS=1)
++AoEProfiles=( Profile=RocketLauncherSingleProfile, Ability=RocketLauncher, bUsePrecomputePath=1, bFailOnFriendlyFire=1, MinTargets=1, bRequireLoS=1)
++AoEProfiles=( Profile=RocketLauncherAggressiveProfile, Ability=RocketLauncher, bUsePrecomputePath=1, bRequireLoS=1)
++AoEProfiles=( Profile=GrenadeLauncherProfile, Ability=LaunchGrenade, bUsePrecomputePath=1, bFailOnFriendlyFire=1, bRequireLoS=1)
++AoEProfiles=( Profile=GrenadeLauncherSingleProfile, Ability=LaunchGrenade, bUsePrecomputePath=1, bFailOnFriendlyFire=1, MinTargets=1, bRequireLoS=1)
++AoEProfiles=( Profile=MassReanimation_LWManyProfile, Ability=MassReanimation_LW, bTargetEnemy=0, bTargetCivilians=0, bTargetCorpses=1, bFailOnObjectiveFire=0, bFailOnFriendlyFire=0, MinTargets=4, bRequireLoS=1)
++AoEProfiles=( Profile=MassReanimation_LWFewProfile, Ability=MassReanimation_LW, bTargetEnemy=0, bTargetCivilians=0, bTargetCorpses=1, bFailOnObjectiveFire=0, bFailOnFriendlyFire=0, MinTargets=2, bRequireLoS=1)
++AoEProfiles=( Profile=MassMindspinManyProfile, Ability=MassMindspin, bFailOnObjectiveFire=0, bFailOnFriendlyFire=0, MinTargets=3, bRequireLoS=1)
++AoEProfiles=( Profile=MassMindspinFewProfile, Ability=MassMindspin, bFailOnObjectiveFire=0, bFailOnFriendlyFire=0, MinTargets=1, bRequireLoS=1)
 
 
 ;Make poison spit targetting ignore units
 -AoEProfiles=( Profile=PoisonSpitProfile, Ability=PoisonSpit, bIgnoreSelfDamage=1)
 -AoEProfiles=( Profile=PoisonSpitSingleProfile, Ability=PoisonSpit, bIgnoreSelfDamage=1, MinTargets=1)
 
-+AoEProfiles=( Profile=PoisonSpitProfile, Ability=PoisonSpit, bIgnoreSelfDamage=1, bTestTargetEffectsApply=true)
-+AoEProfiles=( Profile=PoisonSpitSingleProfile, Ability=PoisonSpit, bIgnoreSelfDamage=1, MinTargets=1, bTestTargetEffectsApply=true)
++AoEProfiles=( Profile=PoisonSpitProfile, Ability=PoisonSpit, bIgnoreSelfDamage=1, bTestTargetEffectsApply=true, bRequireLoS=1)
++AoEProfiles=( Profile=PoisonSpitSingleProfile, Ability=PoisonSpit, bIgnoreSelfDamage=1, MinTargets=1, bTestTargetEffectsApply=true, bRequireLoS=1)
 
 ;Make purifiers not poison spit enemies
 -AoEProfiles=( Profile=FlameThrowerMultiProfile, Ability=AdvPurifierFlamethrower, bIgnoreSelfDamage=True, bFailOnObjectiveFire=true, bFailOnFriendlyFire=true, MinTargets=2, bAreaSearchSpace=1, bRequireLoS=1, bIgnoreRepeatAttackList=1)

--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -323,8 +323,14 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 +AoEProfiles=( Profile=MassMindspinManyProfile, Ability=MassMindspin, bFailOnObjectiveFire=0, bFailOnFriendlyFire=0, MinTargets=3, bRequireLoS=1)
 +AoEProfiles=( Profile=MassMindspinFewProfile, Ability=MassMindspin, bFailOnObjectiveFire=0, bFailOnFriendlyFire=0, MinTargets=1, bRequireLoS=1)
 
+; Make Micro Missiles require line of sight so they can't be used through walls
+-AoEProfiles=( Profile=MicroMissilesProfile, bUsePrecomputePath=1, Ability=MicroMissiles)
+-AoEProfiles=( Profile=MicroMissilesProfileMk2, bUsePrecomputePath=1, Ability=MicroMissiles, MinTargets=1)
 
-;Make poison spit targetting ignore units
++AoEProfiles=( Profile=MicroMissilesProfile, bUsePrecomputePath=1, Ability=MicroMissiles, bRequireLoS=1)
++AoEProfiles=( Profile=MicroMissilesProfileMk2, bUsePrecomputePath=1, Ability=MicroMissiles, MinTargets=1, bRequireLoS=1)
+
+;Make poison spit targetting ignore units and require LoS
 -AoEProfiles=( Profile=PoisonSpitProfile, Ability=PoisonSpit, bIgnoreSelfDamage=1)
 -AoEProfiles=( Profile=PoisonSpitSingleProfile, Ability=PoisonSpit, bIgnoreSelfDamage=1, MinTargets=1)
 

--- a/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
+++ b/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
@@ -707,9 +707,12 @@
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Ability_PerkPackAbilitySet.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Ability_PerkPackAbilitySet2.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Condition_CoverStatus.uc" />
+    <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Condition_IsStunned_LW.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Condition_OverwatchLimit.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Condition_RequireConcealed.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Condition_RequiredToHitChance.uc" />
+    <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Condition_RevivalProtocol_LW.uc" />
+    <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Condition_RevivalProtocolRestoreActionPoints_LW.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2DownloadableContentInfo_LWPerkPack.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Effect_AbsorptionFields.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Effect_Aggression.uc" />

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Condition_IsStunned_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Condition_IsStunned_LW.uc
@@ -1,0 +1,25 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Condition_IsStunned_LW.uc
+//  AUTHOR:  Peter ledbrook
+//  PURPOSE: A condition that returns true if the unit is stunned. Required by
+//           Revival Protocol so that it can use the appropriate Effect for
+//           restoring action points.
+//---------------------------------------------------------------------------------------
+class X2Condition_IsStunned_LW extends X2Condition;
+
+event name CallMeetsCondition(XComGameState_BaseObject kTarget)
+{
+	local XComGameState_Unit TargetUnit;
+
+    TargetUnit = XComGameState_Unit(kTarget);
+    if (TargetUnit == none) return 'AA_NotAUnit';
+
+    if (TargetUnit.IsStunned() || TargetUnit.StunnedActionPoints > 0)
+    {
+        return 'AA_Success';
+    }
+    else
+    {
+        return 'AA_MissingRequiredEffect';
+    }
+}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Condition_RevivalProtocolRestoreActionPoints_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Condition_RevivalProtocolRestoreActionPoints_LW.uc
@@ -1,0 +1,24 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Condition_RevivalProtocolRestoreActionPoints_LW.uc
+//  AUTHOR:  Peter ledbrook
+//  PURPOSE: Used by Revival Protocol to determine whether X2Effect_RestoreActionPoints
+//           should be applied.
+//---------------------------------------------------------------------------------------
+class X2Condition_RevivalProtocolRestoreActionPoints_LW extends X2Condition;
+
+event name CallMeetsCondition(XComGameState_BaseObject kTarget)
+{
+	local XComGameState_Unit TargetUnit;
+
+    // This condition applies to the effect, so we can assume the target is a unit.
+    // In other words, we are relying on the ability targeting ensuring that the
+    // target is valid for Revival Protocol.
+    TargetUnit = XComGameState_Unit(kTarget);
+
+    // Only allow action points to be restored for units that aren't disoriented
+    // (stunned is handled by X2Effect_StunRecover).
+	if (TargetUnit.IsPanicked() || TargetUnit.IsUnconscious() || TargetUnit.IsDazed())
+        return 'AA_Success';
+
+    return 'AA_UnitIsNotImpaired';
+}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Condition_RevivalProtocol_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Condition_RevivalProtocol_LW.uc
@@ -1,0 +1,22 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Condition_RevivalProtocol_LW.uc
+//  AUTHOR:  Peter ledbrook
+//  PURPOSE: Allows Revival Protocol to also target stunned units.
+//---------------------------------------------------------------------------------------
+class X2Condition_RevivalProtocol_LW extends X2Condition_RevivalProtocol;
+
+event name CallMeetsCondition(XComGameState_BaseObject kTarget)
+{
+	local XComGameState_Unit TargetUnit;
+    local name Result;
+
+	TargetUnit = XComGameState_Unit(kTarget);
+
+    Result = super.CallMeetsCondition(kTarget);
+    if (Result == 'AA_UnitIsNotImpaired' && TargetUnit != none && TargetUnit.IsStunned())
+    {
+        Result = 'AA_Success';
+    }
+
+    return Result;
+}


### PR DESCRIPTION
Contains fixes for enemies shooting rockets/spitting poison through walls and solves the various issues with Revival Protocol granting extra action points to the target when it shouldn't.

I have made the Micro Missiles' AoE profiles require line of sight along with the other AoE abilities, but I'm not sure whether this will prevent MEC Archers from using their micro missiles at squadsight range, which is kind of the point of the unit. Would like to just include the fix, though, and see whether it has any noticeable effect on the Archers.