### PR TITLE
Allow M3 Gunner to Traverse Fire (#1152)

### DIFF
--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -769,7 +769,7 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 
 +Behaviors=(BehaviorName="LWAdventGunnerRoot", NodeType=Selector, Child[0]=TryJob, Child[1]=GenericGreenMovement, Child[2]=LWAdventGunnerRedAlert, Child[3]=GenericAlertHandler)
 +Behaviors=(BehaviorName=LWAdventGunnerRedAlert, NodeType=Sequence, Child[0]=IsRedAlert, Child[1]=LWAdventGunner_RedAbilitySelector)
-+Behaviors=(BehaviorName=LWAdventGunner_RedAbilitySelector, NodeType=Selector, Child[0]=MimicBeaconBehavior, Child[1]=LWAdventGunnerRedFirstAction, Child[2]=LWAdventGunnerRedLastAction, Child[3]=LWAdventGunnerRedPostTraverseFire, Child[4]=AdventRedFallbackAction)
++Behaviors=(BehaviorName=LWAdventGunner_RedAbilitySelector, NodeType=Selector, Child[0]=MimicBeaconBehavior, Child[1]=LWAdventGunnerRedFirstAction, Child[2]=LWAdventGunnerRedLastAction, Child[3]=LWAdventGunnerRedPostTraverseFireAction, Child[4]=AdventRedFallbackAction)
 
 +Behaviors=(BehaviorName=LWAdventGunnerRedFirstAction, NodeType=Sequence, Child[0]=NotLastActionPoint, Child[1]=LWAdventGunnerRedFirstActionSelector)
 +Behaviors=(BehaviorName=LWAdventGunnerRedFirstActionSelector, NodeType=Selector, \\
@@ -781,7 +781,7 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 	Child[5]=TryShootOrReloadOrOverwatch, \\
 	Child[6]=HuntEnemyWithCover)
 
-+Behaviors=(BehaviorName=LWAdventGunnerRedPostTraverseFire, NodeType=Sequence, Child[0]=WasLastAbility-StandardShot, Child[1]=LWAdventGunnerRedLastActionSelector)
++Behaviors=(BehaviorName=LWAdventGunnerRedPostTraverseFireAction, NodeType=Sequence, Child[0]=WasLastAbility-StandardShot, Child[1]=LWAdventGunnerRedLastActionSelector)
 +Behaviors=(BehaviorName=LWAdventGunnerRedLastAction, NodeType=Sequence, Child[0]=IsLastActionPoint, Child[1]=LWAdventGunnerRedLastActionSelector)
 ; Rolls twice for TryAreaSuppression, since "per-ally" check is fixed at 10%
 +Behaviors=(BehaviorName=LWAdventGunnerRedLastActionSelector, NodeType=Selector, \\

--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -769,17 +769,19 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 
 +Behaviors=(BehaviorName="LWAdventGunnerRoot", NodeType=Selector, Child[0]=TryJob, Child[1]=GenericGreenMovement, Child[2]=LWAdventGunnerRedAlert, Child[3]=GenericAlertHandler)
 +Behaviors=(BehaviorName=LWAdventGunnerRedAlert, NodeType=Sequence, Child[0]=IsRedAlert, Child[1]=LWAdventGunner_RedAbilitySelector)
-+Behaviors=(BehaviorName=LWAdventGunner_RedAbilitySelector, NodeType=Selector, Child[0]=MimicBeaconBehavior, Child[1]=LWAdventGunnerRedFirstAction, Child[2]=LWAdventGunnerRedLastAction, Child[3]=AdventRedFallbackAction)
++Behaviors=(BehaviorName=LWAdventGunner_RedAbilitySelector, NodeType=Selector, Child[0]=MimicBeaconBehavior, Child[1]=LWAdventGunnerRedFirstAction, Child[2]=LWAdventGunnerRedLastAction, Child[3]=LWAdventGunnerRedPostTraverseFire, Child[4]=AdventRedFallbackAction)
 
 +Behaviors=(BehaviorName=LWAdventGunnerRedFirstAction, NodeType=Sequence, Child[0]=NotLastActionPoint, Child[1]=LWAdventGunnerRedFirstActionSelector)
 +Behaviors=(BehaviorName=LWAdventGunnerRedFirstActionSelector, NodeType=Selector, \\
 	Child[0]=DoIfFlankedMove, \\
 	Child[1]=NeedsReload, \\
-	Child[2]=TryMoveOrTraverseFire, \\
-	Child[3]=SelectMove_JobOrDefensive, \\
-	Child[4]=TryShootOrReloadOrOverwatch, \\
-	Child[5]=HuntEnemyWithCover)
+	Child[2]=TryHighPriorityShot, \\
+	Child[3]=TryMoveOrTraverseFire, \\
+	Child[4]=SelectMove_JobOrDefensive, \\
+	Child[5]=TryShootOrReloadOrOverwatch, \\
+	Child[6]=HuntEnemyWithCover)
 
++Behaviors=(BehaviorName=LWAdventGunnerRedPostTraverseFire, NodeType=Sequence, Child[0]=WasLastAbility-StandardShot, Child[1]=LWAdventGunnerRedLastActionSelector)
 +Behaviors=(BehaviorName=LWAdventGunnerRedLastAction, NodeType=Sequence, Child[0]=IsLastActionPoint, Child[1]=LWAdventGunnerRedLastActionSelector)
 ; Rolls twice for TryAreaSuppression, since "per-ally" check is fixed at 10%
 +Behaviors=(BehaviorName=LWAdventGunnerRedLastActionSelector, NodeType=Selector, \\
@@ -791,12 +793,12 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 	Child[5]=SelectMove_JobOrDefensive)
 
 +Behaviors=(BehaviorName=TryMoveOrTraverseFire, NodeType=RandSelector, Child[0]=SelectMove_JobOrDefensive, Param[0]=33, Child[1]=TryTraverseFire, Param[1]=67)
-+Behaviors=(BehaviorName=TryTraverseFire, NodeType=Sequence, Child[0]=IsAbilityAvailable-TraverseFire, Child[1]=TryShootOrReload)
++Behaviors=(BehaviorName=TryTraverseFire, NodeType=Sequence, Child[0]=TemplateNameIs-AdvGunnerM3, Child[1]=TryShootOrReload)
 
 +Behaviors=(BehaviorName=TryAreaSuppression, NodeType=Sequence, Child[0]=IsAbilityAvailable-AreaSuppression, Child[1]=CheckShouldSuppressVar, Child[2]=SelectTargetForAreaSuppressionByAim, Child[3]=SelectAbility-AreaSuppression)
 +Behaviors=(BehaviorName=SelectTargetForAreaSuppressionByAim, NodeType=Sequence, Child[0]=SetTargetStack-AreaSuppression, Child[1]=SelectBestSuppressionTargetByAim, Child[2]=HasValidTarget-AreaSuppression)
 
-+Behaviors=(BehaviorName=IsAbilityAvailable-TraverseFire, NodeType=Condition)
++Behaviors=(BehaviorName=TemplateNameIs-AdvGunnerM3, NodeType=Condition)
 +Behaviors=(BehaviorName=IsAbilityAvailable-AreaSuppression, NodeType=Condition)
 +Behaviors=(BehaviorName=IsAbilityReady-AreaSuppression, NodeType=Condition)
 +Behaviors=(BehaviorName=SelectAbility-AreaSuppression, NodeType=Action)

--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -793,12 +793,12 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 	Child[5]=SelectMove_JobOrDefensive)
 
 +Behaviors=(BehaviorName=TryMoveOrTraverseFire, NodeType=RandSelector, Child[0]=SelectMove_JobOrDefensive, Param[0]=33, Child[1]=TryTraverseFire, Param[1]=67)
