### PR TITLE
Naja movement AI update

### DIFF
--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -378,8 +378,8 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 
 ; ***                                           MOVEMENT PROFILES                                                   ***
 
-; snipermove that prioritize 22-27 distance
-+m_arrMoveWeightProfile=(Profile=SniperMove, fCoverWeight=0.1f, fDistanceWeight=2.0f, fFlankingWeight=0.0f, fEnemyVisWeight=1.0f, fEnemyVisWeightPeak1=1.0, fAllyVisWeight=0.1f, fCloseModifier=0.2f, fFarModifier=1.0f)
+; defensive SniperMove profile, seeks 15-18 tile distance with safe visibility if no target
++m_arrMoveWeightProfile=(Profile=SniperMove, fCoverWeight=0.0f, fDistanceWeight=1.0f, fFlankingWeight=0.0f, fEnemyVisWeight=0.0f, fEnemyVisWeightPeak1=0.5, fAllyVisWeight=0.4f, fCloseModifier=0.2f, fFarModifier=2.4f)
 
 ; change fallback to inverse weight distance to prefer positions that are further away
 -m_arrMoveWeightProfile=(Profile=Fallback, fCoverWeight=3.0f, fDistanceWeight=0.0f, fFlankingWeight=0.0f, fEnemyVisWeight=0.0f, fEnemyVisWeightPeak1=2.0, fAllyVisWeight=1.0f, fCloseModifier=0.9f, fFarModifier=1.1f)
@@ -887,15 +887,15 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 +Behaviors=(BehaviorName=FindDestination-SniperMove, NodeType=Action)
 +Behaviors=(BehaviorName=FindDestinationWithLoS-SniperMove, NodeType=Action)
 +Behaviors=(BehaviorName=FindRestrictedDestination-SniperMove, NodeType=Action)
-
+ 
 +Behaviors=(BehaviorName=SniperMove, NodeType=Sequence, Child[0]=SafeToMove, Child[1]=SniperMoveUnsafeSelector)
-+Behaviors=(BehaviorName=SniperMoveUnsafeSelector, NodeType=Selector, Child[0]=SniperMoveUnsafeDashIfNotLastAP, Child[1]=SniperMoveUnsafe)
-+Behaviors=(BehaviorName=SniperMoveUnsafeDashIfNotLastAP, NodeType=Sequence, Child[0]=NotLastActionPoint, Child[1]=SniperMoveUnsafeDash)
-+Behaviors=(BehaviorName=SniperMoveUnsafeDash, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=RestrictToUnflanked, Child[3]=OverrideIdealRange-33, Child[4]=UseDashMovement, Child[5]=FindBestSniperDestination, Child[6]=SelectAbility-StandardMove)
-+Behaviors=(BehaviorName=SniperMoveUnsafe, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=RestrictToUnflanked, Child[3]=OverrideIdealRange-33, Child[4]=FindBestSniperDestination, Child[5]=SelectAbility-StandardMove)
++Behaviors=(BehaviorName=SniperMoveUnsafeSelector, NodeType=Selector, Child[0]=SniperMoveUnsafeDashIfFlanked, Child[1]=SniperMoveUnsafe)
++Behaviors=(BehaviorName=SniperMoveUnsafeDashIfFlanked, NodeType=Sequence, Child[0]=NotLastActionPoint, Child[1]=CheckIfNeedToMove, Child[2]=SniperMoveUnsafeDash)
++Behaviors=(BehaviorName=SniperMoveUnsafeDash, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=RestrictToUnflanked, Child[3]=OverrideIdealRange-21, Child[4]=UseDashMovement, Child[5]=FindBestSniperDestination, Child[6]=SelectAbility-StandardMove)
++Behaviors=(BehaviorName=SniperMoveUnsafe, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=RestrictToUnflanked, Child[3]=OverrideIdealRange-21, Child[4]=FindBestSniperDestination, Child[5]=SelectAbility-StandardMove)
 +Behaviors=(BehaviorName=FindBestSniperDestination, NodeType=Selector, Child[0]=FindRestrictedDestination-SniperMove, Child[1]=FindRestrictedDestination-MWP_Defensive, Child[2]=FindDestination-MWP_Defensive)
