### PR TITLE
Make Officer Promotion Screen controller compatible + a few related fixes.

### DIFF
--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIArmory_LWOfficerPromotion.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIArmory_LWOfficerPromotion.uc
@@ -1,9 +1,7 @@
 //---------------------------------------------------------------------------------------
-//  FILE:    UIArmory_LWOfficerPromotion
+//  FILE:    UIArmory_LWOfficerPromotion 
 //  AUTHOR:  Amineri (Pavonis Interactive)
-//
 //  PURPOSE: Tweaked ability selection UI for LW officer system
-//
 //--------------------------------------------------------------------------------------- 
 
 class UIArmory_LWOfficerPromotion extends UIArmory_Promotion config(LW_OfficerPack);
@@ -18,11 +16,14 @@ var localized string strLeadershipButton;
 var localized string strLeadershipDialogueTitle;
 var localized string strLeadershipDialogueData;
 
+// KDM : -1 = unset, 0 = false, 1 = true
+var int AbilityInfoTipIsShowing, SelectAbilityTipIsShowing;
+
 simulated function InitPromotion(StateObjectReference UnitRef, optional bool bInstantTransition)
 {
 	// If the AfterAction screen is running, let it position the camera
 	AfterActionScreen = UIAfterAction(Movie.Stack.GetScreen(class'UIAfterAction'));
-	if(AfterActionScreen != none)
+	if (AfterActionScreen != none)
 	{
 		bAfterActionPromotion = true;
 		PawnLocationTag = AfterActionScreen.GetPawnLocationTag(UnitRef);
@@ -40,13 +41,24 @@ simulated function InitPromotion(StateObjectReference UnitRef, optional bool bIn
 
 	super(UIArmory).InitArmory(UnitRef,,,,,, bInstantTransition);
 
-	List = Spawn(class'UIList', self).InitList('', 58, 170, 630, 700);
-	List.OnSelectionChanged = PreviewRow;
-	List.bStickyHighlight = false;
+	List = Spawn(class'UIList', self);
 	List.bAutosizeItems = false;
+	List.bStickyHighlight = false;
+	List.OnSelectionChanged = PreviewRow;
+	List.InitList('', 58, 170, 630, 700);
+	
+	LeadershipButton = Spawn(class'UIButton', self);
+	// KDM : Make the Leadership button a hotlink when using a controller.
+	LeadershipButton.InitButton(, strLeadershipButton, ViewLeadershipStats, eUIButtonStyle_HOTLINK_BUTTON);
+	// KDM : Add the gamepad icon, right stick click, when a controller is in use.
+	LeadershipButton.SetGamepadIcon(class'UIUtilities_Input'.const.ICON_RSCLICK_R3);
+	LeadershipButton.SetPosition(58, 971);
 
-	LeadershipButton = Spawn(class'UIButton', self).InitButton(, strLeadershipButton, ViewLeadershipStats);
-	LeadershipButton.SetPosition(58, 971); //100,100
+	// KDM : Set up the navigator; ClassRowItem is not used for officers, so we can safely ignore it.
+	Navigator.Clear();
+	Navigator.LoopSelection = false;
+	Navigator.AddControl(List);
+	Navigator.SetSelected(List);
 
 	PopulateData();
 
@@ -60,52 +72,56 @@ simulated function bool CanUnitEnterOTSTraining(XComGameState_Unit Unit)
 
 	UnitInfo.UnitRef = Unit.GetReference();
 
-	if (`SCREENSTACK.IsInStack(class'UIFacility_Academy')) { return true; }
+	if (`SCREENSTACK.IsInStack(class'UIFacility_Academy'))
+	{
+		return true;
+	}
 	StaffSlotState = GetEmptyOfficerTrainingStaffSlot();
 	if (StaffSlotState != none && 
-			class'X2StrategyElement_LW_OTS_OfficerStaffSlot'.static.IsUnitValidForOTSOfficerSlot(StaffSlotState, UnitInfo)) { return true; }
+		class'X2StrategyElement_LW_OTS_OfficerStaffSlot'.static.IsUnitValidForOTSOfficerSlot(StaffSlotState, UnitInfo)) 
+	{
+		return true;
+	}
 
 	return false;
 }
 
 simulated function PopulateData()
 {
-	local int i, MaxRank;
+	local bool bHasAbility1, bHasAbility2, DisplayOnly;
+	local int i, MaxRank, RankToPromote, SelectionIndex;
 	local string AbilityIcon1, AbilityIcon2, AbilityName1, AbilityName2, HeaderString;
-	local bool bHasAbility1, bHasAbility2;
-	local XComGameState_Unit Unit;
+	local UIArmory_LWOfficerPromotionItem Item;
 	local X2AbilityTemplate AbilityTemplate1, AbilityTemplate2;
 	local X2AbilityTemplateManager AbilityTemplateManager;
-	local UIArmory_LWOfficerPromotionItem Item;
+	local XComGameState_Unit Unit;
 	local XComGameState_Unit_LWOfficer OfficerState;
-	local int RankToPromote;
-
-	local bool DisplayOnly;
-
-	//AlwaysShow = true; // Debug switch to always show all perks
-
-	// We don't need to clear the list, or recreate the pawn here -sbatista
-	//super.PopulateData();
+	
+	AbilityTemplateManager = class'X2AbilityTemplateManager'.static.GetAbilityTemplateManager();
 	Unit = GetUnit();
 	DisplayOnly = !CanUnitEnterOTSTraining(Unit);
 	MaxRank = class'LWOfficerUtilities'.static.GetMaxRank();
-	AbilityTemplateManager = class'X2AbilityTemplateManager'.static.GetAbilityTemplateManager();
+	SelectionIndex = INDEX_NONE;
 
 	if (default.ALLOWTRAININGINARMORY)
+	{
 		DisplayOnly = false;
+	}
 
-	//Differentiate Header based on whether is in Armory or in OTS Facility
+	// Differentiate header based on whether we are in the Armory or the OTS Facility.
 	if (DisplayOnly)
 	{
 		HeaderString = m_strAbilityHeader;
-	} else {
+	} 
+	else
+	{
 		HeaderString = m_strSelectAbility;
 	}
 
-	//clear left/right ability titles
+	// Clear left and right ability titles
 	AS_SetTitle("", HeaderString, "", "", "");
 
-	//Init but then hide the first row, since it's set up for both class and single ability
+	// Init but then hide the first row, since it's set up for both class and single ability
 	if (ClassRowItem == none)
 	{
 		ClassRowItem = Spawn(class'UIArmory_PromotionItem', self);
@@ -114,87 +130,102 @@ simulated function PopulateData()
 	}
 	ClassRowItem.Hide();
 
-	//List.SetPosition(58, 170); // shift the list object to cover the gap from hiding the ClassRow and the left/right ability titles
-
-	// show core abilities
+	// Core, non-selectable, officer abilities are shown as the list's 1st row; these are "Leadership" and "Command".
 	Item = UIArmory_LWOfficerPromotionItem(List.GetItem(0));
 	if (Item == none)
 	{
-		Item = UIArmory_LWOfficerPromotionItem(UIArmory_LWOfficerPromotionItem(List.CreateItem(class'UIArmory_LWOfficerPromotionItem')).InitPromotionItem(0));
+		Item = UIArmory_LWOfficerPromotionItem(List.CreateItem(class'UIArmory_LWOfficerPromotionItem'));
+		Item.InitPromotionItem(0);
 	}
+
 	Item.Rank = 1;
 	Item.SetRankData(class'LWOfficerUtilities'.static.GetRankIcon(1), Caps(class'LWOfficerUtilities'.static.GetLWOfficerRankName(1)));
+	
 	AbilityTemplate1 = AbilityTemplateManager.FindAbilityTemplate(class'LWOfficerUtilities'.default.OfficerAbilityTree[0].AbilityName);
-	AbilityTemplate2 = AbilityTemplateManager.FindAbilityTemplate(class'LWOfficerUtilities'.default.OfficerAbilityTree[1].AbilityName);
 	AbilityName1 = Caps(AbilityTemplate1.LocFriendlyName);
 	AbilityIcon1 = AbilityTemplate1.IconImage;
+	Item.AbilityName1 = AbilityTemplate1.DataName;
+	
+	AbilityTemplate2 = AbilityTemplateManager.FindAbilityTemplate(class'LWOfficerUtilities'.default.OfficerAbilityTree[1].AbilityName);
 	AbilityName2 = Caps(AbilityTemplate2.LocFriendlyName);
 	AbilityIcon2 = AbilityTemplate2.IconImage;
-	Item.AbilityName1 = AbilityTemplate1.DataName;
 	Item.AbilityName2 = AbilityTemplate2.DataName;
+	
 	Item.SetAbilityData(AbilityIcon1, AbilityName1, AbilityIcon2, AbilityName2);
 	Item.SetEquippedAbilities(true, true);
 	Item.SetPromote(false);
 	Item.SetDisabled(false);
 	Item.RealizeVisuals();
 		
-	//loop over rows
+	// Show the rest of the officer rows; these will have the officer's selectable abilities.
 	for (i = 1; i <= MaxRank; ++i)
 	{
 		Item = UIArmory_LWOfficerPromotionItem(List.GetItem(i));
 		if (Item == none)
 		{
-			Item = UIArmory_LWOfficerPromotionItem(UIArmory_LWOfficerPromotionItem(List.CreateItem(class'UIArmory_LWOfficerPromotionItem')).InitPromotionItem(i));
+			Item = UIArmory_LWOfficerPromotionItem(List.CreateItem(class'UIArmory_LWOfficerPromotionItem'));
+			Item.InitPromotionItem(i);
 		}
+		
 		Item.Rank = i;
 		Item.SetRankData(class'LWOfficerUtilities'.static.GetRankIcon(Item.Rank), Caps(class'LWOfficerUtilities'.static.GetLWOfficerRankName(Item.Rank)));
 
 		AbilityTemplate1 = AbilityTemplateManager.FindAbilityTemplate(class'LWOfficerUtilities'.static.GetAbilityName(Item.Rank, 0));
 		AbilityTemplate2 = AbilityTemplateManager.FindAbilityTemplate(class'LWOfficerUtilities'.static.GetAbilityName(Item.Rank, 1));
-		//`log("LW Officer Pack : Display Ability:" @ string(AbilityTemplate1.DataName) @ "at Rank:" @ Item.Rank $ ", Option: 0");
-		//`log("LW Officer Pack : Display Ability:" @ string(AbilityTemplate2.DataName) @ "at Rank:" @ Item.Rank $ ", Option: 1");
 		
 		OfficerState = class'LWOfficerUtilities'.static.GetOfficerComponent(Unit);
-		if(OfficerState != none)
+		if (OfficerState != none)
 		{
+			// KDM : Determines if the officer already has either of these abilities.
 			bHasAbility1 = OfficerState.HasOfficerAbility(AbilityTemplate1.DataName);
 			bHasAbility2 = OfficerState.HasOfficerAbility(AbilityTemplate2.DataName);
 		}
+		
+		// KDM : Determines which row of officer abilites is the current promotion row.
 		if (DisplayOnly)
 		{
 			RankToPromote = -1;
-		} else 	if (OfficerState == none) 
+		} 
+		else if (OfficerState == none) 
 		{
 			RankToPromote = 1;
-			//`log("LW Officer Pack : Did not find Unit Officer Component");
-		} else {
+		}
+		else
+		{
 			RankToPromote = OfficerState.GetOfficerRank() + 1;
-			//`log("LW Officer Pack : Found Unit Officer Component, Rank=" $ string(OfficerState.GetOfficerRank()));
 		}
 
-		//get left-side ability
+		// Left side ability
 		if (AbilityTemplate1 != none)
 		{
 			Item.AbilityName1 = AbilityTemplate1.DataName;
-			if (default.ALWAYSSHOW || class'XComGameState_LWPerkPackOptions'.static.IsViewLockedStatsEnabled() || Item.Rank <= OfficerState.GetOfficerRank() || (!DisplayOnly && Item.Rank == RankToPromote))
+			// KDM : Determines whether we show the ability name and icon, or an unknown ability name and icon.
+			if (default.ALWAYSSHOW || class'XComGameState_LWPerkPackOptions'.static.IsViewLockedStatsEnabled() || Item.Rank <= OfficerState.GetOfficerRank() || 
+				(!DisplayOnly && Item.Rank == RankToPromote))
 			{
 				AbilityName1 = Caps(AbilityTemplate1.LocFriendlyName);
 				AbilityIcon1 = AbilityTemplate1.IconImage;
-			} else {
+			} 
+			else
+			{
 				AbilityName1 = class'UIUtilities_Text'.static.GetColoredText(m_strAbilityLockedTitle, eUIState_Disabled);
 				AbilityIcon1 = class'UIUtilities_Image'.const.UnknownAbilityIcon;
 			}
 		}
 
-		//get right-side ability
+		// Right side ability
 		if (AbilityTemplate2 != none)
 		{
 			Item.AbilityName2 = AbilityTemplate2.DataName;
-			if (default.ALWAYSSHOW || class'XComGameState_LWPerkPackOptions'.static.IsViewLockedStatsEnabled()  || Item.Rank <= OfficerState.GetOfficerRank() || (!DisplayOnly && Item.Rank == RankToPromote))
+			// KDM : Determines whether we show the ability name and icon, or an unknown ability name and icon.
+			if (default.ALWAYSSHOW || class'XComGameState_LWPerkPackOptions'.static.IsViewLockedStatsEnabled()  || Item.Rank <= OfficerState.GetOfficerRank() || 
+				(!DisplayOnly && Item.Rank == RankToPromote))
 			{
 				AbilityName2 = Caps(AbilityTemplate2.LocFriendlyName);
 				AbilityIcon2 = AbilityTemplate2.IconImage;
-			} else {
+			}
+			else
+			{
 				AbilityName2 = class'UIUtilities_Text'.static.GetColoredText(m_strAbilityLockedTitle, eUIState_Disabled);
 				AbilityIcon2 = class'UIUtilities_Image'.const.UnknownAbilityIcon;
 			}
@@ -203,22 +234,19 @@ simulated function PopulateData()
 		Item.SetAbilityData(AbilityIcon1, AbilityName1, AbilityIcon2, AbilityName2);
 		Item.SetEquippedAbilities(bHasAbility1, bHasAbility2);
 
+		// KDM : If this is the promotion row, highlight it as such; this row will also be given initial focus.
 		if (Item.Rank == RankToPromote)
 		{
 			Item.SetPromote(true);
-			Item.SetDisabled(false);
-		} else {
+			SelectionIndex = i;
+		}
+		else
+		{
 			Item.SetPromote(false);
 		}
 
-		//if (bHasRankAbility || default.ALWAYSSHOW)
-		//{
-			//Item.SetDisabled(false);
-		//} else {
-			//Item.SetDisabled(true);
-		//}
-
-		if((Item.Rank <= OfficerState.GetOfficerRank()) || ((Item.Rank == RankToPromote)) || default.ALWAYSSHOW || class'XComGameState_LWPerkPackOptions'.static.IsViewLockedStatsEnabled())
+		if ((Item.Rank <= OfficerState.GetOfficerRank()) || (Item.Rank == RankToPromote) || default.ALWAYSSHOW || 
+			class'XComGameState_LWPerkPackOptions'.static.IsViewLockedStatsEnabled())
 		{
 			Item.SetDisabled(false);
 		}
@@ -226,15 +254,25 @@ simulated function PopulateData()
 		{
 			Item.SetDisabled(true);
 		}
+
 		Item.RealizeVisuals();
 	}
 
-	//updates right-side ability panel
+	// Update ability summary at the bottom
 	PopulateAbilitySummary(Unit);
 
-	List.SetSelectedIndex(-1); // initial selection
+	// KDM : If there was no promotion row, select the highest ranking row the officer has attained.
+	if (SelectionIndex == INDEX_NONE)
+	{
+		SelectionIndex = OfficerState.GetOfficerRank();
+	}
+	
+	// KDM : Whenever list selection is changed, PreviewRow() is called, due to the setting of OnSelectionChanged within InitPromotion().
+	// The parameter, bForce, is set to true so that PreviewRow() is called regardless of the list's previously selected index.
+	// This matters when the next/previous soldier button is clicked, with the 2 soldiers having the same rank and, thus, SelectionIndex.
+	List.SetSelectedIndex(SelectionIndex, true);
 
-	PreviewRow(List, 1); // initial abilities shown at bottom of panel
+	UpdateNavHelp();
 }
 
 simulated function PopulateAbilitySummary(XComGameState_Unit Unit)
@@ -249,7 +287,7 @@ simulated function PopulateAbilitySummary(XComGameState_Unit Unit)
 	Movie.Pres.m_kTooltipMgr.RemoveTooltipsByPartialPath(string(MCPath) $ ".abilitySummaryList");
 
 	OfficerState = class'LWOfficerUtilities'.static.GetOfficerComponent(Unit);
-	if( OfficerState == none || OfficerState.GetOfficerRank() == 0 )
+	if (OfficerState == none || OfficerState.GetOfficerRank() == 0)
 	{
 		MC.FunctionVoid("hideAbilityList");
 		return;
@@ -264,10 +302,10 @@ simulated function PopulateAbilitySummary(XComGameState_Unit Unit)
 
 	AbilityTemplateManager = class'X2AbilityTemplateManager'.static.GetAbilityTemplateManager();
 	`Log("Soldier has " $ OfficerState.OfficerAbilities.Length $ " officer abilities");
-	for(i = 0; i < OfficerState.OfficerAbilities.Length; ++i)
+	for (i = 0; i < OfficerState.OfficerAbilities.Length; ++i)
 	{
 		AbilityTemplate = AbilityTemplateManager.FindAbilityTemplate(OfficerState.OfficerAbilities[i].AbilityType.AbilityName);
-		if( AbilityTemplate != none && !AbilityTemplate.bDontDisplayInAbilitySummary )
+		if (AbilityTemplate != none && !AbilityTemplate.bDontDisplayInAbilitySummary)
 		{
 			`Log("Adding " $ AbilityTemplate.DataName $ " to the summary");
 			class'UIUtilities_Strategy'.static.AddAbilityToSummary(self, AbilityTemplate, Index++, Unit, none);
@@ -279,21 +317,25 @@ simulated function PopulateAbilitySummary(XComGameState_Unit Unit)
 
 simulated function OnLoseFocus()
 {
-	super(UIArmory).OnLoseFocus();
-	//List.SetSelectedIndex(-1);
-	`HQPRES.m_kAvengerHUD.NavHelp.ClearButtonHelp();
-}
+	// KDM : We want the navigation help system to reload itself upon receiving focus.
+	AbilityInfoTipIsShowing = -1;
+	SelectAbilityTipIsShowing = -1;
 
+	super.OnLoseFocus();
+
+}
 
 simulated function PreviewRow(UIList ContainerList, int ItemIndex)
 {
+	local bool DisplayOnly;
 	local int i, Rank, EffectiveRank;
 	local string TmpStr;
 	local X2AbilityTemplate AbilityTemplate;
 	local X2AbilityTemplateManager AbilityTemplateManager;
 	local XComGameState_Unit Unit; 
-	local bool DisplayOnly;
 
+	// KDM : EffectiveRank is the rank the officer actually is, while Rank is the rank associated with this particular list item row.
+	
 	Unit = GetUnit();
 	DisplayOnly = !CanUnitEnterOTSTraining(Unit);
 
@@ -301,65 +343,92 @@ simulated function PreviewRow(UIList ContainerList, int ItemIndex)
 	{
 		Rank = 1;
 		return;
-	} else {
+	}
+	else
+	{
 		Rank = UIArmory_LWOfficerPromotionItem(List.GetItem(ItemIndex)).Rank;
 	}
 
 	MC.BeginFunctionOp("setAbilityPreview");
 
-	if(class'LWOfficerUtilities'.static.GetOfficerComponent(Unit) != none)
-		EffectiveRank = class'LWOfficerUtilities'.static.GetOfficerComponent(Unit).GetOfficerRank();
-	else
-		EffectiveRank = 0;
-
-	if (!DisplayOnly) {	EffectiveRank++; }
-
-	if((Rank > EffectiveRank) && !(default.ALWAYSSHOW || class'XComGameState_LWPerkPackOptions'.static.IsViewLockedStatsEnabled()))
+	if (class'LWOfficerUtilities'.static.GetOfficerComponent(Unit) != none)
 	{
-		for(i = 0; i < NUM_ABILITIES_PER_RANK; ++i)
+		EffectiveRank = class'LWOfficerUtilities'.static.GetOfficerComponent(Unit).GetOfficerRank();
+	}
+	else
+	{
+		EffectiveRank = 0;
+	}
+
+	if (!DisplayOnly)
+	{
+		EffectiveRank++;
+	}
+
+	// KDM : If the rank associated with this row is greater than the officer's actual rank show locked information and icons.
+	// This, however, can be negated by ALWAYSSHOW and IsViewLockedStatsEnabled().
+	if ((Rank > EffectiveRank) && !(default.ALWAYSSHOW || class'XComGameState_LWPerkPackOptions'.static.IsViewLockedStatsEnabled()))
+	{
+		for (i = 0; i < NUM_ABILITIES_PER_RANK; ++i)
 		{
-			MC.QueueString(class'UIUtilities_Image'.const.LockedAbilityIcon); // icon
-			MC.QueueString(class'UIUtilities_Text'.static.GetColoredText(m_strAbilityLockedTitle, eUIState_Disabled)); // name
-			MC.QueueString(class'UIUtilities_Text'.static.GetColoredText(m_strAbilityLockedDescription, eUIState_Disabled)); // description
-			MC.QueueBoolean(false); // isClassIcon
+			MC.QueueString(class'UIUtilities_Image'.const.LockedAbilityIcon); // Icon
+			MC.QueueString(class'UIUtilities_Text'.static.GetColoredText(m_strAbilityLockedTitle, eUIState_Disabled)); // Name
+			MC.QueueString(class'UIUtilities_Text'.static.GetColoredText(m_strAbilityLockedDescription, eUIState_Disabled)); // Description
+			MC.QueueBoolean(false); // IsClassIcon
 		}
 	}
+	// KDM : We are looking at a row whose associated rank is less than, or equal to, the officer's actual rank.
 	else
 	{
 		AbilityTemplateManager = class'X2AbilityTemplateManager'.static.GetAbilityTemplateManager();
 
-		for(i = 0; i < NUM_ABILITIES_PER_RANK; ++i)
+		for (i = 0; i < NUM_ABILITIES_PER_RANK; ++i)
 		{
+			// KDM : The 1st row corresponds to the officer's core, non-selectable, abilities.
 			if (ItemIndex == 0)
 			{
-				AbilityTemplate = AbilityTemplateManager.FindAbilityTemplate (class'LWOfficerUtilities'.static.GetAbilityName(0, i));
+				AbilityTemplate = AbilityTemplateManager.FindAbilityTemplate(class'LWOfficerUtilities'.static.GetAbilityName(0, i));
 			}
 			else
 			{
 				AbilityTemplate = AbilityTemplateManager.FindAbilityTemplate(class'LWOfficerUtilities'.static.GetAbilityName(Rank, i));
 			}
-			if(AbilityTemplate != none)
+
+			if (AbilityTemplate != none)
 			{
-				MC.QueueString(AbilityTemplate.IconImage); // icon
+				MC.QueueString(AbilityTemplate.IconImage); // Icon
 
 				TmpStr = AbilityTemplate.LocFriendlyName != "" ? AbilityTemplate.LocFriendlyName : ("Missing 'LocFriendlyName' for " $ AbilityTemplate.DataName);
-				MC.QueueString(Caps(TmpStr)); // name
+				MC.QueueString(Caps(TmpStr)); // Name
 
 				TmpStr = AbilityTemplate.HasLongDescription() ? AbilityTemplate.GetMyLongDescription() : ("Missing 'LocLongDescription' for " $ AbilityTemplate.DataName);
-				MC.QueueString(TmpStr); // description
-				MC.QueueBoolean(false); // isClassIcon
+				MC.QueueString(TmpStr); // Description
+				MC.QueueBoolean(false); // IsClassIcon
 			}
 			else
 			{
-				MC.QueueString(""); // icon
-				MC.QueueString(string(class'LWOfficerUtilities'.static.GetAbilityName(Rank, i))); // name
-				MC.QueueString("Missing template for ability '" $ class'LWOfficerUtilities'.static.GetAbilityName(Rank, i) $ "'"); // description
-				MC.QueueBoolean(false); // isClassIcon
+				MC.QueueString(""); // Icon
+				MC.QueueString(string(class'LWOfficerUtilities'.static.GetAbilityName(Rank, i))); // Name
+				MC.QueueString("Missing template for ability '" $ class'LWOfficerUtilities'.static.GetAbilityName(Rank, i) $ "'"); // Description
+				MC.QueueBoolean(false); // IsClassIcon
 			}
 		}
 	}
 
 	MC.EndOp();
+
+	if (`ISCONTROLLERACTIVE)
+	{
+		// KDM : When a new row is selected, preserve the ability selection; this means :
+		// 1.] If the previous row's left ability was selected, select the left ability for the new row.
+		// 2.] If the previous row's right ability was selected, select the right ability for the new row.
+		UIArmory_LWOfficerPromotionItem(List.GetItem(ItemIndex)).SetSelectedAbility(SelectedAbilityIndex);
+
+		// KDM : The navigation system should be updated because it might have changed. For example,
+		// 1.] If a promotion row ability is selected, a "Select" tip needs to be displayed.
+		// 2.] If an unhidden ability is selected, an "Ability Info" tip needs to be displayed.   
+		UpdateNavHelp();
+	}
 }
 
 simulated function ViewLeadershipStats(UIButton Button)
@@ -373,26 +442,30 @@ simulated function ViewLeadershipStats(UIButton Button)
 	DialogData.strText = GetFormattedLeadershipText();
 	DialogData.strCancel = class'UIUtilities_Text'.default.m_strGenericOK;;
 	Movie.Pres.UIRaiseDialog(DialogData);
-
 }
 
 simulated function string GetFormattedLeadershipText()
 {
-	local XComGameStateHistory History;
+	local int idx, limit;
 	local string OutString;
-	local XComGameState_Unit_LWOfficer OfficerState;
-	local XComGameState_Unit OfficerUnit, Unit;
 	local array<LeadershipEntry> LeadershipData;
 	local LeadershipEntry Entry;
-	local int idx, limit;
-	//local XGParamTag LocTag;
 	local X2SoldierClassTemplate ClassTemplate;
-
+	local XComGameState_Unit OfficerUnit, Unit;
+	local XComGameState_Unit_LWOfficer OfficerState;
+	local XComGameStateHistory History;
+	
 	OutString = "";
 	OfficerUnit = GetUnit();
-	if (OfficerUnit == none) { return Outstring; }
+	if (OfficerUnit == none)
+	{
+		return Outstring;
+	}
 	OfficerState = class'LWOfficerUtilities'.static.GetOfficerComponent(OfficerUnit);
-	if (OfficerState == none) {return Outstring; }
+	if (OfficerState == none)
+	{
+		return Outstring;
+	}
 
 	LeadershipData = OfficerState.GetLeadershipData_MissionSorted();
 	History = `XCOMHISTORY;
@@ -401,106 +474,54 @@ simulated function string GetFormattedLeadershipText()
 
 	foreach LeaderShipData (Entry, idx)
 	{
-		if (idx >= limit) { break; } // limit to the top 40
-		if (Entry.UnitRef.ObjectID == 0) { limit += 1; continue; }
+		// Limit to the top 40
+		if (idx >= limit) 
+		{
+			break;
+		}
+		
+		if (Entry.UnitRef.ObjectID == 0)
+		{
+			limit += 1; 
+			continue;
+		}
+		
 		Unit = XComGameState_Unit(History.GetGameStateForObjectID(Entry.UnitRef.ObjectID));
-		if (Unit == none) { limit += 1; continue; }
-		if (Unit.IsDead()) { limit += 1; continue; }
-		ClassTemplate = Unit.GetSoldierClassTemplate();
-		if (ClassTemplate.DataName == 'LWS_RebelSoldier') { limit += 1; continue; }
+		if (Unit == none)
+		{
+			limit += 1;
+			continue;
+		}
+		
+		if (Unit.IsDead())
+		{
+			limit += 1;
+			continue;
+		}
 
+		ClassTemplate = Unit.GetSoldierClassTemplate();
+		if (ClassTemplate.DataName == 'LWS_RebelSoldier')
+		{
+			limit += 1;
+			continue;
+		}
 
 		OutString $= Entry.SuccessfulMissionCount $ " : ";
 		OutString $= Unit.GetName(eNameType_RankFull) $ " / ";
 		Outstring $= ClassTemplate.DisplayName;
-		//LocTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
-		//LocTag.StrValue0 = Unit.GetName(eNameType_RankFull);
-		//LocTag.IntValue0 = Entry.SuccessfulMissionCount;
-		//Outstring $= `XEXPAND.ExpandString(strLeadershipDialogueData);
 		Outstring $= "\n";
 	}
 
 	return OutString;
 }
 
