### PR TITLE
Fix finicky facility navigation for controllers + enable train officers staff slot for controllers

### DIFF
--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIFacility_LWOfficerSlot.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIFacility_LWOfficerSlot.uc
@@ -1,82 +1,76 @@
 //---------------------------------------------------------------------------------------
 //  FILE:    UIFacility_LWOfficerSlot.uc
-//  AUTHOR:  Amineri
-//           
+//  AUTHOR:  Amineri    
 //  PURPOSE: Reworked UIFacility_StaffSlot for officer functionality
 //---------------------------------------------------------------------------------------
 
-class UIFacility_LWOfficerSlot extends UIFacility_StaffSlot
-	dependson(UIPersonnel);
+class UIFacility_LWOfficerSlot extends UIFacility_StaffSlot dependson(UIPersonnel);
 
 var localized string m_strTrainOfficerDialogTitle;
 var localized string m_strTrainOfficerDialogText;
 var localized string m_strStopTrainOfficerDialogTitle;
 var localized string m_strStopTrainOfficerDialogText;
 
-//-----------------------------------------------------------------------------
 simulated function OnClickStaffSlot(UIPanel kControl, int cmd)
 {
+	local string StopTrainingText;
+	local XComGameState_HeadquartersProjectTrainLWOfficer TrainProject;
 	local XComGameState_StaffSlot StaffSlot;
 	local XComGameState_Unit UnitState;
-	//local XComGameState_HeadquartersXCom XComHQ;
-	local XComGameState_HeadquartersProjectTrainLWOfficer TrainProject;
-	local string StopTrainingText;
-
+	
 	StaffSlot = XComGameState_StaffSlot(`XCOMHISTORY.GetGameStateForObjectID(StaffSlotRef.ObjectID));
 
 	switch (cmd)
 	{
-	case class'UIUtilities_Input'.const.FXS_L_MOUSE_DOUBLE_UP:
-	case class'UIUtilities_Input'.const.FXS_L_MOUSE_UP_DELAYED:
-		if (StaffSlot.IsLocked())
-		{
-			ShowUpgradeFacility();
-		}
-		else if (StaffSlot.IsSlotEmpty())
-		{
-			//StaffContainer.ShowDropDown(self);
-			OnOfficerTrainSelected();
-		}
-		else // Ask the user to confirm that they want to empty the slot and stop training
-		{
-			//XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
-			UnitState = StaffSlot.GetAssignedStaff();
-			TrainProject = class'X2StrategyElement_LW_OTS_OfficerStaffSlot'.static.GetLWOfficerTrainProject(UnitState.GetReference(), StaffSlot);
+		// KDM : UIStaffSlot --> OnUnrealCommand() simulates a click by calling OnClickStaffSlot() with FXS_L_MOUSE_UP.
+		// Therefore, add this case to make it controller compatible.
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_UP:
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_DOUBLE_UP:
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_UP_DELAYED:
+			if (StaffSlot.IsLocked())
+			{
+				ShowUpgradeFacility();
+			}
+			else if (StaffSlot.IsSlotEmpty())
+			{
+				OnOfficerTrainSelected();
+			}
+			else // Ask the user to confirm that they want to empty the slot and stop training
+			{
+				UnitState = StaffSlot.GetAssignedStaff();
+				TrainProject = class'X2StrategyElement_LW_OTS_OfficerStaffSlot'.static.GetLWOfficerTrainProject(UnitState.GetReference(), StaffSlot);
 
-			StopTrainingText = m_strStopTrainOfficerDialogText;
-			StopTrainingText = Repl(StopTrainingText, "%UNITNAME", UnitState.GetName(eNameType_RankFull));
-			StopTrainingText = Repl(StopTrainingText, "%CLASSNAME", TrainProject.GetTrainingAbilityFriendlyName());
+				StopTrainingText = m_strStopTrainOfficerDialogText;
+				StopTrainingText = Repl(StopTrainingText, "%UNITNAME", UnitState.GetName(eNameType_RankFull));
+				StopTrainingText = Repl(StopTrainingText, "%CLASSNAME", TrainProject.GetTrainingAbilityFriendlyName());
 
-			ConfirmEmptyProjectSlotPopup(m_strStopTrainOfficerDialogTitle, StopTrainingText);
-		}
-		break;
-	case class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT:
-	case class'UIUtilities_Input'.const.FXS_L_MOUSE_RELEASE_OUTSIDE:
-		if(!StaffSlot.IsLocked())
-		{
-			StaffContainer.HideDropDown(self);
-		}
-		break;
+				ConfirmEmptyProjectSlotPopup(m_strStopTrainOfficerDialogTitle, StopTrainingText);
+			}
+			break;
+		
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT:
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_RELEASE_OUTSIDE:
+			if (!StaffSlot.IsLocked())
+			{
+				StaffContainer.HideDropDown(self);
+			}
+			break;
 	}
 }
 
 simulated function QueueDropDownDisplay()
 {
 	OnClickStaffSlot(none, class'UIUtilities_Input'.const.FXS_L_MOUSE_DOUBLE_UP);
-	//m_QueuedDropDown = true;
 }
 
 simulated function OnOfficerTrainSelected()
 {
-	//local XGParamTag LocTag;
-	local TDialogueBoxData DialogData;
-	//local XComGameState_Unit Unit;
-	//local UICallbackData_StateObjectReference CallbackData;
-	local XComGameState_HeadquartersXCom XComHQ;
-	local XComGameState_CampaignSettings Settings;
 	local name FlagName;
+	local TDialogueBoxData DialogData;
 	local XComGameState NewGameState;
-
+	local XComGameState_CampaignSettings Settings;
+	local XComGameState_HeadquartersXCom XComHQ;
+	
 	FlagName = 'LWOfficerPack_WarningPlayed';
 
 	XComHQ = `XCOMHQ;
@@ -100,18 +94,18 @@ simulated function OnOfficerTrainSelected()
 	}
 	else
 	{
-		// go directly to soldier list and bypass warning
+		// Go directly to soldier list and bypass warning
 		TrainOfficerDialogCallback('eUIAction_Accept', none);
 	}
 }
 
 simulated function OnPersonnelSelected(StaffUnitInfo UnitInfo)
 {
-	local XGParamTag LocTag;
 	local TDialogueBoxData DialogData;
-	local XComGameState_Unit Unit;
 	local UICallbackData_StateObjectReference CallbackData;
-
+	local XComGameState_Unit Unit;
+	local XGParamTag LocTag;
+	
 	Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitInfo.UnitRef.ObjectID));
 
 	LocTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
