### PR TITLE
Make the first SPARK easier to get

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1062,7 +1062,7 @@ AutopsyAdventPsiWitchIntelCost=0
 
 ; DLC - SLG
 ; Spark is created via special function that also creates the unlimited CV tier weapons and armors
-+TechTable=(TechTemplateName="MechanizedWarfare",			ProvingGround=true,		ResearchPointCost=1800,	ModPointsToCompleteOnly=false,	PrereqTech1="AutopsyDrone",					PrereqTech2="",		PrereqTech3="",		SupplyCost=100,	AlloyCost=10,	CrystalCost=5,	CoreCost=1, ReqItemTemplateName1="",	 ReqItemCost1=0, ReqItemTemplateName2="",	 ReqItemCost2=0,	ItemGranted="",	RequiredScienceScore=20, RequiredEngineeringScore=20)
++TechTable=(TechTemplateName="MechanizedWarfare",			ProvingGround=true,		ResearchPointCost=1200,	ModPointsToCompleteOnly=false,	PrereqTech1="",					PrereqTech2="",		PrereqTech3="",		SupplyCost=50,	AlloyCost=0,	CrystalCost=0,	CoreCost=1, ReqItemTemplateName1="CorpseAdventMEC",	 ReqItemCost1=0, ReqItemTemplateName2="",	 ReqItemCost2=0,	ItemGranted="",	RequiredScienceScore=20, RequiredEngineeringScore=20)
 ; Spark template has 'MechanizedWarfare' set as an AltRequirement to completing the narrative mission
 +TechTable=(TechTemplateName="BuildSpark",					ProvingGround=true,		ResearchPointCost=1500,	ModPointsToCompleteOnly=false,	PrereqTech1="",								PrereqTech2="",		PrereqTech3="",		SupplyCost=80,	AlloyCost=10,	CrystalCost=5,	CoreCost=1, ReqItemTemplateName1="",	 ReqItemCost1=0, ReqItemTemplateName2="",	 ReqItemCost2=0,	ItemGranted="",	RequiredScienceScore=20, RequiredEngineeringScore=20)
 


### PR DESCRIPTION
This removes ADVENT Robotics as a requirement for Mechanized Warfare, so you don't have to acquire 3 drone wrecks, and the cost of Mechanized Warfare it much reduced. However, it does now require a MEC wreck to start the project. This adds an effective FL gate to getting your first SPARK.