### PR TITLE
Add config option for whether steadying weapon breaks concealment.

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -378,6 +378,8 @@ CARAPACE_PLATING_HP=5
 NANOFIBER_CRITDEF_BONUS=25
 BONUS_COILGUN_SHRED=1
 
+STEADY_WEAPON_BREAKS_CONCEALMENT=TRUE
+
 [LW_Overhaul.LWTemplateMods]
 +SchematicsToDisable=AssaultRifle_MG_Schematic
 +SchematicsToDisable=AssaultRifle_BM_Schematic

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GearAbilities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GearAbilities.uc
@@ -31,6 +31,8 @@ var config int NANOFIBER_CRITDEF_BONUS;
 
 var config int BONUS_COILGUN_SHRED;
 
+var config bool STEADY_WEAPON_BREAKS_CONCEALMENT;
+
 var localized string strWeight;
 var localized string AblativeHPLabel;
 
@@ -165,7 +167,14 @@ static function X2AbilityTemplate CreateStockSteadyWeaponAbility(name TemplateNa
 	Template.bShowActivation=true;
 	Template.AbilityConfirmSound = "Unreal2DSounds_OverWatch";
 	Template.bCrossClassEligible = false;
-	Template.ConcealmentRule = eConceal_Never;
+	if(!default.STEADY_WEAPON_BREAKS_CONCEALMENT)
+	{
+		Template.ConcealmentRule = eConceal_Always;
+	}
+	else
+	{
+		Template.ConcealmentRule = eConceal_Never;
+	}
 	//Template.DefaultKeyBinding = 539;
 	//Template.bNoConfirmationWithHotKey = true;
 	Template.AddShooterEffectExclusions();


### PR DESCRIPTION
Default behavior should remain unchanged, since the default is that steadying *does* break concealment. This just allows users to revert back to the original LW2 behavior if they so choose, without needing to rebuild from source.

(I have never done X2 modding before, I simply examined the way similar things were already done, and copied syntax/procedures from there. This may be a small PR but please take extra care when checking my work.)