### PR TITLE
Soldier List Item D-Pad Down fix

### DIFF
--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIScreenListener_LWOfficerPack.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIScreenListener_LWOfficerPack.uc
@@ -11,8 +11,10 @@ var localized string strCommandingOfficerTooltip;
 var localized string strSubordinateOfficerTooltipTitle;
 var localized string strSubordinateOfficerTooltip;
 
-var bool bRegisteredForEvents; // has this registered this game session?
-var bool bLastUpdateStrategy; // has this registered since a tactical/strategy switch ?
+// Has this registered this game session ?
+var bool bRegisteredForEvents; 
+// Has this registered since a tactical/strategy switch ?
+var bool bLastUpdateStrategy; 
 
 var UIArmory_MainMenu ArmoryMainMenu;
 var UIListItemString LeaderAbilityButton;
@@ -22,18 +24,18 @@ delegate OnItemSelectedCallback(UIList _list, int itemIndex);
 
 private function bool IsInStrategy()
 {
-	return `HQGAME  != none && `HQPC != None && `HQPRES != none;
+	return ((`HQGAME  != none) && (`HQPC != None) && (`HQPRES != none));
 }
 
 event OnInit(UIScreen Screen)
 {
-	//reset switch in tactical so we re-register back in strategy
-	if(UITacticalHUD(Screen) == none)
+	// Reset switch in tactical so we re-register back in strategy
+	if (UITacticalHUD(Screen) == none)
 	{
 		RegisterForEvents();
 		bRegisteredForEvents = false;
 	}
-	if(IsInStrategy() && !bRegisteredForEvents)
+	if (IsInStrategy() && !bRegisteredForEvents)
 	{
 		RegisterForEvents();
 		bRegisteredForEvents = true;
@@ -42,9 +44,9 @@ event OnInit(UIScreen Screen)
 
 function RegisterForEvents()
 {
-	local X2EventManager EventManager;
 	local Object ThisObj;
-
+	local X2EventManager EventManager;
+	
 	ThisObj = self;
 
 	EventManager = `XEVENTMGR;
@@ -69,25 +71,27 @@ function RegisterForEvents()
 
 function EventListenerReturn UpdateOfficerLeadership(Object EventData, Object EventSource, XComGameState GameState, Name InEventID, Object CallbackData)
 {
-	local XComGameStateHistory History;
-	local XComGameState_XpManager XpManager;
-	local XComGameState_HeadquartersXCom XComHQ;
-	local XComGameState NewGameState;
+	local bool PlayerWonMission;
 	local StateObjectReference UnitRef, CommandingRef;
+	local X2MissionSourceTemplate MissionSource;
+	local XComGameState NewGameState;
+	local XComGameState_BattleData BattleState;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_MissionSite MissionState;
 	local XComGameState_Unit UnitState, CommandingUnit;
 	local XComGameState_Unit_LWOfficer OfficerState;
-	local XComGameState_BattleData BattleState;
-	local XComGameState_MissionSite MissionState;
-	local X2MissionSourceTemplate MissionSource;
+	local XComGameState_XpManager XpManager;
+	local XComGameStateHistory History;
 	local XGBattle_SP Battle;
-	local bool PlayerWonMission;
 
 	XComHQ = XComGameState_HeadquartersXCom(EventData);
-	if(XComHQ == none)
+	if (XComHQ == none)
+	{
 		return ELR_NoInterrupt;
+	}
 
 	XpManager = XComGameState_XpManager(EventSource);
-	if(XpManager == none)
+	if (XpManager == none)
 	{
 		`REDSCREEN("OnAddMissionEncountersToUnits event triggered with invalid event source.");
 		return ELR_NoInterrupt;
@@ -95,13 +99,19 @@ function EventListenerReturn UpdateOfficerLeadership(Object EventData, Object Ev
 
 	History = `XCOMHISTORY;
 
-	// get commanding officer
+	// Get commanding officer
 	foreach XComHQ.Squad(UnitRef)
 	{
-		if (UnitRef.ObjectID == 0) { continue; }
+		if (UnitRef.ObjectID == 0)
+		{
+			continue;
+		}
 
 		UnitState = XComGameState_Unit(History.GetGameStateForObjectID(UnitRef.ObjectID));
-		if (UnitState == none) { continue; }
+		if (UnitState == none)
+		{
+			continue;
+		}
 
 		if (class'LWOfficerUtilities'.static.IsHighestRankOfficerInSquad(UnitState, XComHQ))
 		{
@@ -115,82 +125,120 @@ function EventListenerReturn UpdateOfficerLeadership(Object EventData, Object Ev
 		}
 	}
 
-	if (OfficerState == none) { return ELR_NoInterrupt; }
-	if (CommandingUnit.bCaptured) { return ELR_NoInterrupt; }
-	if (CommandingUnit.IsDead()) { return ELR_NoInterrupt; }
+	if (OfficerState == none)
+	{
+		return ELR_NoInterrupt; 
+	}
+	if (CommandingUnit.bCaptured) 
+	{ 
+		return ELR_NoInterrupt; 
+	}
+	if (CommandingUnit.IsDead())
+	{
+		return ELR_NoInterrupt;
+	}
 
-	// determine if strategy objectives were met
+	// Determine if strategy objectives were met
 	BattleState = XComGameState_BattleData(History.GetSingleGameStateObjectForClass(class'XComGameState_BattleData'));
-	if (BattleState != none && BattleState.m_iMissionID != XComHQ.MissionRef.ObjectID)
+	if ((BattleState != none) && (BattleState.m_iMissionID != XComHQ.MissionRef.ObjectID))
 	{
 		`REDSCREEN("LongWar: Mismatch in BattleState and XComHQ MissionRef when updating Officer Leadership Data");
 		return ELR_NoInterrupt;
 	}
 	Battle = XGBattle_SP(`BATTLE);
-	if (Battle == none) { return ELR_NoInterrupt; }
+	if (Battle == none)
+	{
+		return ELR_NoInterrupt;
+	}
 
 	MissionState = XComGameState_MissionSite(History.GetGameStateForObjectID(BattleState.m_iMissionID));
-	if(MissionState == none) { return ELR_NoInterrupt; }
+	if (MissionState == none)
+	{
+		return ELR_NoInterrupt;
+	}
 
 	PlayerWonMission = true;
 	MissionSource = MissionState.GetMissionSource();
-	if(MissionSource.WasMissionSuccessfulFn != none)
+	if (MissionSource.WasMissionSuccessfulFn != none)
 	{
 		PlayerWonMission = MissionSource.WasMissionSuccessfulFn(BattleState);
 	}
 
-	if (!PlayerWonMission) { return ELR_NoInterrupt; }
+	if (!PlayerWonMission)
+	{ 
+		return ELR_NoInterrupt;
+	}
 
-	//Build NewGameState change container
+	// Build NewGameState change container
 	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Update Officer Leadership Data post-mission");
 	OfficerState = XComGameState_Unit_LWOfficer(NewGameState.CreateStateObject(class'XComGameState_Unit_LWOfficer', OfficerState.ObjectID));
 	NewGameState.AddStateObject(OfficerState);
 
 	foreach XComHQ.Squad(UnitRef)
 	{
-		if (UnitRef.ObjectID == 0) { continue; }
-		if (UnitRef.ObjectID == CommandingRef.ObjectID) { continue; } // don't count the unit itself
+		if (UnitRef.ObjectID == 0)
+		{
+			continue;
+		}
+		// Don't count the unit itself
+		if (UnitRef.ObjectID == CommandingRef.ObjectID)
+		{
+			continue;
+		} 
 
 		UnitState = XComGameState_Unit(History.GetGameStateForObjectID(UnitRef.ObjectID));
-		if (UnitState == none) { continue; }
-		if (UnitState.IsDead()) { continue; }
-		if (UnitState.bCaptured) { continue; }
-		if (UnitState.GetSoldierClassTemplateName() == 'LWS_RebelSoldier') { continue; } // exclude rebels from counting toward leadership bonuses -- ID 1582
+		
+		if ((UnitState == none) || UnitState.IsDead() || UnitState.bCaptured)
+		{
+			continue;
+		}
+		// Exclude rebels from counting toward leadership bonuses -- ID 1582
+		if (UnitState.GetSoldierClassTemplateName() == 'LWS_RebelSoldier')
+		{
+			continue;
+		} 
 
 		OfficerState.AddSuccessfulMissionToLeaderShip(UnitRef, NewGameState);
 	}
 
-
 	if (NewGameState.GetNumGameStateObjects() > 0)
+	{
 		`GAMERULES.SubmitGameState(NewGameState);
+	}
 	else
+	{
 		History.CleanupPendingGameState(NewGameState);
+	}
 
 	return ELR_NoInterrupt;
 }
 
 function EventListenerReturn OverrideOfficerRankName(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
 {
-	local XComLWTuple				OverrideTuple;
-	local XComGameState_Unit		UnitState;
+	local XComGameState_Unit UnitState;
 	local XComGameState_Unit_LWOfficer OfficerState;
-
+	local XComLWTuple OverrideTuple;
+	
 	OverrideTuple = XComLWTuple(EventData);
-	if(OverrideTuple == none)
+	if (OverrideTuple == none)
 	{
 		`REDSCREEN("Override event triggered with invalid event data.");
 		return ELR_NoInterrupt;
 	}
 
 	UnitState = XComGameState_Unit(EventSource);
-	if(UnitState == none)
+	if (UnitState == none)
+	{
 		return ELR_NoInterrupt;
+	}
 
-	if(OverrideTuple.Id != 'SoldierRankName')
+	if (OverrideTuple.Id != 'SoldierRankName')
+	{
 		return ELR_NoInterrupt;
+	}
 
 	OfficerState = class'LWOfficerUtilities'.static.GetOfficerComponent(UnitState);
-	if(OfficerState != none && OfficerState.GetOfficerRank() > 0 && OverrideTuple.Data[0].i == -1)
+	if ((OfficerState != none) && (OfficerState.GetOfficerRank() > 0) && (OverrideTuple.Data[0].i == -1))
 	{
 		OverrideTuple.Data[1].s = class'LWOfficerUtilities'.static.GetLWOfficerRankName(OfficerState.GetOfficerRank());
 	}
@@ -200,26 +248,30 @@ function EventListenerReturn OverrideOfficerRankName(Object EventData, Object Ev
 
 function EventListenerReturn OverrideOfficerShortRankName(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
 {
-	local XComLWTuple				OverrideTuple;
-	local XComGameState_Unit		UnitState;
+	local XComGameState_Unit UnitState;
 	local XComGameState_Unit_LWOfficer OfficerState;
-
+	local XComLWTuple OverrideTuple;
+	
 	OverrideTuple = XComLWTuple(EventData);
-	if(OverrideTuple == none)
+	if (OverrideTuple == none)
 	{
 		`REDSCREEN("Override event triggered with invalid event data.");
 		return ELR_NoInterrupt;
 	}
 
 	UnitState = XComGameState_Unit(EventSource);
-	if(UnitState == none)
+	if (UnitState == none)
+	{
 		return ELR_NoInterrupt;
+	}
 
-	if(OverrideTuple.Id != 'SoldierShortRankName')
+	if (OverrideTuple.Id != 'SoldierShortRankName')
+	{
 		return ELR_NoInterrupt;
+	}
 
 	OfficerState = class'LWOfficerUtilities'.static.GetOfficerComponent(UnitState);
-	if(OfficerState != none && OfficerState.GetOfficerRank() > 0 && OverrideTuple.Data[0].i == -1)
+	if ((OfficerState != none) && (OfficerState.GetOfficerRank() > 0) && (OverrideTuple.Data[0].i == -1))
 	{
 		OverrideTuple.Data[1].s = class'LWOfficerUtilities'.static.GetLWOfficerShortRankName(OfficerState.GetOfficerRank());
 	}
@@ -229,26 +281,30 @@ function EventListenerReturn OverrideOfficerShortRankName(Object EventData, Obje
 
 function EventListenerReturn OverrideOfficerRankIcon(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
 {
-	local XComLWTuple				OverrideTuple;
-	local XComGameState_Unit		UnitState;
+	local XComGameState_Unit UnitState;
 	local XComGameState_Unit_LWOfficer OfficerState;
-
+	local XComLWTuple OverrideTuple;
+	
 	OverrideTuple = XComLWTuple(EventData);
-	if(OverrideTuple == none)
+	if (OverrideTuple == none)
 	{
 		`REDSCREEN("Override event triggered with invalid event data.");
 		return ELR_NoInterrupt;
 	}
 
 	UnitState = XComGameState_Unit(EventSource);
-	if(UnitState == none)
+	if (UnitState == none)
+	{
 		return ELR_NoInterrupt;
+	}
 
-	if(OverrideTuple.Id != 'SoldierRankIcon')
+	if (OverrideTuple.Id != 'SoldierRankIcon')
+	{
 		return ELR_NoInterrupt;
+	}
 
 	OfficerState = class'LWOfficerUtilities'.static.GetOfficerComponent(UnitState);
-	if(OfficerState != none && OfficerState.GetOfficerRank() > 0 && OverrideTuple.Data[0].i == -1)
+	if ((OfficerState != none) && (OfficerState.GetOfficerRank() > 0) && (OverrideTuple.Data[0].i == -1))
 	{
 		OverrideTuple.Data[1].s = class'LWOfficerUtilities'.static.GetRankIcon(OfficerState.GetOfficerRank());
 	}
@@ -261,16 +317,16 @@ function EventListenerReturn AddArmoryMainMenuItem(Object EventData, Object Even
 	local UIList List;
 	local XComGameState_Unit Unit;
 
-	`LOG("AddArmoryMainMenuItem: Starting.");
+	// `LOG("AddArmoryMainMenuItem: Starting.");
 
 	List = UIList(EventData);
-	if(List == none)
+	if (List == none)
 	{
 		`REDSCREEN("Add Armory MainMenu event triggered with invalid event data.");
 		return ELR_NoInterrupt;
 	}
 	ArmoryMainMenu = UIArmory_MainMenu(EventSource);
-	if(ArmoryMainMenu == none)
+	if (ArmoryMainMenu == none)
 	{
 		`REDSCREEN("Add Armory MainMenu event triggered with invalid event source.");
 		return ELR_NoInterrupt;
@@ -284,22 +340,23 @@ function EventListenerReturn AddArmoryMainMenuItem(Object EventData, Object Even
 	{
 		LeaderAbilityButton = ArmoryMainMenu.Spawn(class'UIListItemString', List.ItemContainer).InitListItem(CAPS(class'UIScreenListener_Armory_MainMenu_LWOfficerPack'.default.strOfficerMenuOption));
 		LeaderAbilityButton.ButtonBG.OnClickedDelegate = OnOfficerButtonCallback;
-		if(NextOnSelectionChanged == none)
+		if (NextOnSelectionChanged == none)
 		{
-		 	NextOnSelectionChanged = List.OnSelectionChanged;
+			NextOnSelectionChanged = List.OnSelectionChanged;
 			List.OnSelectionChanged = OnSelectionChanged;
 		}
 		List.MoveItemToBottom(FindDismissListItem(List));
 	}
+	
 	return ELR_NoInterrupt;
 }
 
-//callback handler for list button -- invokes the LW officer ability UI
+// Callback handler for list button -- invokes the LW officer ability UI
 simulated function OnOfficerButtonCallback(UIButton kButton)
 {
-	local XComHQPresentationLayer HQPres;
 	local UIArmory_LWOfficerPromotion OfficerScreen;
-
+	local XComHQPresentationLayer HQPres;
+	
 	HQPres = `HQPRES;
 	OfficerScreen = UIArmory_LWOfficerPromotion(HQPres.ScreenStack.Push(HQPres.Spawn(class'UIArmory_LWOfficerPromotion', HQPres), HQPres.Get3DMovie()));
 	OfficerScreen.InitPromotion(ArmoryMainMenu.GetUnitRef(), false);
@@ -309,7 +366,7 @@ simulated function OnOfficerButtonCallback(UIButton kButton)
 	OfficerScreen.CreateSoldierPawn();
 }
 
-//callback handler for list button info at bottom of screen
+// Callback handler for list button info at bottom of screen
 simulated function OnSelectionChanged(UIList ContainerList, int ItemIndex)
 {
 	if (ContainerList.GetItem(ItemIndex) == LeaderAbilityButton) 
@@ -317,6 +374,7 @@ simulated function OnSelectionChanged(UIList ContainerList, int ItemIndex)
 		ArmoryMainMenu.MC.ChildSetString("descriptionText", "htmlText", class'UIUtilities_Text'.static.AddFontInfo(class'UIScreenListener_Armory_MainMenu_LWOfficerPack'.default.OfficerListItemDescription, true));
 		return;
 	}
+	
 	NextOnSelectionChanged(ContainerList, ItemIndex);
 }
 
@@ -328,21 +386,24 @@ simulated function UIListItemString FindDismissListItem(UIList List)
 	for (Idx = 0; Idx < List.ItemCount ; Idx++)
 	{
 		Current = UIListItemString(List.GetItem(Idx));
-		//`log("Dismiss Search: Text=" $ Current.Text $ ", DismissName=" $ ArmoryMainMenu.m_strDismiss);
+		// `log("Dismiss Search: Text=" $ Current.Text $ ", DismissName=" $ ArmoryMainMenu.m_strDismiss);
 		if (Current.Text == ArmoryMainMenu.m_strDismiss)
+		{
 			return Current;
+		}
 	}
+	
 	return none;
 }
 
 function EventListenerReturn AddOfficerIcon_SquadSelectListItem(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
 {
-	local XComGameState_Unit Unit;
-	local UISquadSelect_ListItem ListItem;
 	local UIIcon Icon;
-
+	local UISquadSelect_ListItem ListItem;
+	local XComGameState_Unit Unit;
+	
 	ListItem = UISquadSelect_ListItem(EventSource);
-	if(ListItem == none)
+	if (ListItem == none)
 	{
 		`REDSCREEN("Add Officer Icon event triggered with invalid source.");
 		return ELR_NoInterrupt;
@@ -373,9 +434,13 @@ function EventListenerReturn AddOfficerIcon_SquadSelectListItem(Object EventData
 			Icon.SetBGColorState(eUIState_Normal);
 			Icon.SetToolTipText(strSubordinateOfficerTooltip, strSubordinateOfficerTooltipTitle,,, true, class'UIUtilities'.const.ANCHOR_BOTTOM_LEFT, false, 0.5);
 		}
-	} else {
+	} 
+	else 
+	{
 		if (Icon != none)
+		{
 			Icon.Hide();
+		}
 	}
 
 	return ELR_NoInterrupt;
@@ -383,33 +448,21 @@ function EventListenerReturn AddOfficerIcon_SquadSelectListItem(Object EventData
 
 function EventListenerReturn SetDisabledOfficerListItems(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
 {
-	//local XComGameState_HeadquartersXCom XComHQ;
 	local UIPersonnel_ListItem ListItem;
-	//local XComGameState_Unit Unit;
-	//local GeneratedMissionData MissionData;
-	//local bool bAllowWoundedSoldiers;
-
-	//only do this for squadselect
-	if(!IsInSquadSelect())
+	
+	// Only do this for squadselect
+	if (!IsInSquadSelect())
+	{
 		return ELR_NoInterrupt;
+	}
 
 	ListItem = UIPersonnel_ListItem(EventData);
-	if(ListItem == none)
+	if (ListItem == none)
 	{
 		`REDSCREEN("Set Disabled Officer List Items event triggered with invalid event data.");
 		return ELR_NoInterrupt;
 	}
 
-	//XComHQ = `XCOMHQ;
-	//MissionData = XComHQ.GetGeneratedMissionData(XComHQ.MissionRef.ObjectID);
-	//bAllowWoundedSoldiers = MissionData.Mission.AllowDeployWoundedUnits;
-//
-	//Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(ListItem.UnitRef.ObjectID));
-	//if(Unit != none)
-	//{
-		//if(class'LWOfficerUtilities'.static.IsOfficer(Unit) && class'LWOfficerUtilities'.static.HasOfficerInSquad() && !bAllowWoundedSoldiers)
-			//ListItem.SetDisabled(true);
-	//}
 	return ELR_NoInterrupt;
 }
 
@@ -419,23 +472,25 @@ function bool IsInSquadSelect()
 	local UIScreenStack ScreenStack;
 
 	ScreenStack = `SCREENSTACK;
-	for( Index = 0; Index < ScreenStack.Screens.Length;  ++Index)
+	for (Index = 0; Index < ScreenStack.Screens.Length; ++Index)
 	{
-		if( ScreenStack.Screens[Index].IsA('UISquadSelect') )
+		if (ScreenStack.Screens[Index].IsA('UISquadSelect'))
+		{
 			return true;
+		}
 	}
+
 	return false; 
 }
 
 function EventListenerReturn AddOfficerIcon_PersonnelListItem(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
 {
-	local XComGameState_Unit Unit;
-	local UIPersonnel_SoldierListItem ListItem;
-	//local int SlotIndex;
 	local UIIcon OfficerIcon;
+	local UIPersonnel_SoldierListItem ListItem;
+	local XComGameState_Unit Unit;
 	
 	ListItem = UIPersonnel_SoldierListItem(EventData);
-	if(ListItem == none)
+	if (ListItem == none)
 	{
 		`REDSCREEN("AddOfficerIcon_PersonnelListItem event triggered with invalid event data.");
 		return ELR_NoInterrupt;
@@ -444,8 +499,13 @@ function EventListenerReturn AddOfficerIcon_PersonnelListItem(Object EventData, 
 	Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(ListItem.UnitRef.ObjectID));
 	if (class'LWOfficerUtilities'.static.IsOfficer(Unit))
 	{
-		OfficerIcon = ListItem.Spawn(class'UIIcon', ListItem).InitIcon('abilityIcon1MC', class'LWOfficerUtilities'.static.GetGenericIcon(), false, true, 18);
+		OfficerIcon = ListItem.Spawn(class'UIIcon', ListItem);
 		OfficerIcon.bAnimateOnInit = false;
+		// KDM : Remove the officer icon's selection brackets since they are unnecessary and look odd.
+		OfficerIcon.bDisableSelectionBrackets = true;
+		// KDM : Icons shouldn't be navigable, else they mess with controller navigation.
+		OfficerIcon.bIsNavigable = false;
+		OfficerIcon.InitIcon('abilityIcon1MC', class'LWOfficerUtilities'.static.GetGenericIcon(), false, true, 18);
 		OfficerIcon.OriginTopLeft();
 		OfficerIcon.SetPosition(101, 24);
 	}
@@ -455,53 +515,43 @@ function EventListenerReturn AddOfficerIcon_PersonnelListItem(Object EventData, 
 
 function EventListenerReturn CheckOfficerMissionStatus(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
 {
-	local XComLWTuple PersonnelStrings;
-	//local UIPersonnel_SoldierListItem ListItem;
-	local XComGameState_HeadquartersXCom HQState;
 	local bool bUnitInSquad;
-	//local GeneratedMissionData MissionData;
+	local XComGameState_HeadquartersXCom HQState;
 	local XComGameState_Unit Unit;
-
-	//only do this for squadselect
-	if(!IsInSquadSelect() && GetScreenOrChild('UIPersonnel_SquadBarracks') == none)
+	local XComLWTuple PersonnelStrings;
+	
+	// Only do this for squadselect
+	if ((!IsInSquadSelect()) && (GetScreenOrChild('UIPersonnel_SquadBarracks') == none))
+	{
 		return ELR_NoInterrupt;
+	}
 
 	PersonnelStrings = XComLWTuple(EventData);
-	if(PersonnelStrings == none)
+	if (PersonnelStrings == none)
 	{
 		`REDSCREEN("Check Officer MissionStatus event triggered with invalid event data.");
 		return ELR_NoInterrupt;
 	}
-	//ListItem = UIPersonnel_SoldierListItem(EventSource);
-	//if(ListItem == none)
-	//{
-		//`REDSCREEN("Check Officer MissionStatus event triggered with invalid source data.");
-		//return ELR_NoInterrupt;
-	//}
+	
 	Unit = XComGameState_Unit(EventSource);
-	if(Unit == none)
+	if (Unit == none)
 	{
 		`REDSCREEN("OverrideGetPersonnelStatusSeparate event triggered with invalid source data.");
 		return ELR_NoInterrupt;
 	}
 
 	HQState = `XCOMHQ;
-	//Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(ListItem.UnitRef.ObjectID));
 	bUnitInSquad = HQState.IsUnitInSquad(Unit.GetReference());
-	//MissionData = HQState.GetGeneratedMissionData(HQState.MissionRef.ObjectID);
-	//bAllowWoundedSoldiers = MissionData.Mission.AllowDeployWoundedUnits;
-
-	if (GetScreenOrChild ('UISquadSelect') != none && GetScreenOrChild('UIPersonnel_SquadBarracks') == none)
+	
+	if ((GetScreenOrChild ('UISquadSelect') != none) && (GetScreenOrChild('UIPersonnel_SquadBarracks') == none))
 	{
-		if(Unit != none && PersonnelStrings.Id == 'OverrideGetPersonnelStatusSeparate') 
+		if ((Unit != none) && (PersonnelStrings.Id == 'OverrideGetPersonnelStatusSeparate')) 
 		{
-			if(PersonnelStrings.Data.Length == 0 || PersonnelStrings.Data[0].b != true) // not already set by another method
+			if ((PersonnelStrings.Data.Length == 0) || (PersonnelStrings.Data[0].b != true)) // Not already set by another method
 			{
-				if (!bUnitInSquad && class'LWOfficerUtilities'.static.IsOfficer(Unit) && class'LWOfficerUtilities'.static.HasOfficerInSquad())
+				if ((!bUnitInSquad) && class'LWOfficerUtilities'.static.IsOfficer(Unit) && class'LWOfficerUtilities'.static.HasOfficerInSquad())
 				{
 					PersonnelStrings.Data.Add(4-PersonnelStrings.Data.Length);
-					//PersonnelStrings.Data[0].kind = XComLWTVBool;
-					//PersonnelStrings.Data[0].b = true;
 					PersonnelStrings.Data[0].kind = XComLWTVString;
 					PersonnelStrings.Data[1].kind = XComLWTVString;
 					PersonnelStrings.Data[2].kind = XComLWTVString;
@@ -514,36 +564,43 @@ function EventListenerReturn CheckOfficerMissionStatus(Object EventData, Object 
 			}
 		}
 	}
+	
 	return ELR_NoInterrupt;
 }
 
 static function UIScreen GetScreenOrChild(name ScreenType)
 {
-	local UIScreenStack ScreenStack;
 	local int Index;
+	local UIScreenStack ScreenStack;
+	
 	ScreenStack = `SCREENSTACK;
-	for( Index = 0; Index < ScreenStack.Screens.Length;  ++Index)
+	for (Index = 0; Index < ScreenStack.Screens.Length; ++Index)
 	{
-		if(ScreenStack.Screens[Index].IsA(ScreenType))
+		if (ScreenStack.Screens[Index].IsA(ScreenType))
+		{
 			return ScreenStack.Screens[Index];
+		}
 	}
+
 	return none; 
 }
 
 function EventListenerReturn CleanUpComponentStateOnDismiss(Object EventData, Object EventSource, XComGameState GameState, Name EventID, Object CallbackData)
 {
-	local XComGameState_Unit UnitState, UpdatedUnit;
 	local XComGameState NewGameState;
+	local XComGameState_Unit UnitState, UpdatedUnit;
 	local XComGameState_Unit_LWOfficer OfficerState, UpdatedOfficer;
 
 	UnitState = XComGameState_Unit(EventData);
-	if(UnitState == none)
+	if (UnitState == none)
+	{
 		return ELR_NoInterrupt;
+	}
 
 	OfficerState = class'LWOfficerUtilities'.static.GetOfficerComponent(UnitState);
-	if(OfficerState != none)
+	if (OfficerState != none)
 	{
-		`LOG("LWOfficerPack: Found OfficerState, Unit=" $ UnitState.GetFullName() $ ", Removing Component.");
+		// `LOG("LWOfficerPack: Found OfficerState, Unit=" $ UnitState.GetFullName() $ ", Removing Component.");
 		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("OfficerState cleanup");
 		UpdatedUnit = XComGameState_Unit(NewGameState.CreateStateObject(class'XComGameState_Unit', UnitState.ObjectID));
 		UpdatedOfficer = XComGameState_Unit_LWOfficer(NewGameState.CreateStateObject(class'XComGameState_Unit_LWOfficer', OfficerState.ObjectID));
@@ -552,41 +609,21 @@ function EventListenerReturn CleanUpComponentStateOnDismiss(Object EventData, Ob
 		NewGameState.AddStateObject(UpdatedOfficer);
 		NewGameState.AddStateObject(UpdatedUnit);
 		if (NewGameState.GetNumGameStateObjects() > 0)
+		{
 			`GAMERULES.SubmitGameState(NewGameState);
+		}
 		else
+		{
 			`XCOMHISTORY.CleanupPendingGameState(NewGameState);
+		}
 	}
+
 	return ELR_NoInterrupt;
 }
 
-//function bool IsDLCActive(string DLCIdentifier)
-//{
-	//local X2DownloadableContentInfo DLCInfo;
-	//local array<X2DownloadableContentInfo> DLCInfos;
-	//local XComOnlineEventMgr EventManager;
-//
-	//EventManager = `ONLINEEVENTMGR;
-	//
-	////retrieve all active DLCs
-	//DLCInfos = EventManager.GetDLCInfos(false);
-	//foreach DLCInfos(DLCInfo)
-	//{
-		//if(DLCInfo.DLCIdentifier == DLCIdentifier)
-			//return true;
-	//}
-	//return false;
-//}
-
-// This event is triggered after a screen gains focus
-//event OnReceiveFocus(UIScreen Screen);
-
-// This event is triggered after a screen loses focus
-//event OnLoseFocus(UIScreen Screen);
-
-// This event is triggered when a screen is removed
 event OnRemoved(UIScreen Screen)
 {
-	if(UIArmory_MainMenu(Screen) != none)
+	if (UIArmory_MainMenu(Screen) != none)
 	{
 		ArmoryMainMenu = none;
 		NextOnSelectionChanged = none;
@@ -595,6 +632,5 @@ event OnRemoved(UIScreen Screen)
 
 defaultproperties
 {
-	// Leaving this assigned to none will cause every screen to trigger its signals on this class
 	ScreenClass = none;
 }


### PR DESCRIPTION
This fix was originally implemented for a detailed soldier list item (see pull request #1042); however, the detailed soldier list has since been replaced with a modified LW2 list. Hence, this fix was needed.

----------------------

Modifies : UIScreenListener_LWOfficerPack.AddOfficerIcon_PersonnelListItem

1.] UIPersonnel_SoldierListItem_LW.AddAdditionalItems triggers the event 'OnSoldierListItemUpdate_End' which ends up calling AddOfficerIcon_PersonnelListItem; its goal is to add an officer icon to a soldier list item, if need be. Unforunately, while icons are added to the navigation system by default, they can create controller navigation issues. In this case, the first D-Pad down press, when viewing a soldier list, would appear to be ignored. As a result, the officer icon needed to be removed from the navigation system.

2.] The officer icon's bDisableSelectionBrackets was set to true, so that brackets no longer appear around the icon when the soldier is selected; these brackets were unnecessary and looked odd.

3.] A bunch of code cleanup, mainly tabs and spacing, was done within this file.