### PR TITLE
Fix Templar's Void Conduit ability

### DIFF
--- a/LongWarOfTheChosen/Localization/LW_FactionBalance/LW_FactionBalance.int
+++ b/LongWarOfTheChosen/Localization/LW_FactionBalance/LW_FactionBalance.int
@@ -1,0 +1,4 @@
+; LWOTC Needs Translation
+[X2Effect_VoidConduitPatch]
+ActionsLeftFlyoverText="Actions left: <XGParam:IntValue0/>"
+; End Translation

--- a/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
+++ b/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
@@ -27,6 +27,7 @@
     <Folder Include="Content\Sounds\INT\" />
     <Folder Include="Localization\" />
     <Folder Include="Localization\LW_AlienPack_Integrated\" />
+    <Folder Include="Localization\LW_FactionBalance\" />
     <Folder Include="Localization\LW_LaserPack_Integrated\" />
     <Folder Include="Localization\LW_OfficerPack_Integrated\" />
     <Folder Include="Localization\LW_PerkPack_Integrated\" />
@@ -221,6 +222,8 @@
     <Content Include="Localization\LW_AlienPack_Integrated\XComGame.kor" />
     <Content Include="Localization\LW_AlienPack_Integrated\XComGame.pol" />
     <Content Include="Localization\LW_AlienPack_Integrated\XComGame.rus" />
+    <Content Include="Localization\LW_FactionBalance\LW_FactionBalance.int" />
+    <Content Include="Localization\LW_FactionBalance\XComGame.int" />
     <Content Include="Localization\LW_LaserPack_Integrated\XComGame.chn" />
     <Content Include="Localization\LW_LaserPack_Integrated\XComGame.cht" />
     <Content Include="Localization\LW_LaserPack_Integrated\XComGame.deu" />

--- a/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
+++ b/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
@@ -1163,6 +1163,7 @@
     <Content Include="Src\LW_FactionBalance\Classes\X2LWModTemplate_ReaperAbilities.uc" />
     <Content Include="Src\LW_FactionBalance\Classes\X2Effect_ResetReflex.uc" />
     <Content Include="Src\LW_FactionBalance\Classes\X2Effect_TemplarFocusStatBonuses.uc" />
+    <Content Include="Src\LW_FactionBalance\Classes\X2Effect_VoidConduitPatch.uc" />
     <Content Include="Src\LW_FactionBalance\Classes\X2LWModTemplate_SkirmisherAbilities.uc" />
     <Content Include="Src\LW_FactionBalance\Classes\X2LWModTemplate_TemplarAbilities.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Condition_Solace_LW.uc" />

--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_VoidConduitPatch.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_VoidConduitPatch.uc
@@ -7,6 +7,8 @@
 
 class X2Effect_VoidConduitPatch extends X2Effect_Persistent;
 
+var localized string ActionsLeftFlyoverText;
+
 // This replicates the implementation in `X2Effect_PersistentVoidConduit`, but that
 // function never gets called because the effect is removed on player turn begun,
 // whereas `ModifyTurnStartActionPoints()` is called on *unit group turn begun*.
