### PR TITLE
Fix Region/Haven map item button clicks

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_UIStrategyMap.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_UIStrategyMap.uc
@@ -28,6 +28,8 @@ simulated protected function bool OnUIStrategyMapCommand(UIScreen Screen, int cm
 {
 	local bool bHandled;
 	local UIResistanceManagement_LW ResistanceOverviewScreen;
+	local UIStrategyMap StrategyMapScreen;
+	local UIStrategyMapItem_Region_LW SelectedRegionMapItem;
 	local XComHQPresentationLayer HQPres;
 
 	HQPres = `HQPRES;
@@ -40,13 +42,28 @@ simulated protected function bool OnUIStrategyMapCommand(UIScreen Screen, int cm
 
 	switch (cmd)
 	{
-		// KDM : X button brings up the Resistance overview screen
+		// KDM : X button brings up either : 
+		// 1.] The selected haven's rebel screen, if a haven is selected. 
+		// 2.] The resistance management screen.
+		//
+		// This needs to be done because the highlander deals with input before UIStrategyMap gets a chance; however, if a haven is selected,
+		// we want the input piped through UIStrategyMap down to the selected haven map item.
 		case class'UIUtilities_Input'.const.FXS_BUTTON_X:
-			if (!HQPres.ScreenStack.HasInstanceOf(class'UIResistanceManagement_LW'))
+			StrategyMapScreen = UIStrategyMap(Screen);
+			SelectedRegionMapItem = UIStrategyMapItem_Region_LW(StrategyMapScreen.SelectedMapItem);
+			if (SelectedRegionMapItem != none && SelectedRegionMapItem.OutpostButton.bIsVisible)
 			{
-				ResistanceOverviewScreen = HQPres.Spawn(class'UIResistanceManagement_LW', HQPres);
-				ResistanceOverviewScreen.EnableCameraPan = false;
-				HQPres.ScreenStack.Push(ResistanceOverviewScreen);
+				// KDM : Make sure OnUnrealCommand() is called on the strategy map, which will then forward it onto the selected haven map item.
+				bHandled = false;
+			}
+			else
+			{
+				if (!HQPres.ScreenStack.HasInstanceOf(class'UIResistanceManagement_LW'))
+				{
+					ResistanceOverviewScreen = HQPres.Spawn(class'UIResistanceManagement_LW', HQPres);
+					ResistanceOverviewScreen.EnableCameraPan = false;
+					HQPres.ScreenStack.Push(ResistanceOverviewScreen);
+				}
 			}
 			break;
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_Region_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_Region_LW.uc
@@ -457,6 +457,55 @@ simulated public function InterruptionPopupCallback(Name eAction)
 	}
 }
 
+simulated function bool OnUnrealCommand(int cmd, int arg)
+{
+	local bool bHandled;
+
+	if (!CheckInputIsReleaseOrDirectionRepeat(cmd, arg))
+	{
+		return true;
+	}
+
+	bHandled = true;
+
+	switch(cmd)
+	{
+		case class'UIUtilities_Input'.const.FXS_BUTTON_A:
+			// KDM : A button opens up the "Make Contact" pop up screen if the contact button is visible.
+			// Long War 2 code within UpdateFlyoverText() determines if the contact button should be visible.
+			if (ContactButton.bIsVisible)
+			{
+				OnContactClicked(ContactButton);
+			}
+			// KDM : A button toggles scanning if the Avenger is currently at this region location.
+			else if (IsAvengerLandedHere())
+			{
+				ScanButton.ClickButtonScan();
+			}
+			// KDM : A button travels to this region location if possible.
+			else
+			{
+				OnDefaultClicked();
+			}
+			break;
+
+		case class'UIUtilities_Input'.const.FXS_BUTTON_X:
+			// KDM : X button opens up this haven's rebel screen if the outpost button is visible.
+			// Long War 2 code within UpdateFlyoverText() determines if the outpost button should be visible.
+			if (OutpostButton.bIsVisible)
+			{
+				OnOutpostClicked(OutpostButton);
+			}
+			break;
+			
+		default:
+			bHandled = false;
+			break;		
+	}
+
+	return bHandled || super(UIStrategyMapItem).OnUnrealCommand(cmd, arg);
+}
+
 defaultproperties
 {
 	bDisableHitTestWhenZoomedOut = false;


### PR DESCRIPTION
Modifies UIStrategyMapItem_Region_LW --> OnUnrealCommand()

Previously, if a haven was selected with a controller, the A button would open up the haven's rebel screen; it wouldn't allow you to travel to that haven or scan there. Consequently, OnUnrealCommand() has been overridden so that :
1A.] The A button clicks the contact button of a region if it hasn't been contacted.
1B.] If 1A is false and the Avenger is in this region, the A button toggles scanning.
1C.] If 1A and 1B are false, the A button attempts to travel to the region.

2.] The X button opens up the selected haven's rebel screen.

------------------------------

Modifies UIScreenListener_UIStrategyMap --> OnUIStrategyMapCommand()

Previously, on the strategy map, the X button would always open up the Resistance management screen; however, what we actually want the X button to do is :
1A.] Open up the selected haven's rebel screen, if a haven is selected.
1B.] Open up the Resistance management screen if no haven is currently selected.