### PR TITLE
New sit reps

### DIFF
--- a/LongWarOfTheChosen/Config/XComGameData.ini
+++ b/LongWarOfTheChosen/Config/XComGameData.ini
@@ -1301,6 +1301,7 @@ MedicalModeHealRateScalar[3]=0.25
 
 ; Location Scout now gives Tracking to XCOM soldiers rather than revealing the map
 +SitReps=ProjectMiranda      ; Makes all organic units lethargic
++SitReps=SomethingInTheAir   ; Grants Combat Rush on any crit to all team XCOM and team Alien units
 +SitReps=ViperKing
 +SitReps=BerserkerQueen
 +SitReps=ArchonKing
@@ -1328,6 +1329,13 @@ PositiveEffects="IncreaseTimer2Effect"
 
 DisplayEffects="LethargyEffect"
 DisplayEffects="IncreaseTimer2Effect"
+; ExcludePlotTypes="Abandoned"
+
+[SomethingInTheAir X2SitRepTemplate]
+bNegativeEffect=false
+PositiveEffects="CombatRushOnCritEffect"
+
+DisplayEffects="CombatRushOnCritEffect"
 ; ExcludePlotTypes="Abandoned"
 
 [DarkEventHighAlertSitRep X2SitRepTemplate]

--- a/LongWarOfTheChosen/Config/XComGameData.ini
+++ b/LongWarOfTheChosen/Config/XComGameData.ini
@@ -1299,6 +1299,7 @@ MedicalModeHealRateScalar[3]=0.25
 ; -SitReps="DarkEventDarkTowerSitRep"
 ;-SitReps="ChallengeNoReinforcements" DON'T Disable this as it only applies to TQL and skirmish mode and swarms you with redscreens. Really annoying
 
+; Location Scout now gives Tracking to XCOM soldiers rather than revealing the map
 +SitReps=ProjectMiranda      ; Makes all organic units lethargic
 +SitReps=ViperKing
 +SitReps=BerserkerQueen
@@ -1311,6 +1312,14 @@ MedicalModeHealRateScalar[3]=0.25
 +SitReps=DarkEventSealedArmorSitRep
 +SitReps=DarkEventUndyingLoyaltySitRep
 +SitReps=DarkEventVigilanceSitRep
+
+[LocationScout X2SitRepTemplate]
+-TacticalGameplayTags="SITREP_LocationScout"
+-PositiveEffects="IntroVOEffect"
+-PositiveEffects="PerfectVisibilityEffect"
++PositiveEffects="TrackingEffect"
+
+;DisplayEffects="PerfectVisibilityEffect"
 
 [ProjectMiranda X2SitRepTemplate]
 bNegativeEffect=true

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -5275,12 +5275,22 @@ LocFriendlyName="Lethargic"
 LocHelpText="Unit suffers from reduced aim and mobility."
 LocLongDescription="Unit suffers from reduced aim and mobility."
 
+[CombatRushOnCrit X2AbilityTemplate]
+LocFriendlyName="Combat Rush (on crit)"
+LocFlyOverText="Combat Rush (on crit)"
+LocHelpText="When you get a crit, nearby humanoid allies receive temporary bonuses to aim, crit chance and mobility."
+LocLongDescription="When you get a crit with any shot or ability, your human or humanoid squad mates temporarily receive bonuses to aim, critical chance and mobility."
+
 [LocationScout X2SitRepTemplate]
 Description="The resistance have placed low-range motion detectors throughout the AO that hook into your squad's comms. Your soldiers will be able to detect enemy units that are out of line of sight."
 
 [ProjectMiranda X2SitRepTemplate]
 FriendlyName="Project Miranda"
 Description="ADVENT are testing pacification technology in the area, which is making all non-robotic units lethargic. They will have penalties to aim and mobility."
+
+[SomethingInTheAir X2SitRepTemplate]
+FriendlyName="There's Something in the Air"
+Description="Maybe it's something in the air, but whatever it is, it's causing soldiers to trigger Combat Rush whenever they crit. Beware, this works for ADVENT too!"
 
 [DarkEventBarrierSitRep X2SitRepTemplate]
 FriendlyName="Barrier"

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -5275,6 +5275,9 @@ LocFriendlyName="Lethargic"
 LocHelpText="Unit suffers from reduced aim and mobility."
 LocLongDescription="Unit suffers from reduced aim and mobility."
 