-+Behaviors=(BehaviorName=RestrictedSniperMoveOnly, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=RestrictToUnflanked, Child[3]=OverrideIdealRange-33, Child[4]=FindRestrictedDestination-SniperMove, Child[5]=SelectAbility-StandardMove)
-+Behaviors=(BehaviorName=OverrideIdealRange-33, NodeType=Action, Param[0]=33)
++Behaviors=(BehaviorName=RestrictedSniperMoveOnly, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=RestrictToUnflanked, Child[3]=OverrideIdealRange-21, Child[4]=FindRestrictedDestination-SniperMove, Child[5]=SelectAbility-StandardMove)
++Behaviors=(BehaviorName=OverrideIdealRange-21, NodeType=Action, Param[0]=21)
 
 +Behaviors=(BehaviorName=SniperMoveWithLoS, NodeType=Sequence, Child[0]=SafeToMove, Child[1]=SniperMoveWithLoSUnsafe)
 +Behaviors=(BehaviorName=SniperMoveWithLoSUnsafe, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=FindDestinationWithLoS-SniperMove, Child[3]=SelectAbility-StandardMove)

--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -81,6 +81,9 @@
 +BehaviorRemovals="GenericScamperRoot"
 +NewBehaviors=(BehaviorName=GenericScamperRoot, NodeType=Selector,       Child[0]=CounterBeaglerushManeuver,       Child[1]=MoveStandardWithLoSUnsafe,       Child[2]=MoveStandardUnsafe, Child[3]=MoveStandardWithLoSUnsafeIgnoreHazards, Child[4]=MoveStandardUnsafeIgnoreHazards, Child[5]=SkipMove)
 
+; "ScamperRoot_Naja" - naja scamper uses snipermove
++NewBehaviors=(BehaviorName=ScamperRoot_Naja, NodeType=Selector, Child[0]=CounterBeaglerushManeuver, Child[1]=SniperMove, Child[2]=MoveStandardWithLoSUnsafe, Child[3]=MoveStandardUnsafe, Child[4]=MoveStandardWithLoSUnsafeIgnoreHazards, Child[5]=MoveStandardUnsafeIgnoreHazards, Child[6]=SkipMove)
+
 ; "AvoidBoundAndPanickedTargets" - Add a uniform score bonus to all non-last-resort units (+25)
 +BehaviorRemovals="AvoidBoundAndPanickedTargets"
 +NewBehaviors=(BehaviorName=AvoidBoundAndPanickedTargets, NodeType=Selector, Child[0]=ScoreIfTargetBoundOrPanicked, Child[1]=AddToTargetScore_25)
@@ -373,9 +376,10 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 +AoEProfiles=( Profile=FlameThrowerMimicBeaconAdjacent, Ability=AdvPurifierFlamethrower, bIgnoreSelfDamage=True, bFailOnObjectiveFire=true, bFailOnFriendlyFire=false, MinTargets=1, bTargetEnemy=0, bAreaSearchSpace=1, bRequireLoS=1, bCountAdjacentAsHits=1, bRequirePotentialTarget=1, bTestTargetEffectsApply=true, bIgnoreRepeatAttackList=1)
 
 
-+m_arrMoveWeightProfile=(Profile=SniperMove, fCoverWeight=2.0f, fDistanceWeight=1.0f, fFlankingWeight=0.25f, fEnemyVisWeight=0.0f, fEnemyVisWeightPeak1=2.0, fAllyVisWeight=0.5f, fCloseModifier=0.5f, fFarModifier=1.1f)
-
 ; ***                                           MOVEMENT PROFILES                                                   ***
+
+; snipermove that prioritize 22-27 distance
++m_arrMoveWeightProfile=(Profile=SniperMove, fCoverWeight=0.1f, fDistanceWeight=2.0f, fFlankingWeight=0.0f, fEnemyVisWeight=1.0f, fEnemyVisWeightPeak1=1.0, fAllyVisWeight=0.1f, fCloseModifier=0.2f, fFarModifier=1.0f)
 
 ; change fallback to inverse weight distance to prefer positions that are further away
 -m_arrMoveWeightProfile=(Profile=Fallback, fCoverWeight=3.0f, fDistanceWeight=0.0f, fFlankingWeight=0.0f, fEnemyVisWeight=0.0f, fEnemyVisWeightPeak1=2.0, fAllyVisWeight=1.0f, fCloseModifier=0.9f, fFarModifier=1.1f)