@@ -134,26 +128,23 @@ simulated function OnPersonnelSelected(StaffUnitInfo UnitInfo)
 simulated function TrainOfficerDialogCallback(Name eAction, UICallbackData xUserData)
 {
 	local UIPersonnel_LWOfficer kPersonnelList;
-	local XComHQPresentationLayer HQPres;
-	//local UICallbackData_StateObjectReference CallbackData;
 	local XComGameState_StaffSlot StaffSlotState;
-	
-	//CallbackData = UICallbackData_StateObjectReference(xUserData);
+	local XComHQPresentationLayer HQPres;
 	
 	if (eAction == 'eUIAction_Accept')
 	{
 		HQPres = `HQPRES;
 		StaffSlotState = XComGameState_StaffSlot(`XCOMHISTORY.GetGameStateForObjectID(StaffSlotRef.ObjectID));
 
-		//Don't allow clicking of Personnel List is active or if staffslot is filled
-		if(HQPres.ScreenStack.IsNotInStack(class'UIPersonnel') && !StaffSlotState.IsSlotFilled())
+		// Don't allow clicking of Personnel List is active or if staffslot is filled
+		if (HQPres.ScreenStack.IsNotInStack(class'UIPersonnel') && !StaffSlotState.IsSlotFilled())
 		{
-			kPersonnelList = Spawn( class'UIPersonnel_LWOfficer', HQPres);
+			kPersonnelList = Spawn(class'UIPersonnel_LWOfficer', HQPres);
 			kPersonnelList.m_eListType = eUIPersonnel_Soldiers;
 			kPersonnelList.onSelectedDelegate = OnSoldierSelected;
 			kPersonnelList.m_bRemoveWhenUnitSelected = true;
 			kPersonnelList.SlotRef = StaffSlotRef;
-			HQPres.ScreenStack.Push( kPersonnelList );
+			HQPres.ScreenStack.Push(kPersonnelList);
 		}
 	}
 }