-simulated function UpdateNavHelp()
-{
-	//<workshop> SCI 2016/4/12
-	//INS:
-	local int i;
-	local string PrevKey, NextKey;
-	local XGParamTag LocTag;
-	if(!bIsFocused)
-	{
-		return;
-	}
-
-	NavHelp = `HQPRES.m_kAvengerHUD.NavHelp;
-
-	NavHelp.ClearButtonHelp();
-	//</workshop>
-
-	//<workshop> SCI 2016/4/12
-	//WAS:
-	//super.UpdateNavHelp();
-	NavHelp.AddBackButton(OnCancel);
-		
-	if (XComHQPresentationLayer(Movie.Pres) != none)
-	{
-		LocTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
-		LocTag.StrValue0 = Movie.Pres.m_kKeybindingData.GetKeyStringForAction(PC.PlayerInput, eTBC_PrevUnit);
-		PrevKey = `XEXPAND.ExpandString(PrevSoldierKey);
-		LocTag.StrValue0 = Movie.Pres.m_kKeybindingData.GetKeyStringForAction(PC.PlayerInput, eTBC_NextUnit);
-		NextKey = `XEXPAND.ExpandString(NextSoldierKey);
-
-		if (class'XComGameState_HeadquartersXCom'.static.GetObjectiveStatus('T0_M7_WelcomeToGeoscape') != eObjectiveState_InProgress &&
-			RemoveMenuEvent == '' && NavigationBackEvent == '' && !`ScreenStack.IsInStack(class'UISquadSelect'))
-		{
-			NavHelp.AddGeoscapeButton();
-		}
-
-		if (Movie.IsMouseActive() && IsAllowedToCycleSoldiers() && class'UIUtilities_Strategy'.static.HasSoldiersToCycleThrough(UnitReference, CanCycleTo))
-		{
-			NavHelp.SetButtonType("XComButtonIconPC");
-			i = eButtonIconPC_Prev_Soldier;
-			NavHelp.AddCenterHelp( string(i), "", PrevSoldier, false, PrevKey);
-			i = eButtonIconPC_Next_Soldier; 
-			NavHelp.AddCenterHelp( string(i), "", NextSoldier, false, NextKey);
-			NavHelp.SetButtonType("");
-		}
-	}
-
-	if (UIArmory_PromotionItem(List.GetSelectedItem()).bEligibleForPromotion)
-	{
-		NavHelp.AddSelectNavHelp();
-	}
-
-	if (`ISCONTROLLERACTIVE && !UIArmory_PromotionItem(List.GetSelectedItem()).bIsDisabled)
-	{
-		NavHelp.AddLeftHelp(m_strInfo, class'UIUtilities_Input'.static.GetGamepadIconPrefix() $class'UIUtilities_Input'.const.ICON_LSCLICK_L3);
-	}
-
-	if( `ISCONTROLLERACTIVE )
-	{
-		if (IsAllowedToCycleSoldiers() && class'UIUtilities_Strategy'.static.HasSoldiersToCycleThrough(UnitReference, CanCycleTo))
-		{
-			NavHelp.AddLeftHelp(class'UIUtilities_Input'.static.InsertGamepadIcons("%LB %RB" @ m_strTabNavHelp));
-		}
-
-		NavHelp.AddLeftHelp(class'UIUtilities_Input'.static.InsertGamepadIcons("%RS" @ m_strRotateNavHelp));
-	}
-
-	NavHelp.Show();
-	//</workshop>
-}
-
 simulated function ConfirmAbilitySelection(int Rank, int Branch)
 {
-	local XGParamTag LocTag;
 	local TDialogueBoxData DialogData;
 	local X2AbilityTemplate AbilityTemplate;
 	local X2AbilityTemplateManager AbilityTemplateManager;
-
+	local XGParamTag LocTag;
+	
 	PendingRank = Rank;
 	PendingBranch = Branch;
 
@@ -520,6 +541,9 @@ simulated function ConfirmAbilitySelection(int Rank, int Branch)
 	LocTag.StrValue0 = AbilityTemplate.LocFriendlyName;
 	DialogData.strText = `XEXPAND.ExpandString(m_strConfirmAbilityText);
 	Movie.Pres.UIRaiseDialog(DialogData);
+
+	// KDM : Follow the new WotC UIArmory_Promotion and update the navigation help system.
+	UpdateNavHelp();
 }
 
 simulated function ConfirmAbilityCallback(Name Action)
@@ -538,11 +562,11 @@ simulated function ConfirmAbilityCallback(Name Action)
 	local XComGameState_HeadquartersProjectTrainLWOfficer TrainLWOfficerProject;
 	local XComGameState_StaffSlot StaffSlotState;
 
-	if(Action == 'eUIAction_Accept')
+	if (Action == 'eUIAction_Accept')
 	{
 		Unit = GetUnit();
 
-		//Build ClassAgnosticAbility to allow instant training into Officer Ability
+		// Build ClassAgnosticAbility to allow instant training into Officer Ability
 		Ability.AbilityName = class'LWOfficerUtilities'.static.GetAbilityName(PendingRank, PendingBranch);
 		Ability.ApplyToWeaponSlot = eInvSlot_Unknown;
 		Ability.UtilityCat = '';
@@ -550,36 +574,41 @@ simulated function ConfirmAbilityCallback(Name Action)
 		NewOfficerAbility.iRank = PendingRank;
 		NewOfficerAbility.bUnlocked = true;
 
-		//Build GameState change container
+		// Build GameState change container
 		History = `XCOMHISTORY;
 		ChangeContainer = class'XComGameStateContext_ChangeContainer'.static.CreateEmptyChangeContainer("Staffing Train Officer Slot");
 		UpdateState = History.CreateNewGameState(true, ChangeContainer);
 		UpdatedUnit = XComGameState_Unit(UpdateState.CreateStateObject(class'XComGameState_Unit', GetUnit().ObjectID));
 
-		//Try to retrieve new OfficerComponent from Unit -- note that it may not have been created for non-officers yet
+		// Try to retrieve new OfficerComponent from Unit -- note that it may not have been created for non-officers yet
 		OfficerState = class'LWOfficerUtilities'.static.GetOfficerComponent(Unit);
 
 		if (OfficerState == none) 
 		{
-			//first promotion, create component gamestate and attach it
+			// First promotion, create component gamestate and attach it
 			OfficerState = XComGameState_Unit_LWOfficer(UpdateState.CreateStateObject(class'XComGameState_Unit_LWOfficer'));
 			OfficerState.InitComponent();
 			if (default.INSTANTTRAINING) 
 			{
 				OfficerState.SetOfficerRank(1);
-			} else {
+			}
+			else
+			{
 				NewOfficerRank = 1;
 			}
 			UpdatedUnit.AddComponentObject(OfficerState);
-		} else {
-			//subsequent promotion, update existing component gamestate
+		}
+		else
+		{
+			// Subsequent promotion, update existing component gamestate
 			NewOfficerRank = OfficerState.GetOfficerRank() + 1;
 			OfficerState = XComGameState_Unit_LWOfficer(UpdateState.CreateStateObject(class'XComGameState_Unit_LWOfficer', OfficerState.ObjectID));
 			if (default.INSTANTTRAINING) 
 			{
 				OfficerState.SetOfficerRank(NewOfficerRank);
-			} else {
-				
+			}
+			else
+			{	
 			}
 		}
 
@@ -589,7 +618,9 @@ simulated function ConfirmAbilityCallback(Name Action)
 			OfficerState.OfficerAbilities.AddItem(NewOfficerAbility);
 			UpdatedUnit = class'LWOfficerUtilities'.static.AddInitialAbilities(UpdatedUnit, OfficerState, UpdateState);
 			bTrainingSuccess = true;
-		} else {
+		}
+		else
+		{
 			bTrainingSuccess = OfficerState.SetRankTraining(NewOfficerRank, Ability.AbilityName);
 		}
 