@@ -820,34 +824,41 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 
 +Behaviors=(BehaviorName=LWNajaRedFirstAction, NodeType=Sequence, Child[0]=NotLastActionPoint, Child[1]=LWNajaRedFirstActionSelector)
 +Behaviors=(BehaviorName=LWNajaRedFirstActionSelector, NodeType=Selector, \\
-	Child[0]=DoIfFlankedMove, \\
+	Child[0]=DoIfFlankedSniperMove, \\
 	Child[1]=TryHighPriorityShot, \\
-	Child[2]=NeedsReload, \\
-	Child[3]=RandMoveIfEnemyClose, \\
-	Child[4]=TrySniperShootOrReload, \\
-	Child[5]=MoveIfAnyEnemyWithin12Tiles, \\
-	Child[6]=TrySniperShootOrReloadOrOverwatch, \\
-	Child[7]=TryMoveThenPoisonSpit, \\
-	Child[8]=SniperMove, \\
-	Child[9]=HuntEnemyWithCover)
+	Child[2]=TrySniperShootOrReload, \\
+	Child[3]=MoveIfAnyEnemyWithin12Tiles, \\
+	Child[4]=TrySniperShootOrReloadOrOverwatch, \\
+	Child[5]=TryMoveThenPoisonSpit, \\
+	Child[6]=SniperMoveIfEnemyVisible, \\
+	Child[7]=HuntEnemyWithCover)
 
 +Behaviors=(BehaviorName=LWNajaRedLastAction, NodeType=Sequence, Child[0]=IsLastActionPoint, Child[1]=LWNajaRedLastActionSelector)
 +Behaviors=(BehaviorName=LWNajaRedLastActionSelector, NodeType=Selector, \\
 	Child[0]=TryHighPriorityShot, \\
-	Child[1]=DoIfFlankedMove, \\
+	Child[1]=DoIfFlankedSniperMove, \\
 	Child[2]=MoveIfAnyEnemyWithin12Tiles, \\
 	Child[3]=TrySniperShootOrReloadOrOverwatch, \\
 	Child[4]=TryPoisonSpitSingle, \\
-	Child[5]=HuntEnemyWithCover, \\
-	Child[6]=SniperMove)
+	Child[5]=RestrictedSniperMoveOnly, \\
+	Child[6]=HoldGroundIfEnemyVisible, \\
+	Child[7]=SniperMove, \\
+	Child[8]=HuntEnemyWithCover)
+
++Behaviors=(BehaviorName=DoIfFlankedSniperMove, NodeType=Sequence, Child[0]=CheckIfNeedToMove, Child[1]=SniperMove)
++Behaviors=(BehaviorName=HoldGroundIfEnemyVisible, NodeType=Sequence, Child[0]=AnyLivingEnemyVisible, Child[1]=SkipMove)
++Behaviors=(BehaviorName=SniperMoveIfEnemyVisible, NodeType=Sequence, Child[0]=AnyLivingEnemyVisible, Child[1]=SniperMove)
 
 +Behaviors=(BehaviorName=RandMoveIfEnemyClose, NodeType=RandFilter, Child[0]=MoveIfAnyEnemyWithin12Tiles, Param[0]=60)
 +Behaviors=(BehaviorName=MoveIfAnyEnemyWithin12Tiles, NodeType=Sequence, Child[0]=AnyEnemyWithin12Tiles, Child[1]=SniperMove)