+[LocationScout X2SitRepTemplate]
+Description="The resistance have placed low-range motion detectors throughout the AO that hook into your squad's comms. Your soldiers will be able to detect enemy units that are out of line of sight."
+
 [ProjectMiranda X2SitRepTemplate]
 FriendlyName="Project Miranda"
 Description="ADVENT are testing pacification technology in the area, which is making all non-robotic units lethargic. They will have penalties to aim and mobility."

--- a/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
+++ b/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
@@ -574,6 +574,7 @@
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_DoubleDamage.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_DoubleTap.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_Failsafe.uc" />
+    <Content Include="Src\LW_Overhaul\Classes\X2Effect_FireEventOnCrit.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_Guardian_LW.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_HairTrigger.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_HEATGrenades.uc" />

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_SitRepGrantedAbilitySet_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_SitRepGrantedAbilitySet_LW.uc
@@ -14,6 +14,7 @@ static function array<X2DataTemplate> CreateTemplates()
 	local array<X2DataTemplate> Templates;
 	
 	Templates.AddItem(CreateLethargyTemplate());
+	Templates.AddItem(CreateCombatRushOnCritTemplate());
 
 	return Templates;
 }
@@ -56,5 +57,39 @@ static function X2AbilityTemplate CreateLethargyTemplate()
 
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
 