@@ -599,32 +630,34 @@ simulated function ConfirmAbilityCallback(Name Action)
 			if (StaffSlotState != none)
 			{
 				UnitInfo.UnitRef = UpdatedUnit.GetReference();
-				StaffSlotState.FillSlot(UnitInfo, UpdateState); // The Training project is started when the staff slot is filled
+				// The Training project is started when the staff slot is filled
+				StaffSlotState.FillSlot(UnitInfo, UpdateState); 
 		
 				// Find the new Training Project which was just created by filling the staff slot and set the rank and ability
 				foreach UpdateState.IterateByClassType(class'XComGameState_HeadquartersProjectTrainLWOfficer', TrainLWOfficerProject)
 				{
-					if (TrainLWOfficerProject.ProjectFocus.ObjectID == GetUnit().ObjectID) //handle possible cases of multiple officer training slots
+					// Handle possible cases of multiple officer training slots
+					if (TrainLWOfficerProject.ProjectFocus.ObjectID == GetUnit().ObjectID) 
 					{
 						TrainLWOfficerProject.AbilityName = Ability.AbilityName;
 						TrainLWOfficerProject.NewRank = NewOfficerRank;
 
-						// have to recompute time for project after rank is set in order to handle completion time based on rank
+						// Have to recompute time for project after rank is set in order to handle completion time based on rank
 						TrainLWOfficerProject.ProjectPointsRemaining = TrainLWOfficerProject.CalculatePointsToTrain(); 
 						TrainLWOfficerProject.InitialProjectPoints = TrainLWOfficerProject.CalculatePointsToTrain();
 						TrainLWOfficerProject.SetProjectedCompletionDateTime(TrainLWOfficerProject.StartDateTime);
 						break;
 					}
 				}
-
-				//RefreshAcademyFacility();
-			} else {
+			}
+			else
+			{
 				`Redscreen("LW Officer Pack : Failed to find StaffSlot in UIArmory_LWOfficerPromotion.ConfirmAbilityCallback");
 				bTrainingSuccess = false;
 			}
 		}
 
-		//submit or clear update state based on success/failure
+		// Submit or clear update state based on success/failure
 		if (bTrainingSuccess) 
 		{
 			UpdateState.AddStateObject(UpdatedUnit);
@@ -633,14 +666,18 @@ simulated function ConfirmAbilityCallback(Name Action)
 
 			Header.PopulateData();
 			PopulateData();
-		} else {
+		}
+		else 
+		{
 			History.CleanupPendingGameState(UpdateState);
 		}
 		Movie.Pres.PlayUISound(eSUISound_SoldierPromotion);
 		Movie.Pres.ScreenStack.PopUntilClass(class'UIFacility_Academy', true);
 	}
 	else
+	{
 		Movie.Pres.PlayUISound(eSUISound_MenuClickNegative);
+	}
 }
 
 simulated function XComGameState_StaffSlot GetEmptyOfficerTrainingStaffSlot()
@@ -654,19 +691,21 @@ simulated function XComGameState_StaffSlot GetEmptyOfficerTrainingStaffSlot()
 
 	ScreenStack = Movie.Pres.ScreenStack;
 
-	//find the class UIFacilityAcademy that invoked this (just in case there's more than 1)
+	// Find the class UIFacilityAcademy that invoked this (just in case there's more than 1)
 	AcademyUI = UIFacility_Academy(ScreenStack.GetScreen(class'UIFacility_Academy'));
-	if(AcademyUI == none)
+	if (AcademyUI == none)
 	{
-		//search for override classes
+		// Search for override classes
 		foreach ScreenStack.Screens(CurrScreen)
 		{
 			AcademyUI = UIFacility_Academy(CurrScreen);
-			if(AcademyUI != none)
+			if (AcademyUI != none)
+			{
 				break;
+			}
 		}
 	}
-	if(AcademyUI == none)
+	if (AcademyUI == none)
 	{
 		FacilityState = `XCOMHQ.GetFacilityByName('OfficerTrainingSchool');
 	}