@@ -168,9 +159,6 @@ simulated function OnSoldierSelected(StateObjectReference _UnitRef)
 	OfficerScreen.InitPromotion(_UnitRef, false);
 	OfficerScreen.CreateSoldierPawn();
 }
-
-
-//==============================================================================
 
 defaultproperties
 {

--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIScreenListener_Facility.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIScreenListener_Facility.uc
@@ -1,0 +1,162 @@
+//---------------------------------------------------------------------------------------
+//	FILE:    UIScreenListener_Facility
+//	AUTHOR:  Keith (KDM)
+//	PURPOSE: Controller navigation, for UIFacilities, acts quite strangely at times. Here are just a few examples :
+//	1.] If the rightmost staff slot is selected, and you hit D-Pad right, suddenly the room button, if one exists, becomes selected.
+//	It would be better if selection looped within the staff slot container.
+//	2.] If you press the left or right bumper, the Avenger shortcuts, at the bottom of the screen, become selected. At this point, D-Pad
+//	down selects the room button, and D-Pad up does nothing.
+//	3.] If you press right bumper --> D-Pad right --> D-Pad right, navigation becomes temporarily stuck on the 1st staff slot.
+//	4.] If you press right bumper --> D-Pad right --> D-Pad left, there are suddenly 2 highlighted staff slots.
+//	5.] Etc. Etc.
+//
+//	The solution : Kill the finicky navigation system and create it anew; this way we have complete control over its setup.
+//--------------------------------------------------------------------------------------- 
+
+class UIScreenListener_Facility extends UIScreenListener;
+
+event OnInit(UIScreen Screen)
+{
+	local UIFacility FacilityScreen;
+
+	// KDM : We are only concerned with UIFacility and its subclasses.
+	if (`ISCONTROLLERACTIVE && Screen.IsA('UIFacility'))
+	{
+		FacilityScreen = UIFacility(Screen);
+		ReconstructNavigationSystem(FacilityScreen);
+		PerformInitialSelection(FacilityScreen);
+	}
+}
+
+// KDM : A facility, represented by UIFacility, can contain up to 1 staff slot container, and up to 1 room container.
+// 1.] The staff slot container, located on the top of the screen, stores all of the staff slots; typically a facility has between 1 and 4 staff slots.
+// 2.] The room container, near the bottom of the screen, stores the room buttons; typically a facility has either 0 or 1 room buttons.
+//
+// For example, the base XCom 2 Guerilla Tactics School has 1 staff slot container which contains 1 staff slot; this staff slot is used to
+// 'Train Rookies'. Furthermore, the facility has 1 room container containing 1 room button labelled 'New Combat Tactics'.
+static function ReconstructNavigationSystem(UIFacility FacilityScreen)
+{
+	local bool StaffSlotContainerIsUsable;
+	local UIRoomContainer RoomContainer;
+	local UIStaffContainer StaffSlotContainer;
+
+	if (FacilityScreen == none)
+	{
+		return;
+	}
+
+	RoomContainer = FacilityScreen.m_kRoomContainer;
+	StaffSlotContainer = FacilityScreen.m_kStaffSlotContainer;
+	// KDM : If a staff slot container has no staff slots it should not be dealt with.
+	StaffSlotContainerIsUsable = (StaffSlotContainer != none && StaffSlotContainer.NumChildren() > 0) ? true : false;
+	
+	// KDM : The UIFacility screen should ignore D-Pad left/right; its subcomponents will deal with them. 
+	FacilityScreen.Navigator.HorizontalNavigation = false;
+
+	// KDM : Remove all focus, just in case any existed beforehand.
+	FacilityScreen.Navigator.ClearSelectionHierarchy();
+	// KDM : Remove all navigable controls.
+	FacilityScreen.Navigator.Clear();
+	// KDM : Remove all navigation targets.
+	FacilityScreen.Navigator.ClearAllNavigationTargets();
+	
+	if (StaffSlotContainerIsUsable)
+	{
+		// KDM : The staff slot container should navigate via D-Pad left/right, since its staff slots are positioned horizontally.
+		StaffSlotContainer.Navigator.HorizontalNavigation = true;
+		// KDM : Staff slot selection should loop; this also prevents the facility screen from transferring selection from the staff
+		// slots to the room button via D-Pad left/right.
+		StaffSlotContainer.Navigator.LoopSelection = true;
+		// KDM : When the staff slot container is selected, selection should automatically cascade down to the 1st selectable staff slot.
+		// If this isn't done, strange situations occur whereby the staff slot container is selected, but no staff slot is selected.
+		StaffSlotContainer.bCascadeSelection = true;
+
+		// KDM : Remove all focus, just in case any existed beforehand.
+		StaffSlotContainer.Navigator.ClearSelectionHierarchy();
+		// KDM : Remove all navigation targets.
+		StaffSlotContainer.Navigator.ClearAllNavigationTargets();
+		// KDM : We don't call StaffSlotContainer.Navigator.Clear() because staff slots have already been added, as navigable controls, to
+		// the staff slot container, and we don't want to undo this.
+		
+		FacilityScreen.Navigator.AddControl(StaffSlotContainer);
+		if (RoomContainer != none)
+		{
+			// KDM : If the staff slot container is selected, and you hit D-Pad down, select the room button container below it.
+			StaffSlotContainer.Navigator.AddNavTargetDown(RoomContainer);
+		}
+	}
+
+	if (RoomContainer != none)
+	{
+		// KDM : Remove all focus, just in case any existed beforehand.
+		RoomContainer.Navigator.ClearSelectionHierarchy();
+		// KDM : Remove all navigation targets.
+		RoomContainer.Navigator.ClearAllNavigationTargets();
+		// KDM : We don't call RoomContainer.Navigator.Clear() because we want the room container's navigable controls, which have already
+		// been setup, to remain unaltered.
+		
+		FacilityScreen.Navigator.AddControl(RoomContainer);
+		if (StaffSlotContainerIsUsable)
+		{
+			// KDM : If the room button container is selected, and you hit D-Pad up, select the staff slot container above it.
+			RoomContainer.Navigator.AddNavTargetUp(StaffSlotContainer);
+		}
+	}
+
+	// KDM : When you hit the left and right bumper buttons, the navigation system moves down to the Avenger shortcut bar. 
+	// We want to be able to escape the shortcut bar, and move back to the facility's buttons, with the D-Pad; however, this escape
+	// depends upon 1.] which UI elements are available 2.] whether D-Pad up or D-Pad down was pressed.
+	
+	// KDM : If D-Pad up is pressed, favour the room container since it is just above the Avenger shortcuts.
+	if (RoomContainer != none)
+	{
+		FacilityScreen.Navigator.AddNavTargetUp(RoomContainer);
+	}
+	else if (StaffSlotContainerIsUsable)
+	{
+		FacilityScreen.Navigator.AddNavTargetUp(StaffSlotContainer);
+	}
+
+	// KDM : If D-Pad down is pressed, favour the staff slot container since it is just below the Avenger shortcuts in a looping,
+	// bottom of the screen to top of the screen, sense.
+	if (StaffSlotContainerIsUsable)
+	{
+		FacilityScreen.Navigator.AddNavTargetDown(StaffSlotContainer);
+	}
+	else if (RoomContainer != none)
+	{
+		FacilityScreen.Navigator.AddNavTargetDown(RoomContainer);
+	}
+}
+
+static function PerformInitialSelection(UIFacility FacilityScreen)
+{
+	local bool StaffSlotContainerIsUsable;
+	local UIRoomContainer RoomContainer;
+	local UIStaffContainer StaffSlotContainer;
+
+	if (FacilityScreen == none)
+	{
+		return;
+	}
+
+	RoomContainer = FacilityScreen.m_kRoomContainer;
+	StaffSlotContainer = FacilityScreen.m_kStaffSlotContainer;
+	StaffSlotContainerIsUsable = (StaffSlotContainer != none && StaffSlotContainer.NumChildren() > 0) ? true : false;
+
+	// KDM : If the staff slot container exists, and has at least 1 staff slot, select the 1st available staff slot.
+	if (StaffSlotContainerIsUsable)
+	{
+		FacilityScreen.Navigator.SetSelected(StaffSlotContainer);
+	}
+	// KDM : If the room container exists, then select it.
+	else if (RoomContainer != none)
+	{
+		FacilityScreen.Navigator.SetSelected(RoomContainer);
+	}
+}
+
+defaultproperties
+{
+	// KDM : This is being left empty so we are able to listen to all subclasses of UIFacility.
+}

--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIScreenListener_Facility_Academy_LWOfficerPack.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIScreenListener_Facility_Academy_LWOfficerPack.uc
@@ -1,146 +1,86 @@
 //---------------------------------------------------------------------------------------
 //  FILE:    UIScreenListener_Academy_StaffSlot_LWOfficerPack
 //  AUTHOR:  Amineri
-//
 //  PURPOSE: Implements hooks to setup officer Staff Slot 
 //--------------------------------------------------------------------------------------- 
 
-class UIScreenListener_Facility_Academy_LWOfficerPack extends UIScreenListener;
+class UIScreenListener_Facility_Academy_LWOfficerPack extends UIScreenListener dependsOn(UIScreenListener_Facility);
 
 var UIButton OfficerButton;
-//var UIFacility_Academy ParentScreen;
 var UIFacility_LWOfficerSlot Slot;
 var localized string strOfficerTrainButton;
 var UIPersonnel PersonnelSelection;
 var XComGameState_StaffSlot StaffSlot;
 
-// This event is triggered after a screen is initialized
 event OnInit(UIScreen Screen)
 {
 	local int i, QueuedDropDown;
 	local UIFacility_Academy ParentScreen;
 
-	//default is no dropdown
+	// Default is no dropdown
 	QueuedDropDown = -1;
 
 	ParentScreen = UIFacility_Academy(Screen);
 
-	//check for queued dropdown, and cache it if find one
-	for(i = 0; i < ParentScreen.m_kStaffSlotContainer.StaffSlots.Length; i++)
+	// Check for queued dropdown, and cache it if find one
+	for (i = 0; i < ParentScreen.m_kStaffSlotContainer.StaffSlots.Length; i++)
 	{
-		if(ParentScreen.m_kStaffSlotContainer.StaffSlots[i].m_QueuedDropDown)
+		if (ParentScreen.m_kStaffSlotContainer.StaffSlots[i].m_QueuedDropDown)
 		{
 			QueuedDropDown = i;
 			break;
 		}
 	}
 
-	//update template and facility as needed
-	//`Log("LW OfficerPack: AcademyListener Start");
-	//class'X2DownloadableContentInfo_LWOfficerPack'.static.OnLoadedSavedGame();
 	ParentScreen.RealizeNavHelp();
 
-	//UpdateStaffSlots();
-
-	//Get rid of existing staff slots
-	for(i = ParentScreen.m_kStaffSlotContainer.StaffSlots.Length-1; i >= 0; i--)
+	// Get rid of existing staff slots
+	for (i = ParentScreen.m_kStaffSlotContainer.StaffSlots.Length-1; i >= 0; i--)
 	{
 		ParentScreen.m_kStaffSlotContainer.StaffSlots[i].Remove();
 		ParentScreen.m_kStaffSlotContainer.StaffSlots[i].Destroy();
 	}
 
-	//Get rid of the existing staff slot container
+	// Get rid of the existing staff slot container
 	ParentScreen.m_kStaffSlotContainer.Hide();
-	//ParentScreen.m_kStaffSlotContainer.Remove();
 	ParentScreen.m_kStaffSlotContainer.Destroy();
 
-	//Create the new staff slot container that correctly handles the second soldier officer slot
+	// Create the new staff slot container that correctly handles the second soldier officer slot
 	ParentScreen.m_kStaffSlotContainer = ParentScreen.Spawn(class'UIFacilityStaffContainer_LWOTS', ParentScreen);
 	ParentScreen.m_kStaffSlotContainer.InitStaffContainer();
 	ParentScreen.m_kStaffSlotContainer.SetMessage("");
 	ParentScreen.RealizeStaffSlots();
 
-	//re-queue the dropdown if there was one
-	if(QueuedDropDown >= 0)
+	// Re-queue the dropdown if there was one
+	if (QueuedDropDown >= 0)
 	{
-		//if (ParentScreen.m_kStaffSlotContainer != none)
-		//{
-			//UIFacility_StaffSlot(ParentScreen.m_kStaffSlotContainer.GetChildAt(QueuedDropDown)).OnClickStaffSlot(none, class'UIUtilities_Input'.const.FXS_L_MOUSE_UP);
-		//}
-
 		ParentScreen.ClickStaffSlot(QueuedDropDown);
+	}
+
+	// KDM : UIScreenListener_Facility fixes the finicky UIFacility controller navigation system via OnInit(); however, its functions need 
+	// to be called last, after the facility screen, including its navigation, has been setup. Since we can't determine screen listener 
+	// ordering, make sure these functions are called last no matter what.
+	if (`ISCONTROLLERACTIVE)
+	{
+		class'UIScreenListener_Facility'.static.ReconstructNavigationSystem(UIFacility(Screen));
+		class'UIScreenListener_Facility'.static.PerformInitialSelection(UIFacility(Screen));
 	}
 }
 
-
-// This event is triggered after a screen receives focus
 event OnReceiveFocus(UIScreen Screen)
 {
-	//UpdateStaffSlots();
 	UIFacility_Academy(Screen).m_kStaffSlotContainer.Show();
 }
-// This event is triggered after a screen loses focus
+
 event OnLoseFocus(UIScreen Screen)
 {
-	//UpdateStaffSlots();
 	UIFacility_Academy(Screen).m_kStaffSlotContainer.Hide();
 }
 
-// This event is triggered when a screen is removed
 event OnRemoved(UIScreen Screen)
 {
-	//clear reference to UIScreen so it can be garbage collected
-	//ParentScreen = none;
+	// KDM : I don't believe this needs to be left here as it does nothing; nonetheless, I will leave it here 'just in case'.
 }
-
-//function UpdateStaffSlots()
-//{
-	//local int i;
-	//local XComGameState_FacilityXCom Facility;
-//
-	//Facility = ParentScreen.GetFacility();
-	//`log("LW Officer Pack: Facility Template instantiated=" $ Facility.GetMyTemplateName());
-//
-	////currently only retrieves first officer staffslot
-	//for (i = 0; i < Facility.StaffSlots.Length; ++i)
-	//{
-		//StaffSlot = Facility.GetStaffSlot(i);
-		//if (StaffSlot.GetMyTemplateName() == 'OTSOfficerSlot')
-			//break;
-	//}
-//}
-
-//function AddFloatingButton()
-//{
-	//OfficerButton = ParentScreen.Spawn(class'UIButton', ParentScreen.m_kStaffSlotContainer);
-	//OfficerButton.InitButton('', Caps(strOfficerTrainButton), OnButtonCallback, eUIButtonStyle_HOTLINK_BUTTON);
-	////OfficerButton.AnchorBottomCenter();
-	//OfficerButton.OriginTopLeft();
-	//OfficerButton.SetResizeToText(false);
-	//OfficerButton.SetFontSize(24);
-	//OfficerButton.SetPosition(10, 100);
-	//OfficerButton.SetSize(280, 40);
-	//OfficerButton.Show();
-//}
-
-//simulated function OnButtonCallback(UIButton kButton)
-//{
-	//local UIPersonnel_LWOfficer kPersonnelList;
-	//local XComHQPresentationLayer HQPres;
-//
-	//HQPres = `HQPRES;
-	//
-	////Don't allow clicking of Personnel List is active or if staffslot is filled
-	//if(HQPres.ScreenStack.IsNotInStack(class'UIPersonnel') && !StaffSlot.IsSlotFilled())
-	//{
-		//kPersonnelList = HQPres.Spawn( class'UIPersonnel_LWOfficer', HQPres);
-		//kPersonnelList.m_eListType = eUIPersonnel_Soldiers;
-		//kPersonnelList.onSelectedDelegate = OnSoldierSelected;
-		//kPersonnelList.m_bRemoveWhenUnitSelected = true;
-		//kPersonnelList.SlotRef = StaffSlot.GetReference();
-		//HQPres.ScreenStack.Push( kPersonnelList );
-	//}
-//}
 
 simulated function OnSoldierSelected(StateObjectReference _UnitRef)
 {
@@ -155,6 +95,5 @@ simulated function OnSoldierSelected(StateObjectReference _UnitRef)
 
 defaultproperties
 {
-	// Leaving this assigned to none will cause every screen to trigger its signals on this class
 	ScreenClass = UIFacility_Academy;
 }


### PR DESCRIPTION
1.] Modifies : LW_OfficerPack_Integrated --> UIFacility_LWOfficerSlot --> OnClickStaffSlot().

When a UIStaffslot is clicked with the A button, OnUnrealCommand() simulates the click by calling OnClickStaffSlot(), and sending in FXS_L_MOUSE_UP. This case did not previously exist for the Long War slot; therefore, controllers users were unable to 'click it'. This has been fixed.

----------------------------------

2.] Added : LW_OfficerPack_Integrated --> UIScreenListener_Facility

Controller navigation, for UIFacilities, acts quite strangely at times. Here are some examples :
A.] If the rightmost staff slot is selected, and you hit D-Pad right, suddenly the room button, if one exists, becomes selected. It would be better if selection looped within the staff slot container.
B.] If you press the left or right bumper, the Avenger shortcuts, at the bottom of the screen, become selected. At this point, D-Pad down selects the room button, and D-Pad up does nothing.
C.] If you press right bumper --> D-Pad right --> D-Pad right, navigation becomes temporarily stuck on the 1st staff slot.
D.] If you press right bumper --> D-Pad right --> D-Pad left, there are suddenly 2 highlighted staff slots.