-+Behaviors=(BehaviorName=TryTraverseFire, NodeType=Sequence, Child[0]=TemplateNameIs-AdvGunnerM3, Child[1]=TryShootOrReload)
++Behaviors=(BehaviorName=TryTraverseFire, NodeType=Sequence, Child[0]=IsAbilityAvailable-TraverseFire, Child[1]=TryShootOrReload)
 
 +Behaviors=(BehaviorName=TryAreaSuppression, NodeType=Sequence, Child[0]=IsAbilityAvailable-AreaSuppression, Child[1]=CheckShouldSuppressVar, Child[2]=SelectTargetForAreaSuppressionByAim, Child[3]=SelectAbility-AreaSuppression)
 +Behaviors=(BehaviorName=SelectTargetForAreaSuppressionByAim, NodeType=Sequence, Child[0]=SetTargetStack-AreaSuppression, Child[1]=SelectBestSuppressionTargetByAim, Child[2]=HasValidTarget-AreaSuppression)
 
-+Behaviors=(BehaviorName=TemplateNameIs-AdvGunnerM3, NodeType=Condition)
++Behaviors=(BehaviorName=IsAbilityAvailable-TraverseFire, NodeType=Condition)
 +Behaviors=(BehaviorName=IsAbilityAvailable-AreaSuppression, NodeType=Condition)
 +Behaviors=(BehaviorName=IsAbilityReady-AreaSuppression, NodeType=Condition)
 +Behaviors=(BehaviorName=SelectAbility-AreaSuppression, NodeType=Action)


### PR DESCRIPTION
Added LWAdventGunnerRedPostTraverseFire because LWAdventGunnerRedLastAction did not recognize action refunded by Traverse Fire and returned false.
Added TryHighPriorityShot on LWAdventGunnerRedFirstActionSelector so AI can guarantee shoot-shoot actions against vulnerable targets.

I have confirmed through testing that this allows M3 Gunner to make shoot-shoot turns against vulnerable targets. They still make move-shoot or shoot-move/overwatch etc. turns in absence of good targets.