### PR TITLE
Exclude defined char templates from mission exp

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1649,8 +1649,7 @@ DEFAULT_MISSION_EXPERIENCE_WEIGHT=5.7f
 
 ; A list of soldier classes that will be excluded when mission XP is parceled
 ; out at the end of missions
-; INELIGIBLE_FOR_MISSION_XP="Spark"
-; CLASSES_INELIGIBLE_FOR_MISSION_XP="Spark
+; CLASSES_INELIGIBLE_FOR_MISSION_XP="Spark"
 
 [LW_Overhaul.X2EventListener_Reinforcements]
 LISTENER_PRIORITY=-1		; Use default listener priority (LWListenerManager)

--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1647,6 +1647,11 @@ DEFAULT_MISSION_EXPERIENCE_WEIGHT=5.7f
 +CLASS_MISSION_EXPERIENCE_WEIGHTS=(SoldierClass="PsiOperative", MissionExperienceWeight=5.8f)
 +CLASS_MISSION_EXPERIENCE_WEIGHTS=(SoldierClass="Spark", MissionExperienceWeight=5.7f)
 
+; A list of soldier classes that will be excluded when mission XP is parceled
+; out at the end of missions
+; INELIGIBLE_FOR_MISSION_XP="Spark"
+; CLASSES_INELIGIBLE_FOR_MISSION_XP="Spark
+
 [LW_Overhaul.X2EventListener_Reinforcements]
 LISTENER_PRIORITY=-1		; Use default listener priority (LWListenerManager)
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_XP.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_XP.uc
@@ -19,7 +19,7 @@ var config float TOP_RANK_XP_TRANSFER_FRACTION;
 
 var config int LISTENER_PRIORITY;
 
-var config array<string> INELIGIBLE_FOR_MISSION_EXP;
+var config array<name> INELIGIBLE_FOR_MISSION_EXP;
 
 static function array<X2DataTemplate> CreateTemplates()
 {

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_XP.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_XP.uc
@@ -19,7 +19,7 @@ var config float TOP_RANK_XP_TRANSFER_FRACTION;
 
 var config int LISTENER_PRIORITY;
 
-var config array<name> INELIGIBLE_FOR_MISSION_EXP;
+var config array<name> CLASSES_INELIGIBLE_FOR_MISSION_XP;
 
 static function array<X2DataTemplate> CreateTemplates()
 {
@@ -107,7 +107,7 @@ static function EventListenerReturn OnAddMissionEncountersToUnits(Object EventDa
 			continue;
 
 		UnitState = XComGameState_Unit(NewGameState.CreateStateObject(class'XComGameState_Unit', UnitRef.ObjectID));
-		if (UnitState.IsSoldier() && default.INELIGIBLE_FOR_MISSION_EXP.Find(UnitState.GetSoldierClassTemplateName()) == INDEX_NONE )
+		if (UnitState.IsSoldier() && default.CLASSES_INELIGIBLE_FOR_MISSION_XP.Find(UnitState.GetSoldierClassTemplateName()) == INDEX_NONE)
 		{
 			NewGameState.AddStateObject(UnitState);
 			UnitStates.AddItem(UnitState);

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_XP.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_XP.uc
@@ -19,6 +19,8 @@ var config float TOP_RANK_XP_TRANSFER_FRACTION;
 
 var config int LISTENER_PRIORITY;
 
+var config name INELIGIBLE_FOR_MISSION_EXP;
+
 static function array<X2DataTemplate> CreateTemplates()
 {
 	local array<X2DataTemplate> Templates;
@@ -105,7 +107,7 @@ static function EventListenerReturn OnAddMissionEncountersToUnits(Object EventDa
 			continue;
 
 		UnitState = XComGameState_Unit(NewGameState.CreateStateObject(class'XComGameState_Unit', UnitRef.ObjectID));
-		if (UnitState.IsSoldier())
+		if (UnitState.IsSoldier() && IsEligibleForExp(UnitState.GetMyTemplateName()))
 		{
 			NewGameState.AddStateObject(UnitState);
 			UnitStates.AddItem(UnitState);
@@ -382,3 +384,14 @@ static function EventListenerReturn OnRewardKillXp(Object EventData, Object Even
 
 	return ELR_NoInterrupt;
 }
+
+// Identifies character templates that don't take a share of mission exp
+static function bool IsEligibleForExp(name UnitName)
+{
+	if(UnitName != default.INELIGIBLE_FOR_MISSION_EXP){
+		return true;
+	}
+
+	return false;
+}
+

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_XP.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_XP.uc
@@ -19,7 +19,7 @@ var config float TOP_RANK_XP_TRANSFER_FRACTION;
 
 var config int LISTENER_PRIORITY;
 
-var config name INELIGIBLE_FOR_MISSION_EXP;
+var config array<string> INELIGIBLE_FOR_MISSION_EXP;
 
 static function array<X2DataTemplate> CreateTemplates()
 {

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_XP.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_XP.uc
@@ -107,7 +107,7 @@ static function EventListenerReturn OnAddMissionEncountersToUnits(Object EventDa
 			continue;
 
 		UnitState = XComGameState_Unit(NewGameState.CreateStateObject(class'XComGameState_Unit', UnitRef.ObjectID));
-		if (UnitState.IsSoldier() && IsEligibleForExp(UnitState.GetMyTemplateName()))
+		if (UnitState.IsSoldier() && default.INELIGIBLE_FOR_MISSION_EXP.Find(UnitState.GetSoldierClassTemplateName()) == INDEX_NONE )
 		{
 			NewGameState.AddStateObject(UnitState);
 			UnitStates.AddItem(UnitState);
@@ -384,14 +384,3 @@ static function EventListenerReturn OnRewardKillXp(Object EventData, Object Even
 
 	return ELR_NoInterrupt;
 }
-
-// Identifies character templates that don't take a share of mission exp
-static function bool IsEligibleForExp(name UnitName)
-{
-	if(UnitName != default.INELIGIBLE_FOR_MISSION_EXP){
-		return true;
-	}
-
-	return false;
-}
-


### PR DESCRIPTION
Add a check to exclude a configurable list of character templates from taking a share of the end of mission exp.