### PR TITLE
Rebalance failure risk chances for CAs

### DIFF
--- a/LongWarOfTheChosen/Config/XComGameBoard.ini
+++ b/LongWarOfTheChosen/Config/XComGameBoard.ini
@@ -801,12 +801,12 @@ MaxActionHours[3]=480
 
 ;RISKS
 [CovertActionRisk_Failure_Easy X2CovertActionRiskTemplate]
-MinChanceToOccur=50
-MaxChanceToOccur=60
+MinChanceToOccur=35
+MaxChanceToOccur=40
 
 [CovertActionRisk_Failure_Moderate X2CovertActionRiskTemplate]
-MinChanceToOccur=60
-MaxChanceToOccur=70
+MinChanceToOccur=50
+MaxChanceToOccur=60
 
 [CovertActionRisk_Failure_Hard X2CovertActionRiskTemplate]
 MinChanceToOccur=70

--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1581,15 +1581,18 @@ BLACK_MARKET_PERSONNEL_INFLATION_PER_FORCE_LEVEL=0.075
 BLACK_MARKET_SOLDIER_DISCOUNT=0.4
 
 [LW_Overhaul.X2EventListener_Headquarters]
-CA_RISK_REDUCTION_PER_RANK[0]=15   ; Rookie
-CA_RISK_REDUCTION_PER_RANK[1]=12   ; Veteran
-CA_RISK_REDUCTION_PER_RANK[2]=10   ; Commander
-CA_RISK_REDUCTION_PER_RANK[3]=10   ; Legend
+CA_RISK_REDUCTION_PER_RANK[0]=12   ; Rookie
+CA_RISK_REDUCTION_PER_RANK[1]=10   ; Veteran
+CA_RISK_REDUCTION_PER_RANK[2]=8    ; Commander
+CA_RISK_REDUCTION_PER_RANK[3]=8    ; Legend
 
-CA_RISK_INCREASE_PER_FL[0]=2       ; Rookie
-CA_RISK_INCREASE_PER_FL[1]=2       ; Veteran
-CA_RISK_INCREASE_PER_FL[2]=2       ; Commander
-CA_RISK_INCREASE_PER_FL[3]=2       ; Legend
+CA_RISK_INCREASE_PER_FL[0]=4       ; Rookie
+CA_RISK_INCREASE_PER_FL[1]=4       ; Veteran
+CA_RISK_INCREASE_PER_FL[2]=4       ; Commander
+CA_RISK_INCREASE_PER_FL[3]=4       ; Legend
+
+; The FL at which the failure risk no longer increases
+CA_RISK_FL_CAP=12
 
 CA_AP_REWARD_SCALAR[0]=0.7         ; Rookie
 CA_AP_REWARD_SCALAR[1]=0.6         ; Veteran

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Headquarters.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Headquarters.uc
@@ -9,6 +9,7 @@ var config array<float> CA_RISK_REDUCTION_PER_RANK;
 var config array<float> CA_RISK_INCREASE_PER_FL;
 var config array<float> CA_AP_REWARD_SCALAR;
 var config array<float> CA_STD_REWARD_SCALAR;
+var config int CA_RISK_FL_CAP;
 
 var config int LISTENER_PRIORITY;
 
@@ -279,7 +280,7 @@ static function EventListenerReturn CAAdjustRiskChance(
 
 	// Adjust the risk chance in the other direction based on force level.
 	AlienHQ = XComGameState_HeadquartersAlien(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersAlien'));
-	RiskChanceAdjustment += AlienHQ.GetForceLevel() * `ScaleStrategyArrayFloat(default.CA_RISK_INCREASE_PER_FL);
+	RiskChanceAdjustment += Min(AlienHQ.GetForceLevel(), default.CA_RISK_FL_CAP) * `ScaleStrategyArrayFloat(default.CA_RISK_INCREASE_PER_FL);
 
 	// Make sure we don't go negative on the risk chance.
 	RiskIndex = CAState.Risks.Find('RiskTemplateName', Tuple.Data[0].n);


### PR DESCRIPTION
Early covert actions should be slightly more likely to succeed, but the risk chance ramps up with force level more quickly. This is to prevent mid-game covert actions being reliably done with just LCPLs and CPLs. The effect of each rank has also been reduced for the same reason.

Lastly, I've added a cap on the FL increases so that MSGT squads can reliably complete covert actions throughout the game, rather than then having significant chances to fail by FL20.