### PR TITLE
Fix Region/Haven controller selectability and associated 3D mesh.

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_Region_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_Region_LW.uc
@@ -24,14 +24,9 @@ simulated function bool CanMakeContact()
 	return (class'UIUtilities_Strategy'.static.GetXComHQ().IsContactResearched() && (GetRegion().ResistanceLevel == eResLevel_Unlocked));
 }
 
-simulated function bool CanMakeRadioRelay()
+simulated function bool IsContacted()
 {
-	return (class'UIUtilities_Strategy'.static.GetXComHQ().IsOutpostResearched() && (GetRegion().ResistanceLevel == eResLevel_Contact));
-}
-
-simulated function bool IsRadioRelayInstalled()
-{
-	return (GetRegion().ResistanceLevel == eResLevel_Outpost);
+	return ((GetRegion().ResistanceLevel == eResLevel_Contact) || (GetRegion().ResistanceLevel == eResLevel_Outpost));
 }
 
 /* Issue # 815 : KDM : When using a controller, UIStrategyMap continuously calls UpdateSelection() --> SelectMapItemNearestLocation().
@@ -49,14 +44,13 @@ simulated function bool IsSelectable()
 {
 	// KDM : The region is selectable if any of these conditions are true :
 	// 1.] It is contactable, regardless of whether contacting has commenced.
-	// 2.] It has been contacted, and a radio relay can be built, regardless of whether this building process has actually commenced.
-	// 3.] It has a radio relay installed.
+	// 2.] It has been contacted, regardless of its radio relay status.
 	//
 	// The region is not selectable if any of these conditions are true : 
 	// 1.] It can't be contacted due to insufficient research level. 
 	// 2.] It is too far away.
 	
-	return (CanMakeContact() || CanMakeRadioRelay() || IsRadioRelayInstalled());
+	return (CanMakeContact() || IsContacted());
 }
 
 simulated function UIStrategyMapItem InitMapItem(out XComGameState_GeoscapeEntity Entity)

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_WorldRegion.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_WorldRegion.uc
@@ -1,0 +1,89 @@
+//---------------------------------------------------------------------------------------
+//	FILE:		X2EventListener_WorldRegion.uc
+//	AUTHOR:		KDM
+//	PURPOSE:	When using a controller, and on the strategy map, selectable regions/havens are associated with a 3D mesh.
+//				Unfortunately, Long War 2 introduced states which were not taken into account in the
+//				base game; consequently, selectable regions/havens could be associated with no 3D mesh.
+//				These issues are rectified here.
+//---------------------------------------------------------------------------------------
+
+class X2EventListener_WorldRegion extends X2EventListener config(LW_Overhaul);
+
+static function array<X2DataTemplate> CreateTemplates()
+{
+	local array<X2DataTemplate> Templates;
+
+	Templates.AddItem(CreateWorldRegionListeners());
+	
+	return Templates;
+}
+
+static function CHEventListenerTemplate CreateWorldRegionListeners()
+{
+	local CHEventListenerTemplate Template;
+
+	`CREATE_X2TEMPLATE(class'CHEventListenerTemplate', Template, 'WorldRegionListeners');
+	Template.AddCHEvent('WorldRegionGetStaticMesh', OnWorldRegionGetStaticMesh, ELD_Immediate);
+	Template.AddCHEvent('WorldRegionGetMeshScale', OnWorldRegionGetMeshScale, ELD_Immediate);
+	
+	Template.RegisterInStrategy = true;
+
+	return Template;
+}
+
+static function bool CanMakeContact(XComGameState_WorldRegion WorldRegion)
+{
+	return (class'UIUtilities_Strategy'.static.GetXComHQ().IsContactResearched() && (WorldRegion.ResistanceLevel == eResLevel_Unlocked));
+}
+
+static function bool IsContacted(XComGameState_WorldRegion WorldRegion)
+{
+	return ((WorldRegion.ResistanceLevel == eResLevel_Contact) || (WorldRegion.ResistanceLevel == eResLevel_Outpost));
+}
+
+static function EventListenerReturn OnWorldRegionGetStaticMesh(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
+{
+	local XComGameState_WorldRegion WorldRegion;
+	local XComLWTuple Tuple;
+	
+	Tuple = XComLWTuple(EventData);
+	WorldRegion = XComGameState_WorldRegion(EventSource);
+
+	if (Tuple != none && WorldRegion != none)
+	{
+		// KDM : When using a controller :
+		// 1.]	A radio relay mesh is displayed when a region is contactable, regardless of its scanning status. 
+		//		It is also displayed when a haven has been contacted, regardless of its radio relay status.
+		// 2.]	No mesh will be shown if a region can't be contacted due to tech level or location on the map.
+		//
+		// Note : Originally I had contactable regions display as signal tower meshes (StaticMesh'XB0_XCOM2_OverworldIcons.SingnalInterception').
+		// However, this led to visual problems when switching between the 2, since signal tower meshes are animated while 
+		// radio relay meshes are not. 
+		if (CanMakeContact(WorldRegion) || IsContacted(WorldRegion))
+		{
+			Tuple.Data[0].o = StaticMesh'UI_3D.Overwold_Final.RadioTower';
+		}
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnWorldRegionGetMeshScale(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
+{
+	local XComGameState_WorldRegion WorldRegion;
+	local XComLWTuple Tuple;
+	
+	Tuple = XComLWTuple(EventData);
+	WorldRegion = XComGameState_WorldRegion(EventSource);
+
+	if (Tuple != none && WorldRegion != none)
+	{
+		// KDM : When using a controller, make sure the static mesh associated with a region/haven is the correct size.
+		if (CanMakeContact(WorldRegion) || IsContacted(WorldRegion))
+		{
+			Tuple.Data[0].v = vect(1.0, 1.0, 1.0);
+		}
+	}
+
+	return ELR_NoInterrupt;
+}


### PR DESCRIPTION
Added X2EventListener_WorldRegion :

This class listens for WorldRegionGetStaticMesh and WorldRegionGetMeshScale, 2 events which are triggered within XComGameState_WorldRegion.

WorldRegionGetStaticMesh is used to make sure that, when using a controller and on the strategy map, each selectable region/haven is associated with a 3D mesh. Previously, Long War 2 introduced states which the base game did not handle; consequently, you could end up with selectable regions/havens with no 3D mesh.

WorldRegionGetMeshScale simply makes sure that the 3D mesh associated with a selectable region/haven is the correct size on the strategy map.

--------------------------------------

Modified UIStrategyMapItem_Region_LW :

UIStrategyMapItem_Region_LW.IsSelectable was previously modified to make sure that the following was true when using a controller :
1.] Contactable regions were selectable.
2.] Contactable regions, which were scanning for contact, were selectable.
3.] Havens, where a radio relay could be built, were selectable.
4.] Havens, with an installed radio relay, were selectable.

The one condition I missed was : Havens, where a radio relay could not be built due to tech level, should still be selectable.

Consequently, I have modified IsSelectable and simplified the logic so any "contactable" or "contacted" region/haven is now selectable.