-+Behaviors=(BehaviorName=AnyEnemyWithin12Tiles, NodeType=Sequence, Child[0]=SetVisiblePotentialTargetStack, Child[1]=SearchAnyEnemyWithin12Tiles)
-+Behaviors=(BehaviorName=SearchAnyEnemyWithin12Tiles, NodeType=Inverter, Child[0]=SearchNoEnemyWithin12Tiles)
-+Behaviors=(BehaviorName=SearchNoEnemyWithin12Tiles, NodeType=RepeatUntilFail, Child[0]=EvaluateEnemyWithin12Tiles)
-+Behaviors=(BehaviorName=EvaluateEnemyWithin12Tiles, NodeType=Sequence, Child[0]=SetNextTarget, Child[1]=TargetDistanceGreaterThan12Tiles)
-+Behaviors=(BehaviorName=TargetDistanceGreaterThan12Tiles, NodeType=StatCondition, Param[0]=PotentialTargetDistance, Param[1]=">", Param[2]=18); 18m = 12 tiles
++Behaviors=(BehaviorName=AnyEnemyWithin12Tiles, NodeType=Sequence, Child[0]=SetVisiblePotentialTargetStack, Child[1]=SearchAnyEnemyWithin12Tiles, Child[2]=HasValidTarget-Potential)
++Behaviors=(BehaviorName=SearchAnyEnemyWithin12Tiles, NodeType=RepeatUntilFail, Child[0]=IterateNextTargetForWithin12Tiles)
++Behaviors=(BehaviorName=IterateNextTargetForWithin12Tiles, NodeType=Sequence, Child[0]=SetNextTarget, Child[1]=SSEvaluateForWithin12Tiles, Child[2]=UpdateBestTarget)
++Behaviors=(BehaviorName=SSEvaluateForWithin12Tiles, NodeType=Successor, Child[0]=EvaluateForWithin12Tiles)
++Behaviors=(BehaviorName=EvaluateForWithin12Tiles, NodeType=Sequence, Child[0]=TargetIsNotCivilian, Child[1]=TargetNotTeamResistance, Child[2]=TargetIsEnemy, Child[3]=TargetIsNotEnemyVIP, Child[4]=TargetNotBoundOrPanicked, Child[5]=TargetIsAttackable, Child[6]=AddToTargetScore_-100, Child[7]=SSScoreTargetIfWithin12Tiles)
++Behaviors=(BehaviorName=SSScoreTargetIfWithin12Tiles, NodeType=Successor, Child[0]=ScoreTargetIfWithin12Tiles)
++Behaviors=(BehaviorName=ScoreTargetIfWithin12Tiles, NodeType=Sequence, Child[0]=TargetDistanceLesserThan12Tiles, Child[1]=AddToTargetScore_300)
++Behaviors=(BehaviorName=TargetDistanceLesserThan12Tiles, NodeType=StatCondition, Param[0]=PotentialTargetDistance, Param[1]="<", Param[2]=18); 18m = 12 tiles
 
 +Behaviors=(BehaviorName=TrySniperShootOrReload, NodeType=Selector, Child[0]=SniperShootIfAvailable, Child[1]=NeedsReload)
 +Behaviors=(BehaviorName=SniperShootIfAvailable, NodeType=Sequence, Child[0]=IsAbilityAvailable-SniperStandardFire, Child[1]=SelectTargetForSniperShot, Child[2]=SelectAbility-SniperStandardFire)
@@ -877,9 +888,15 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 +Behaviors=(BehaviorName=FindDestinationWithLoS-SniperMove, NodeType=Action)
 +Behaviors=(BehaviorName=FindRestrictedDestination-SniperMove, NodeType=Action)
 
