### PR TITLE
Remove problematic, flash based, strategy map help icons when using a controller.

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_Mission_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_Mission_LW.uc
@@ -26,15 +26,16 @@ var transient float CachedScanButtonWidth;
 
 simulated function UIStrategyMapItem InitMapItem(out XComGameState_GeoscapeEntity Entity)
 {
-	// override the super so we can always use MI_alienfacility to allow displaying of doom pips
-	//super.InitMapItem(Entity);
+	// Override the super so we can always use MI_alienfacility to allow displaying of doom pips
+	// super.InitMapItem(Entity);
 
 	local string PinImage;
+	
 	// Initialize static data
 	InitPanel(Name(Entity.GetUIWidgetName()), 'MI_alienFacility');
 
 	PinImage = Entity.GetUIPinImagePath();
-	if( PinImage != "" )
+	if (PinImage != "")
 	{
 		SetImage(PinImage);
 	}
@@ -59,12 +60,17 @@ simulated function UIStrategyMapItem InitMapItem(out XComGameState_GeoscapeEntit
 	InfilLabel.SetPosition(154 - 5, 23);
 
 	ProgressBar = Spawn(class'UIProgressBar', self).InitProgressBar('MissionInfiltrationProgress', -32, 5, 64, 8, 0.5, eUIState_Normal);
-	//MissionSiteIcon = Spawn(class'UIStrategyMap_MissionIcon_LW', self);
-	//MissionSiteIcon.InitMissionIcon(-1);
-
+	
 	bScanButtonResized = false;
 
 	InstanceMapItem3DMaterial();
+
+	// KDM : The mission map item's help icon gets in the way of the infiltrating squad icon; the best way to deal with it is to null it.
+	// For more information on a similar topic please see the comments in UIStrategyMapItem_Region_LW --> InitMapItem().
+	if (`ISCONTROLLERACTIVE)
+	{
+		ScanButton.mc.SetNull("consoleHint");
+	}
 
 	return self;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_Region_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_Region_LW.uc
@@ -59,15 +59,15 @@ simulated function bool IsSelectable()
 
 simulated function UIStrategyMapItem InitMapItem(out XComGameState_GeoscapeEntity Entity)
 {
-	local XComGameState NewGameState;
-	local XComGameStateHistory History;
-	local XComGameState_WorldRegion LandingSite;
-	local X2WorldRegionTemplate RegionTemplate;
-	local Texture2D RegionTexture;
-	local Object TextureObject;
-	local Vector2D CenterWorld;
 	local int i;
-
+	local Object TextureObject;
+	local Texture2D RegionTexture;
+	local Vector2D CenterWorld;
+	local X2WorldRegionTemplate RegionTemplate;
+	local XComGameState NewGameState;
+	local XComGameState_WorldRegion LandingSite;
+	local XComGameStateHistory History;
+	
 	// Spawn the children BEFORE the super.Init because inside that super, it will trigger UpdateFlyoverText and other functions
 	// which may assume these children already exist. 
 
@@ -122,6 +122,29 @@ simulated function UIStrategyMapItem InitMapItem(out XComGameState_GeoscapeEntit
 		Entity.Location.Y = CenterWorld.Y;
 
 		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	}
+
+	// KDM : A Long War 2 (contacted) region map item, generally speaking, has 3 buttons; we will say it has :
+	// 1.] A radio tower button, which opens up the corresponding haven rebel screen.
+	// 2.] A haven information button, which displays the haven region's name, advent strength, vigilance, and force.
+	// 3.] A scan button, which starts and stops scanning at the location.
+	//
+	// Unfortunately, many of these buttons have help icons attached to them within flash when a controller is used.
+	// The reason I say "unfortunately", is because they were never designed for Long War 2 usage; sometimes they will 
+	// display incorrect icons, while other times they will overlap UI elements they should not. The easiest way to deal 
+	// with them, normally, would be to set their visiblity to false, or their alpha to 0; however, they are tweened all
+	// over the place within the Actionscript code. The result is that nulling them is the only method which will get rid of them !
+	//	
+	// Within Actionscript there are 4 help icons :
+	// 1.] MapItem_Region --> consoleHint is the help icon which appears to the left of the radio tower button; it must be removed.
+	// 2.] StrategyScanButton --> scanHint is the help icon which appears to the right of the scan button, when visible; it must be removed.
+	// 3.] StrategyScanButton --> consoleHint appears to the left of the haven information button when no scan button is visible; it must be removed.
+	// 4.] StrategyScanButton --> buyHint appears not to be used in region map items so it is left alone.
+	if (`ISCONTROLLERACTIVE)
+	{
+		mc.SetNull("consoleHint");
+		ScanButton.mc.SetNull("consoleHint");
+		ScanButton.mc.SetNull("scanHint");
 	}
 	
 	return self;


### PR DESCRIPTION
Modifies UIStrategyMapItem_Region_LW --> InitMapItem()

When using a controller, a (contacted) region map item can show 3 possible help icons.
1.] MapItem_Region --> consoleHint is the help icon which appears to the left of the radio tower button.
2.] StrategyScanButton --> scanHint is the help icon which appears to the right of the scan button, when visible.
3.] StrategyScanButton --> consoleHint appears to the left of the haven information button when no scan button is visible.

The problem with these help icons is that sometimes they display the wrong icon, and sometimes they overlap other UI elements. Hiding them is impossible due to the underlying flash code; consequently, the easiest way to deal with them is to remove via setting them to null.

-------------------------

Modifies UIStrategyMapItem_Mission_LW --> InitMapItem()

When using a controller, an infiltrating mission displays a help icon, StrategyScanButton --> consoleHint, to the left of the haven information button. The problem is that it overlaps the icon representing the infiltrating squad. Consequently, just like above, the best way to deal with it, is to null it.