@@ -675,13 +714,10 @@ simulated function XComGameState_StaffSlot GetEmptyOfficerTrainingStaffSlot()
 		FacilityState = AcademyUI.GetFacility();
 	}
 
-	for(idx = 0; idx < FacilityState.StaffSlots.Length; idx++)
+	for (idx = 0; idx < FacilityState.StaffSlots.Length; idx++)
 	{
 		SlotState = FacilityState.GetStaffSlot(idx);
-		if(SlotState != none 
-			&& SlotState.GetMyTemplateName() == 'OTSOfficerSlot' 
-			&& SlotState.IsSlotEmpty()
-			&& !SlotState.bIsLocked)
+		if (SlotState != none && SlotState.GetMyTemplateName() == 'OTSOfficerSlot' && SlotState.IsSlotEmpty() && !SlotState.bIsLocked)
 		{
 			return SlotState;
 		}
@@ -708,3 +744,166 @@ simulated static function CycleToSoldier(StateObjectReference UnitRef)
 	super(UIArmory).CycleToSoldier(UnitRef);
 }
 
+// KDM : Use UIArmory_Promotion --> UpdateNavHelp() as our code base since it has been updated for WotC.
+simulated function UpdateNavHelp()
+{
+	local int i, AbilityInfoTipShouldShow, SelectAbilityTipShouldShow;
+	local string PrevKey, NextKey;
+	local XGParamTag LocTag;
+	
+	if (!bIsFocused)
+	{
+		return;
+	}
+
+	// KDM : -1 = unset, 0 = false, 1 = true
+	AbilityInfoTipShouldShow = (!UIArmory_PromotionItem(List.GetSelectedItem()).bIsDisabled) ? 1 : 0;
+	SelectAbilityTipShouldShow = (UIArmory_PromotionItem(List.GetSelectedItem()).bEligibleForPromotion) ? 1 : 0;
+
+	// KDM : Whenever the promotion screen updates its navigation help system, the whole navigation help system flickers off then on; 
+	// this is because it needs to be cleared, recreated, then re-shown. This is mainly an issue for controller users since, for them,
+	// the navigation system has to refresh whenever a new row is selected, as well as whenever a new ability is selected. The reason is :
+	// 1.] A 'Select' tip appears when a promotion eligible row is selected, and disappears otherwise.
+	// 2.] An 'Ability Info' tip appears whenever an unhidden ability is selected, and disappears otherwise.
+	//
+	// The easiest solution is to only update the navigation help system when dynamic tips do, in fact, change.
+	if (`ISCONTROLLERACTIVE && (AbilityInfoTipIsShowing == AbilityInfoTipShouldShow) && (SelectAbilityTipIsShowing == SelectAbilityTipShouldShow))
+	{
+		// KDM : The navigation help system has not changed so just get out.
+		return;
+	}
+	else if (`ISCONTROLLERACTIVE && ((AbilityInfoTipIsShowing != AbilityInfoTipShouldShow) || (SelectAbilityTipIsShowing != SelectAbilityTipShouldShow)))
+	{
+		// KDM : The navigation help system has changed so let it on through.
+		AbilityInfoTipIsShowing = AbilityInfoTipShouldShow;
+		SelectAbilityTipIsShowing = SelectAbilityTipShouldShow;
+	}
+	
+	NavHelp = `HQPRES.m_kAvengerHUD.NavHelp;
+
+	NavHelp.ClearButtonHelp();
+	
+	// KDM : From what I can see, the officer promotion screen is not accessible via the post mission squad view, represented by UIAfterAction;
+	// therefore, the corresponding code has been removed.
+
+	NavHelp.AddBackButton(OnCancel);
+
+	if (UIArmory_PromotionItem(List.GetSelectedItem()).bEligibleForPromotion)
+	{
+		NavHelp.AddSelectNavHelp();
+	}
+
+	if (XComHQPresentationLayer(Movie.Pres) != none)
+	{
+		LocTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
+		LocTag.StrValue0 = Movie.Pres.m_kKeybindingData.GetKeyStringForAction(PC.PlayerInput, eTBC_PrevUnit);
+		PrevKey = `XEXPAND.ExpandString(PrevSoldierKey);
+		LocTag.StrValue0 = Movie.Pres.m_kKeybindingData.GetKeyStringForAction(PC.PlayerInput, eTBC_NextUnit);
+		NextKey = `XEXPAND.ExpandString(NextSoldierKey);
+
+		if (class'XComGameState_HeadquartersXCom'.static.GetObjectiveStatus('T0_M7_WelcomeToGeoscape') != eObjectiveState_InProgress &&
+			RemoveMenuEvent == '' && NavigationBackEvent == '' && !`ScreenStack.IsInStack(class'UISquadSelect'))
+		{
+			NavHelp.AddGeoscapeButton();
+		}
+
+		if (Movie.IsMouseActive() && IsAllowedToCycleSoldiers() && class'UIUtilities_Strategy'.static.HasSoldiersToCycleThrough(UnitReference, CanCycleTo))
+		{
+			NavHelp.SetButtonType("XComButtonIconPC");
+			i = eButtonIconPC_Prev_Soldier;
+			NavHelp.AddCenterHelp( string(i), "", PrevSoldier, false, PrevKey);
+			i = eButtonIconPC_Next_Soldier; 
+			NavHelp.AddCenterHelp( string(i), "", NextSoldier, false, NextKey);
+			NavHelp.SetButtonType("");
+		}
+	}
+
+	// KDM : 'Make poster' help item has been removed.
+
+	if (`ISCONTROLLERACTIVE)
+	{
+		if (!UIArmory_PromotionItem(List.GetSelectedItem()).bIsDisabled)
+		{
+			NavHelp.AddLeftHelp(m_strInfo, class'UIUtilities_Input'.static.GetGamepadIconPrefix() $class'UIUtilities_Input'.const.ICON_LSCLICK_L3);
+		}
+
+		if (IsAllowedToCycleSoldiers() && class'UIUtilities_Strategy'.static.HasSoldiersToCycleThrough(UnitReference, CanCycleTo))
+		{
+			NavHelp.AddCenterHelp(m_strTabNavHelp, class'UIUtilities_Input'.static.GetGamepadIconPrefix() $ class'UIUtilities_Input'.const.ICON_LBRB_L1R1);
+		}
+
+		NavHelp.AddCenterHelp(m_strRotateNavHelp, class'UIUtilities_Input'.static.GetGamepadIconPrefix() $ class'UIUtilities_Input'.const.ICON_RSTICK); 
+	}
+
+	// KDM : 'Go to Training Center' help item has been removed; might be ok to keep this one though. 
+
+	NavHelp.Show();
+}
+
+simulated function bool OnUnrealCommand(int cmd, int arg)
+{
+	local bool bHandled;
+	
+	if (!CheckInputIsReleaseOrDirectionRepeat(cmd, arg))
+	{
+		return false;
+	}
+	
+	// KDM : Give the selected list item the first chance at the input.
+	if (List.GetSelectedItem().OnUnrealCommand(cmd, arg))
+	{
+		UpdateNavHelp();
+		return true;
+	}
+
+	bHandled = true;
+
+	switch(cmd)
+	{
+		// KDM : Right stick click opens up the leadership screen for controller users.
+		case class'UIUtilities_Input'.const.FXS_BUTTON_R3:
+			if (LeadershipButton.bIsVisible)
+			{
+				ViewLeadershipStats(none);
+			}
+			break;
+		
+		case class'UIUtilities_Input'.const.FXS_MOUSE_5:
+		case class'UIUtilities_Input'.const.FXS_KEY_TAB:
+		case class'UIUtilities_Input'.const.FXS_BUTTON_RBUMPER:
+		case class'UIUtilities_Input'.const.FXS_MOUSE_4:
+		case class'UIUtilities_Input'.const.FXS_KEY_LEFT_SHIFT:
+		case class'UIUtilities_Input'.const.FXS_BUTTON_LBUMPER:
+			// Prevent switching soldiers during AfterAction promotion
+			if (UIAfterAction(Movie.Stack.GetScreen(class'UIAfterAction')) == none)
+			{
+				bHandled = false;
+			}
+			break;
+		
+		case class'UIUtilities_Input'.const.FXS_BUTTON_B:
+		case class'UIUtilities_Input'.const.FXS_KEY_ESCAPE:
+		case class'UIUtilities_Input'.const.FXS_R_MOUSE_DOWN:
+			OnCancel();
+			break;
+		
+		// KDM : 'Make poster' case has been removed.
+
+		// KDM : 'Go to Training Center' case has been removed.
+		
+		default:
+			bHandled = false;
+			break;
+	}
+	
+	return bHandled || super(UIArmory).OnUnrealCommand(cmd, arg);
+}
+
+defaultproperties
+{
+	// KDM : Select the left ability on initialization.
+	SelectedAbilityIndex = 0;
+
+	AbilityInfoTipIsShowing = -1;
+	SelectAbilityTipIsShowing = -1;
+}

--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIArmory_LWOfficerPromotionItem.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIArmory_LWOfficerPromotionItem.uc
@@ -1,14 +1,12 @@
 //---------------------------------------------------------------------------------------
-//  FILE:    UIArmory_LWOfficerPromotionItem
+//  FILE:    UIArmory_LWOfficerPromotionItem 
 //  AUTHOR:  Amineri
-//
 //  PURPOSE: Tweaked ability selection UI for LW officer system
-//
 //--------------------------------------------------------------------------------------- 
 
 class UIArmory_LWOfficerPromotionItem extends UIArmory_PromotionItem;
 
-//override Mouse Controls to point back to UIArmory_LWOfficerPromotion mouse handlers
+// Override Mouse Controls to point back to UIArmory_LWOfficerPromotion mouse handlers
 // all other functionality identical to parent method
 simulated function OnChildMouseEvent(UIPanel ChildControl, int cmd)
 {
@@ -20,68 +18,183 @@ simulated function OnChildMouseEvent(UIPanel ChildControl, int cmd)
 
 	switch(ChildControl)  
 	{
-	case AbilityIcon1:
-		if(cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_UP)
-		{
-			if(bEligibleForPromotion)
-				PromotionScreen.ConfirmAbilitySelection(Rank, 0);
-			else
-				Movie.Pres.PlayUISound(eSUISound_MenuClickNegative);
-		}
-		else if(cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_IN)
-		{
-			OnReceiveFocus();
-			AbilityIcon1.OnReceiveFocus();
-			RealizePromoteState();
-		}
-		else if(cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT || cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_DRAG_OUT)
-		{
-			AbilityIcon1.OnLoseFocus();
-			RealizePromoteState();
-		}
-		break;
-	case AbilityIcon2:
-		if(cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_UP)
-		{
-			if(bEligibleForPromotion)
-				PromotionScreen.ConfirmAbilitySelection(Rank, 1);
-			else
-				Movie.Pres.PlayUISound(eSUISound_MenuClickNegative);
-		}
-		else if(cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_IN || cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_DRAG_OVER)
-		{
-			OnReceiveFocus();
-			AbilityIcon2.OnReceiveFocus();
-			RealizePromoteState();
-		}
-		else if(cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT || cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_DRAG_OUT)
-		{
-			AbilityIcon2.OnLoseFocus();
-			RealizePromoteState();
-		}
-		break;
-	case InfoButton1:
-	case InfoButton2:
-		if(cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_UP)
-		{
-			OnAbilityInfoClicked(UIButton(ChildControl));
-		}
-		else if(cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_IN || cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_DRAG_OVER)
-		{
-			OnReceiveFocus();
-		}
-		break;
-	case ClassIcon:
-		if(cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_IN || cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_DRAG_OVER)
-		{
-			OnReceiveFocus();
-		}
-		break;
-	default:
-		bHandled = false;
-		break;
+		case AbilityIcon1:
+			if (cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_UP)
+			{
+				if (bEligibleForPromotion)
+				{
+					PromotionScreen.ConfirmAbilitySelection(Rank, 0);
+				}
+				else
+				{
+					Movie.Pres.PlayUISound(eSUISound_MenuClickNegative);
+				}
+			}
+			else if (cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_IN)
+			{
+				OnReceiveFocus();
+				AbilityIcon1.OnReceiveFocus();
+				RealizePromoteState();
+			}
+			else if (cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT || cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_DRAG_OUT)
+			{
+				AbilityIcon1.OnLoseFocus();
+				RealizePromoteState();
+			}
+			break;
+		
+		case AbilityIcon2:
+			if (cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_UP)
+			{
+				if (bEligibleForPromotion)
+				{
+					PromotionScreen.ConfirmAbilitySelection(Rank, 1);
+				}
+				else
+				{
+					Movie.Pres.PlayUISound(eSUISound_MenuClickNegative);
+				}
+			}
+			else if (cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_IN || cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_DRAG_OVER)
+			{
+				OnReceiveFocus();
+				AbilityIcon2.OnReceiveFocus();
+				RealizePromoteState();
+			}
+			else if (cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT || cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_DRAG_OUT)
+			{
+				AbilityIcon2.OnLoseFocus();
+				RealizePromoteState();
+			}
+			break;
+		
+		case InfoButton1:
+		case InfoButton2:
+			if (cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_UP)
+			{
+				OnAbilityInfoClicked(UIButton(ChildControl));
+			}
+			else if (cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_IN || cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_DRAG_OVER)
+			{
+				OnReceiveFocus();
+			}
+			break;
+		
+		case ClassIcon:
+			if (cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_IN || cmd == class'UIUtilities_Input'.const.FXS_L_MOUSE_DRAG_OVER)
+			{
+				OnReceiveFocus();
+			}
+			break;
+		
+		default:
+			bHandled = false;
+			break;
 	}
 
-	if( bHandled )
+	if (bHandled)
+	{
 		RealizeVisuals();
+	}
+}
+
+simulated function bool OnUnrealCommand(int cmd, int arg)
+{
+	if (!CheckInputIsReleaseOrDirectionRepeat(cmd, arg))
+	{
+		return false;
+	}
+	
+	switch(cmd)
+	{
+		case class'UIUtilities_Input'.const.FXS_VIRTUAL_LSTICK_LEFT:
+		case class'UIUtilities_Input'.const.FXS_DPAD_LEFT:
+		case class'UIUtilities_Input'.const.FXS_ARROW_LEFT:
+			if (AbilityIcon1.bIsVisible)
+			{
+				OnChildMouseEvent(AbilityIcon1, class'UIUtilities_Input'.const.FXS_L_MOUSE_IN);
+				OnChildMouseEvent(AbilityIcon2, class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT);
+				SelectedAbility = 0;
+				// KDM : Let SelectedAbilityIndex know that the left ability has been selected; this information will be used when
+				// we select a new row.
+				UIArmory_Promotion(Screen).SelectedAbilityIndex = SelectedAbility;
+			}
+			return true;
+
+		case class'UIUtilities_Input'.const.FXS_VIRTUAL_LSTICK_RIGHT:
+		case class'UIUtilities_Input'.const.FXS_DPAD_RIGHT:
+		case class'UIUtilities_Input'.const.FXS_ARROW_RIGHT:
+			if (AbilityIcon2.bIsVisible)
+			{
+				OnChildMouseEvent(AbilityIcon1, class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT);
+				OnChildMouseEvent(AbilityIcon2, class'UIUtilities_Input'.const.FXS_L_MOUSE_IN);
+				SelectedAbility = 1;
+				// KDM : Let SelectedAbilityIndex know that the right ability has been selected; this information will be used when
+				// we select a new row.
+				UIArmory_Promotion(Screen).SelectedAbilityIndex = SelectedAbility;
+			}
+			return true;
+		
+		case class'UIUtilities_Input'.const.FXS_DPAD_UP:
+		case class'UIUtilities_Input'.const.FXS_VIRTUAL_LSTICK_UP:
+		case class'UIUtilities_Input'.const.FXS_ARROW_UP:
+			if (self != UIArmory_Promotion(Screen).ClassRowItem)
+			{
+				// KDM : When a new row is selected, UIArmory_LWOfficerPromotion --> PreviewRow() will make sure that ability selection
+				// remains consistent between the previous row and newly selected row.
+				OnChildMouseEvent(AbilityIcon1, class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT);
+				OnChildMouseEvent(AbilityIcon2, class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT);
+			}
+			break;
+
+		case class'UIUtilities_Input'.const.FXS_DPAD_DOWN:
+		case class'UIUtilities_Input'.const.FXS_VIRTUAL_LSTICK_DOWN:
+		case class'UIUtilities_Input'.const.FXS_ARROW_DOWN:
+			if (UIArmory_Promotion(Screen).List.SelectedIndex < UIArmory_Promotion(Screen).List.GetItemCount() - 1)
+			{
+				// KDM : When a new row is selected, UIArmory_LWOfficerPromotion --> PreviewRow() will make sure that ability selection
+				// remains consistent between the previous row and newly selected row.
+				OnChildMouseEvent(AbilityIcon1, class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT);
+				OnChildMouseEvent(AbilityIcon2, class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT);
+			}
+			break;
+
+		case class'UIUtilities_Input'.const.FXS_BUTTON_A:
+		case class'UIUtilities_Input'.const.FXS_KEY_ENTER:
+		case class'UIUtilities_Input'.const.FXS_KEY_SPACEBAR:
+			if (!bEligibleForPromotion)
+			{
+				return false;
+			}
+
+			// KDM : SelectedAbilityIndex need not be updated here since the A button does nothing to change the selected ability.
+
+			if (SelectedAbility == 0)
+			{
+				OnChildMouseEvent(AbilityIcon1, class'UIUtilities_Input'.const.FXS_L_MOUSE_UP);
+			}
+			else if (SelectedAbility == 1)
+			{
+				OnChildMouseEvent(AbilityIcon2, class'UIUtilities_Input'.const.FXS_L_MOUSE_UP);
+			}
+			return true;
+
+		case class'UIUtilities_Input'.const.FXS_BUTTON_L3:
+			if (!bIsDisabled)
+			{
+				// KDM : SelectedAbilityIndex need not be updated here since the L3 button does nothing to change the selected ability.
+
+				if (SelectedAbility == 0)
+				{
+					OnChildMouseEvent(InfoButton1, class'UIUtilities_Input'.const.FXS_L_MOUSE_UP);
+				}
+				else if (SelectedAbility == 1)
+				{
+					OnChildMouseEvent(InfoButton2, class'UIUtilities_Input'.const.FXS_L_MOUSE_UP);
+				}
+			}
+			return true;
+	}
+
+	return super(UIPanel).OnUnrealCommand(cmd, arg);
 }

--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIScreenListener_LWOfficerPack.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIScreenListener_LWOfficerPack.uc
@@ -1,9 +1,7 @@
 //---------------------------------------------------------------------------------------
 //  FILE:    UIScreenListener_LWOfficerPack
 //  AUTHOR:  Amineri (Pavonis Interactive)
-//
 //  PURPOSE: Implements event listeners used to interface to other mods
-//
 //--------------------------------------------------------------------------------------- 
 
 class UIScreenListener_LWOfficerPack extends UIScreenListener;
@@ -305,6 +303,10 @@ simulated function OnOfficerButtonCallback(UIButton kButton)
 	HQPres = `HQPRES;
 	OfficerScreen = UIArmory_LWOfficerPromotion(HQPres.ScreenStack.Push(HQPres.Spawn(class'UIArmory_LWOfficerPromotion', HQPres), HQPres.Get3DMovie()));
 	OfficerScreen.InitPromotion(ArmoryMainMenu.GetUnitRef(), false);
+	// KDM : Previously, the officer pawn could be rotated when accessing the officer screen through the officer slot, but not when
+	// accessing it through the 'Officer Abilities' menu button. Turns out it was missing a call to CreateSoldierPawn(); this has
+	// been rectified below.
+	OfficerScreen.CreateSoldierPawn();
 }
 
 //callback handler for list button info at bottom of screen