As a result, a screen listener has been implemented which, OnInit(), kills a facility's old navigation system, and creates a new, coherent setup. This applies to UIFacility and all subclasses of UIFacility, as they all share major components : a staff slot container, staff slots, a room container, and room buttons. This file has been commented extensively in order to give the viewer a good idea as to what, exactly, is being done and why.

Note that this file has been added to the LW_OfficerPack_Integrated package, since UIScreenListener_Facility_Academy_LWOfficerPack depends upon it, and according to UE3 documentation, if 2 files are in different packages, you can't dependOn a file in a package located after your own package.

----------------------------------

3.] Modifies : LW_OfficerPack_Integrated --> UIScreenListener_Facility_Academy_LWOfficerPack -- OnInit()

UIScreenListener_Facility_Academy_LWOfficerPack removes its staff slot container, creates a new one, then adds staff slots to it; this is to allow for officer slots to exist.

According to Robojumper, screen listener priority can not be set; this makes sense, as there are no variables of the sort within UIScreenListener. The problem is that my screen listener, UIScreenListener_Facility, relies upon the navigation system having been set up, so it can kill the old system, create a new one, and not have to worry about other screen listeners messing up the navigation system again.

Consequently, at the end of OnInit(), the navigation system is recreated and initial selection is dealt with; this guarantees that the navigation is set up properly no matter which screen listener runs 1st.

----------------------------------

4.] Spaces have also been converted to tabs in a few instances.