+	return Template;
+}
+
+static function X2AbilityTemplate CreateCombatRushOnCritTemplate()
+{
+	local X2AbilityTemplate			Template;
+	local X2Effect_FireEventOnCrit	CombatRushEffect;
+
+	`CREATE_X2ABILITY_TEMPLATE (Template, 'CombatRushOnCrit');
+	Template.IconImage = "img:///UILibrary_LW_PerkPack.LW_AbilityAdrenalNeurosympathy";
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.Hostility = eHostility_Neutral;
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+	Template.AbilityToHitCalc = default.DeadEye;
+	Template.bDisplayInUITooltip = false;
+	Template.bDisplayInUITacticalText = false;
+	Template.AbilityTargetStyle = default.SelfTarget;
+	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
+	Template.bSkipFireAction = true;
+	Template.bShowActivation = false;
+	Template.bCrossClassEligible = false;
+
+	//Effect serves to fire a custom event and that's it
+	CombatRushEffect = new class'X2Effect_FireEventOnCrit';
+	CombatRushEffect.Eventid = 'CombatRush';
+	CombatRushEffect.bShowActivation = false;
+	CombatRushEffect.BuildPersistentEffect(1, true, false);
+	CombatRushEffect.SetDisplayInfo (ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage,,, Template.AbilitySourceName);
+	Template.AddTargetEffect(CombatRushEffect);
+
+	Template.AdditionalAbilities.AddItem('BroadcastCombatRush');
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	//Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;		
 	return Template;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_FireEventOnCrit.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_FireEventOnCrit.uc
@@ -1,0 +1,46 @@
+//--------------------------------------------------------------------------------------- 
+//  FILE:    X2Effect_FireEventOnCrit.uc
+//  AUTHOR:  Peter Ledbrook
+//  PURPOSE: Triggers a specified custom event name when a unit crits the enemy.
+//           This is a slightly modified version of `X2Effect_KilledEnemy` that
+//           is primarily for triggering Combat Rush.
+//--------------------------------------------------------------------------------------- 
+
+class X2Effect_FireEventOnCrit extends X2Effect_Persistent config(LW_SoldierSkills);
+
+var name EventId;
+var bool bShowActivation;
+
+function RegisterForEvents(XComGameState_Effect EffectGameState)
+{
+	local XComGameState_Unit UnitState;
+	local X2EventManager EventMgr;
+	local Object EffectObj;
+
+	if (bshowactivation)
+	{
+		EventMgr = `XEVENTMGR;
+		EffectObj = EffectGameState;
+		UnitState = XComGameState_Unit(class'XComGameStateHistory'.static.GetGameStateHistory().GetGameStateForObjectID(EffectGameState.ApplyEffectParameters.SourceStateObjectRef.ObjectID));
+		EventMgr.RegisterForEvent(EffectObj, EventId, EffectGameState.TriggerAbilityFlyover, 1,, UnitState);  
+	}
+}
+
+function bool PostAbilityCostPaid(XComGameState_Effect EffectState, XComGameStateContext_Ability AbilityContext, XComGameState_Ability kAbility, XComGameState_Unit SourceUnit, XComGameState_Item AffectWeapon, XComGameState NewGameState, const array<name> PreCostActionPoints, const array<name> PreCostReservePoints)
+{
+	local XComGameState_Ability AbilityState;
+	local X2EventManager EventMgr;
+
+	if (AbilityContext.ResultContext.HitResult == eHit_Crit ||
+			AbilityContext.ResultContext.MultiTargetHitResults.Find(eHit_Crit) != INDEX_NONE)
+	{
+		AbilityState = XComGameState_Ability(class'XComGameStateHistory'.static.GetGameStateHistory().GetGameStateForObjectID(EffectState.ApplyEffectParameters.AbilityStateObjectRef.ObjectID));
+		if (AbilityState != none)
+		{
+			EventMgr = `XEVENTMGR;	
+			EventMgr.TriggerEvent(EventId, AbilityState, SourceUnit, NewGameState);
+		}
+	}
+
+	return false;
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2SitRep_DefaultSitRepEffects_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2SitRep_DefaultSitRepEffects_LW.uc
@@ -13,6 +13,7 @@ static function array<X2DataTemplate> CreateTemplates()
 	// Ability Granting Effects
 	Templates.AddItem(CreateLethargyEffectTemplate());
 	Templates.AddItem(CreateTrackingEffectTemplate());
+	Templates.AddItem(CreateCombatRushOnCritEffectTemplate());
 
 	// Miscellaneous effects
 	Templates.AddItem(CreateTheLostEffectTemplate());
@@ -49,6 +50,19 @@ static function X2SitRepEffectTemplate CreateTrackingEffectTemplate()
 	Template.DifficultyModifier = -5;
 	Template.AbilityTemplateNames.AddItem('Hero_Tracking');
 	Template.GrantToSoldiers = true;
+
+	return Template;
+}
+
+static function X2SitRepEffectTemplate CreateCombatRushOnCritEffectTemplate()
+{
+	local X2SitRepEffect_GrantAbilities Template;
+
+	`CREATE_X2TEMPLATE(class'X2SitRepEffect_GrantAbilities', Template, 'CombatRushOnCritEffect');
+	Template.DifficultyModifier = 0;
+	Template.AbilityTemplateNames.AddItem('CombatRushOnCrit');
+	Template.Teams.AddItem(eTeam_Alien);
+	Template.Teams.AddItem(eTeam_XCom);
 
 	return Template;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2SitRep_DefaultSitRepEffects_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2SitRep_DefaultSitRepEffects_LW.uc
@@ -12,6 +12,7 @@ static function array<X2DataTemplate> CreateTemplates()
 
 	// Ability Granting Effects
 	Templates.AddItem(CreateLethargyEffectTemplate());
+	Templates.AddItem(CreateTrackingEffectTemplate());
 
 	// Miscellaneous effects
 	Templates.AddItem(CreateTheLostEffectTemplate());
@@ -36,6 +37,18 @@ static function X2SitRepEffectTemplate CreateLethargyEffectTemplate()
 	`CREATE_X2TEMPLATE(class'X2SitRepEffect_GrantAbilities', Template, 'LethargyEffect');
 	Template.DifficultyModifier = 10;
 	Template.AbilityTemplateNames.AddItem('Lethargy');
+
+	return Template;
+}
+
+static function X2SitRepEffectTemplate CreateTrackingEffectTemplate()
+{
+	local X2SitRepEffect_GrantAbilities Template;
+
+	`CREATE_X2TEMPLATE(class'X2SitRepEffect_GrantAbilities', Template, 'TrackingEffect');
+	Template.DifficultyModifier = -5;
+	Template.AbilityTemplateNames.AddItem('Hero_Tracking');
+	Template.GrantToSoldiers = true;
 
 	return Template;
 }


### PR DESCRIPTION
Replaced the Location Scout sit rep with one that grants all squad members Tracking, and also added another sit rep that grants Combat Rush On Crit, which is like Combat Rush but triggers on any crit, not on kills. This works for both ADVENT and XCOM.