### PR DESCRIPTION
Modifies : UIArmory_LWOfficerPromotion & UIArmory_LWOfficerPromotionItem

1.] The officer training screen has now been made controller capable; D-Pad up/down changes rows, while D-Pad left/right changes abilities. Additionally, ability selection remains consistent when changing rows; if the left ability is selected in the old row, it will also be selected in the new row; same goes for the right ability.
2.] The 'leadership history' button has been made controller capable, via a hotlink.
3.] The navigation system was also modified, for controller users, such that it would only update when necessary. The reason this was done was that each time the navigation system updates, it flickers, since it needs to clear itself, re-create itself, then show itself. 
4.] Spaces --> Tabs

------------------------------------

Modifies : UIAlert_LWOfficerTrainingComplete

When officer training finishes, generally speaking, 2 buttons should appear; 1 button allows you to view the soldier, while the other button simply 'carrys on'. Several fixes were needed :
1.] Both the controller A and B buttons called OnCancelClicked(), equivalent to "carry on"; this was fixed in OnUnrealCommand().
2.] For mouse & keyboard users, these two buttons were placed on top of each other due to a call to OnTrainingButtonRealized(); subsequently, this call was removed.

------------------------------------

Modifies : UIScreenListener_LWOfficerPack --> OnOfficerButtonCallback()

Previously, the officer pawn could be rotated when accessing the officer screen through the officer slot, but not when accessing it through the 'Officer Abilities' menu button. Turns out it was missing a call to CreateSoldierPawn().