-+Behaviors=(BehaviorName=SniperMove, NodeType=Sequence, Child[0]=SafeToMove, Child[1]=SniperMoveUnsafe)
-+Behaviors=(BehaviorName=SniperMoveUnsafe, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=FindBestSniperDestination, Child[3]=SelectAbility-StandardMove)
-+Behaviors=(BehaviorName=FindBestSniperDestination, NodeType=Selector, Child[0]=FindDestinationWithLoS-MWP_Defensive, Child[1]=FindDestinationWithLoS-SniperMove, Child[2]=FindDestination-MWP_Fallback, Child[3]=FindDestination-SniperMove)
++Behaviors=(BehaviorName=SniperMove, NodeType=Sequence, Child[0]=SafeToMove, Child[1]=SniperMoveUnsafeSelector)
++Behaviors=(BehaviorName=SniperMoveUnsafeSelector, NodeType=Selector, Child[0]=SniperMoveUnsafeDashIfNotLastAP, Child[1]=SniperMoveUnsafe)
++Behaviors=(BehaviorName=SniperMoveUnsafeDashIfNotLastAP, NodeType=Sequence, Child[0]=NotLastActionPoint, Child[1]=SniperMoveUnsafeDash)
++Behaviors=(BehaviorName=SniperMoveUnsafeDash, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=RestrictToUnflanked, Child[3]=OverrideIdealRange-33, Child[4]=UseDashMovement, Child[5]=FindBestSniperDestination, Child[6]=SelectAbility-StandardMove)
++Behaviors=(BehaviorName=SniperMoveUnsafe, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=RestrictToUnflanked, Child[3]=OverrideIdealRange-33, Child[4]=FindBestSniperDestination, Child[5]=SelectAbility-StandardMove)
++Behaviors=(BehaviorName=FindBestSniperDestination, NodeType=Selector, Child[0]=FindRestrictedDestination-SniperMove, Child[1]=FindRestrictedDestination-MWP_Defensive, Child[2]=FindDestination-MWP_Defensive)
++Behaviors=(BehaviorName=RestrictedSniperMoveOnly, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=RestrictToUnflanked, Child[3]=OverrideIdealRange-33, Child[4]=FindRestrictedDestination-SniperMove, Child[5]=SelectAbility-StandardMove)
++Behaviors=(BehaviorName=OverrideIdealRange-33, NodeType=Action, Param[0]=33)
+
 +Behaviors=(BehaviorName=SniperMoveWithLoS, NodeType=Sequence, Child[0]=SafeToMove, Child[1]=SniperMoveWithLoSUnsafe)
 +Behaviors=(BehaviorName=SniperMoveWithLoSUnsafe, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=FindDestinationWithLoS-SniperMove, Child[3]=SelectAbility-StandardMove)
 +Behaviors=(BehaviorName=NCSniperMoveWithLoS, NodeType=Sequence, Child[0]=SafeToMove, Child[1]=NCSniperMoveWithLoSUnsafe)

--- a/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Character_AlienPack.uc
+++ b/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Character_AlienPack.uc
@@ -405,6 +405,7 @@ static function X2CharacterTemplate CreateTemplate_Naja(name TemplateName)
 
 	CharTemplate.AddTemplateAvailablility(CharTemplate.BITFIELD_GAMEAREA_Multiplayer); // Allow in MP!
 	CharTemplate.MPPointValue = CharTemplate.XpKillscore * 10;
+	CharTemplate.strScamperBT = "ScamperRoot_Naja";
 
 	CharTemplate.SightedNarrativeMoments.AddItem(XComNarrativeMoment'X2NarrativeMoments.TACTICAL.AlienSitings.T_Tygan_AlienSightings_Viper');
 	CharTemplate.SightedNarrativeMoments.AddItem(XComNarrativeMoment'X2NarrativeMoments.TACTICAL.AlienSitings.T_Central_AlienSightings_Viper');


### PR DESCRIPTION
* Original AnyEnemyWithin12Tiles actually did not trigger even when there was nearby enemy, so changed it to more reliable scoring system.
* SniperMove profile modification: seeks minimum 14 tile distance with enemy visibility, low fCoverWeight so AI is willing to move to half-cover if it's only cover available far away.
* SniperMove behaviour modification: uses RestrictedDestination to guarantee cover, allows dash movement for better sniper spot search and disengagement.

* ActionSelector Behaviours reworked to call SniperMove for every movement except HuntEnemyWithCover.
* Removed RandMoveIfEnemyClose so Naja does not randomly lose opportunity to make normal sniper shots; the behaviour did not work in original anyways as MoveIfAnyEnemyWithin12Tiles had not been functional. This also made NeedsReload redundant as TrySniperShootOrReload checks it.
* Child[6] and Child[7] of LWNajaRedFirstActionSelector allows Naja to track down XCOM that has moved out of sight.
* HoldGroundIfEnemyVisible prevents other backup movement profiles from SniperMove unnecessarily causing Naja to move away from ideal sniper spot.

* ScamperRoot_Naja gives Naja scamper high preference towards 14~18 tiles distance