@@ -47,6 +49,25 @@ function bool TickVoidConduit(X2Effect_Persistent PersistentEffect, const out Ef
 
 	TargetUnit.GetUnitValue(class'X2Effect_PersistentVoidConduit'.default.VoidConduitActionsLeft, ConduitValue);
 	return ConduitValue.fValue <= 0;
+}
+
+simulated function AddX2ActionsForVisualization_Removed(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, const name EffectApplyResult, XComGameState_Effect RemovedEffect)
+{
+	local X2Action_PlaySoundAndFlyOver SoundAndFlyOver;
+	local XComGameState_Unit UnitState;
+	local XGParamTag ParamTag;
+	local string FlyoverText;
+
+	super.AddX2ActionsForVisualization_Removed(VisualizeGameState, ActionMetadata, EffectApplyResult, RemovedEffect);
+
+	UnitState = XComGameState_Unit(ActionMetadata.StateObject_NewState);
+
+	ParamTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
+	ParamTag.IntValue0 = UnitState.NumAllActionPoints();
+	FlyoverText = `XEXPAND.ExpandString(ActionsLeftFlyoverText);
+
+	SoundAndFlyOver = X2Action_PlaySoundAndFlyOver(class'X2Action_PlaySoundAndFlyOver'.static.AddToVisualizationTree(ActionMetadata, VisualizeGameState.GetContext(), false, ActionMetadata.LastActionAdded));
+	SoundAndFlyOver.SetSoundAndFlyOverParameters(none, FlyoverText, '', eColor_Bad);
 }
 
 defaultProperties

--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_VoidConduitPatch.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_VoidConduitPatch.uc
@@ -1,0 +1,55 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Effect_VoidConduitPatch
+//  AUTHOR:  Peter Ledbrook
+//  PURPOSE: Fixes a bug with Void Conduit where targeted units aren't immobilized
+//           for as long as they are supposed to be.
+//--------------------------------------------------------------------------------------- 
+
+class X2Effect_VoidConduitPatch extends X2Effect_Persistent;
+
+// This replicates the implementation in `X2Effect_PersistentVoidConduit`, but that
+// function never gets called because the effect is removed on player turn begun,
+// whereas `ModifyTurnStartActionPoints()` is called on *unit group turn begun*.
+//
+// This effect must tick on unit group turn begun to actually fix Void Conduit.
+function ModifyTurnStartActionPoints(XComGameState_Unit UnitState, out array<name> ActionPoints, XComGameState_Effect EffectState)
+{
+	local UnitValue ActionsValue;
+	local int Limit;
+
+	UnitState.GetUnitValue(class'X2Effect_PersistentVoidConduit'.default.StolenActionsThisTick, ActionsValue);
+	Limit = ActionsValue.fValue;
+
+	if (Limit > ActionPoints.Length)
+	{
+		ActionPoints.Length = 0;
+	}
+	else
+	{
+		ActionPoints.Remove(0, Limit);
+	}
+}
+
+// This is the same implementation as in `X2Effect_PersistentVoidConduit` to ensure this
+// effect is removed on the same turn as that one. It does this by returning `true` once
+// there are not Void Conduit actions left, which results in `InternalTickEffect()` cleaning
+// up this persistent effect.
+function bool TickVoidConduit(X2Effect_Persistent PersistentEffect, const out EffectAppliedData ApplyEffectParameters, XComGameState_Effect kNewEffectState, XComGameState NewGameState, bool FirstApplication)
+{
+	local XComGameState_Unit TargetUnit;
+	local UnitValue ConduitValue;
+
+	TargetUnit = XComGameState_Unit(NewGameState.GetGameStateForObjectID(ApplyEffectParameters.TargetStateObjectRef.ObjectID));
+	if (TargetUnit == none)
+		TargetUnit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(ApplyEffectParameters.TargetStateObjectRef.ObjectID));
+
+	`assert(TargetUnit != none);
+
+	TargetUnit.GetUnitValue(class'X2Effect_PersistentVoidConduit'.default.VoidConduitActionsLeft, ConduitValue);
+	return ConduitValue.fValue <= 0;
+}
+
+defaultProperties
+{
+	EffectTickedFn = TickVoidConduit
+}

--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2LWModTemplate_TemplarAbilities.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2LWModTemplate_TemplarAbilities.uc
@@ -47,6 +47,9 @@ static function UpdateAbilities(X2AbilityTemplate Template, int Difficulty)
 	case 'TemplarFocus':
 		SupportSupremeFocusInTemplarFocus(Template);
 		break;
+	case 'VoidConduit':
+		FixVoidConduit(Template);
+		break;
 	}
 }
 
@@ -216,6 +219,24 @@ static function SupportSupremeFocusInTemplarFocus(X2AbilityTemplate Template)
 	NewStatChange.StatAmount = default.FOCUS4DODGE;
 	StatChanges.AddItem(NewStatChange);
 	FocusEffect.AddNextFocusLevel(StatChanges, 0, default.FOCUS4RENDDAMAGE);
+}
+
+// Void Conduit is broken because it needs to tick at the beginning of the
+// AI player's turn to do the per-action damage, the heal and to calculate
+// the number of actions to remove from the target unit. But it *also* needs
+// to tick at the beginning of the unit group turn, because that's the only
+// time the effect can modify the target unit's starting number of actions.
+//
+// This fix adds another effect that does the work on unit group turn begin,
+// using the values calculated by the existing persistent Void Conduit effect.
+static function FixVoidConduit(X2AbilityTemplate Template)
+{
+	local X2Effect_VoidConduitPatch PatchEffect;
+
+	PatchEffect = new class'X2Effect_VoidConduitPatch';
+	PatchEffect.BuildPersistentEffect(1, true, true, false, eGameRule_UnitGroupTurnBegin);
+	PatchEffect.bRemoveWhenTargetDies = true;
+	Template.AddTargetEffect(PatchEffect);
 }
 
 defaultproperties


### PR DESCRIPTION
For an explanation of the fix, see the `FixVoidConduit()` function in `X2LWModTemplate_TemplarAbilities`. It basically ensures that the targeted unit loses the appropriate number of action points at the start of its turn.