### PR TITLE
Add ability to Strip Weapon Upgrades for Controllers + few weapon upgrade fixes

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWListenerManager.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWListenerManager.uc
@@ -1,8 +1,14 @@
 //---------------------------------------------------------------------------------------
-//  FILE:    XComGameState_LWListenerManager.uc
-//  AUTHOR:  Amineri / Pavonis Interactive
-//  PURPOSE: This singleton object manages general persistent listeners that should live for both strategy and tactical play
+//	FILE:    XComGameState_LWListenerManager.uc
+//	AUTHOR:  Amineri / Pavonis Interactive
+//	PURPOSE: This singleton object manages general persistent listeners that should live for both strategy and tactical play
+//
+//	KDM : The following functions have been removed because they were never called :
+//	1A.] AddArmoryStripWeaponsButton().
+//	1B.] OnStripWeaponClicked(), which was only called from AddArmoryStripWeaponsButton().
+//	1C.] ConfirmStripSingleWeaponUpgradesCallback(), which was called from OnStripWeaponClicked().
 //---------------------------------------------------------------------------------------
+
 class XComGameState_LWListenerManager extends XComGameState_BaseObject config(LW_Overhaul) dependson(XComGameState_LWPersistentSquad);
 
 var config int DEFAULT_LISTENER_PRIORITY;
@@ -399,66 +405,6 @@ function EventListenerReturn AddSquadSelectStripWeaponsButton (Object EventData,
 	NavHelp.AddCenterHelp(class'UIUtilities_LW'.default.m_strStripWeaponUpgrades, "", OnStripUpgrades, false, class'UIUtilities_LW'.default.m_strTooltipStripWeapons);
 	
 	return ELR_NoInterrupt;
-}
-
-function EventListenerReturn AddArmoryStripWeaponsButton (Object EventData, Object EventSource, XComGameState GameState, Name InEventID, Object CallbackData)
-{
-	local UINavigationHelp NavHelp;
-
-	NavHelp = `HQPRES.m_kAvengerHUD.NavHelp;
-
-	// Add a button to make upgrades available.
-	NavHelp.AddLeftHelp(class'UIUtilities_LW'.default.m_strStripWeaponUpgrades, "", OnStripUpgrades, false, class'UIUtilities_LW'.default.m_strTooltipStripWeapons);
-	// Add a button to strip just the upgrades from this weapon.
-	NavHelp.AddLeftHelp(Caps(class'UIScreenListener_ArmoryWeaponUpgrade_LW'.default.strStripWeaponUpgradesButton), "", OnStripWeaponClicked, false, class'UIScreenListener_ArmoryWeaponUpgrade_LW'.default.strStripWeaponUpgradesTooltip);
-	
-	return ELR_NoInterrupt;
-}
-
-simulated function OnStripWeaponClicked()
-{
-	local XComPresentationLayerBase Pres;
-	local TDialogueBoxData DialogData;
-
-	Pres = `PRESBASE;
-	Pres.PlayUISound(eSUISound_MenuSelect);
-
-	DialogData.eType = eDialog_Warning;
-	DialogData.strTitle = class'UIScreenListener_ArmoryWeaponUpgrade_LW'.default.strStripWeaponUpgradeDialogueTitle;
-	DialogData.strText = class'UIScreenListener_ArmoryWeaponUpgrade_LW'.default.strStripWeaponUpgradeDialogueText;
-	DialogData.strAccept = class'UIUtilities_Text'.default.m_strGenericYes;
-	DialogData.strCancel = class'UIUtilities_Text'.default.m_strGenericNO;
-	DialogData.fnCallback = ConfirmStripSingleWeaponUpgradesCallback;
-	Pres.UIRaiseDialog(DialogData);
-}
-
-simulated function ConfirmStripSingleWeaponUpgradesCallback(Name eAction)
-{
-	local XComGameState_Item ItemState;
-	local UIArmory_Loadout LoadoutScreen;
-	local XComGameState_HeadquartersXCom XComHQ;
-	local XComGameState_Unit Soldier;
-	local XComGameState UpdateState;
-
-	if (eAction == 'eUIAction_Accept')
-	{
-		LoadoutScreen = UIArmory_Loadout(`SCREENSTACK.GetFirstInstanceOf(class'UIArmory_Loadout'));
-		if (LoadoutScreen != none)
-		{
-			Soldier = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(LoadoutScreen.GetUnitRef().ObjectID));
-			ItemState = Soldier.GetItemInSlot(eInvSlot_PrimaryWeapon);
-			if (ItemState != none && ItemState.HasBeenModified())
-			{
-				UpdateState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Strip Weapon Upgrades");
-				XComHQ = `XCOMHQ;
-				XComHQ = XComGameState_HeadquartersXCom(UpdateState.CreateStateObject(class'XComGameState_HeadquartersXCom', XComHQ.ObjectID));
-				UpdateState.AddStateObject(XComHQ);
-				StripWeaponUpgradesFromItem(ItemState, XComHQ, UpdateState);
-				`GAMERULES.SubmitGameState(UpdateState);
-				LoadoutScreen.UpdateData(true);
-			}
-		}
-	}
 }
 
 simulated function OnStripUpgrades()


### PR DESCRIPTION
Modifies : XComGameState_LWListenerManager

The 3 functions : AddArmoryStripWeaponsButton(), OnStripWeaponClicked(), ConfirmStripSingleWeaponUpgradesCallback() were removed because :
1.] They were never used.
2.] They led to confusion when investigating what changes needed to be made, in order to add 'strip weapon upgrade' functionality for controllers.

----------------------------------------

Modifies : X2EventListener_Headquarters

1.] Added a new function, CreateXComArmoryListeners(), which adds event listeners dealing with the Armory on the Avenger.

2.] Added an event listener function, OnWeaponUpgradeNavHelpUpdated(), which is triggered by the event 'UIArmory_WeaponUpgrade_NavHelpUpdated'; this is called whenever the navigation help system updates within UIArmory_WeaponUpgrade.

OnWeaponUpgradeNavHelpUpdated() adds a 'Strip All Weapon Upgrades' tip to the navigation help system for both mouse & keyboard users as well as controller users. Additionally, it adds a 'Strip Weapon Upgrades' tip to the navigation help system for controller users; this tip is not needed for mouse & keyboard users since they have their own list item.

----------------------------------------

Modifies : UIScreenListener_ArmoryWeaponUpgrade_LW

1.] Removed a variety of code which was either unused or no longer needed; this includes the UIButton StripWeaponUpgradesButton, the boolean AddedNavHelp, as well as the functions: RegisterForEvents(), OnWeaponUpgradeListChanged(), and UpdateNavHelp(). More precise reasoning is described in the files header.

2.] Added the function OnWeaponUpgradeCommand(), which intercepts UIArmory_WeaponUpgrade's input via the highlander function SubscribeToOnInputForScreen(). This was done for several reasons :

- It allows left stick click to be mapped to 'Strip all weapon upgrades'.
- It allows right stick click to be mapped to 'Strip [this] weapon upgrades'.
- It allows for SlotsList selection to be saved and restored when a controller is being used. This is important because it allows controllers users to, say, click on the 3rd weapon slot, select a weapon upgrade, and then have the 3rd weapon slot be selected upon return. Previously, the 1st weapon slot would "always" be selected upon returning from choosing a weapon upgrade.

3.] RefreshScreen() was modified so that the text for 'Strip Weapon Upgrades' did not disappear when the list item gained focus.

4.] A few other minor issues and cleanup, including spaces to tabs, were made.