### PR TITLE
Fix Soldier will value & combat intelligence colour when disabled.

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_UI.ini
+++ b/LongWarOfTheChosen/Config/XComLW_UI.ini
@@ -66,3 +66,10 @@ SHOW_REGION_TOOLTIPS_CTRL = false			; Shows the region tooltips when using a con
 
 [LW_Overhaul.UIStrategyMapItem_Mission_LW]
 SHOW_MISSION_TOOLTIPS_CTRL = true			; Shows tooltips for missions when using a controller. These tooltips are the same as what you would see on the bottom UI bar when using a mouse & keyboard.
+
+[LW_Overhaul.UIPersonnel_SoldierListItem_LW]
+COM_INT_STANDARD_COLOR = "0xbf1e2e"			; Standard combat intelligence text colour.
+COM_INT_ABOVEAVERAGE_COLOR = "0xe69831"		; Above average combat intelligence text colour.
+COM_INT_GIFTED_COLOR = "0xfdce2b"			; Gifted combat intelligence text colour.
+COM_INT_GENIUS_COLOR = "0x53b45e"			; Genius combat intelligence text colour.
+COM_INT_SAVANT_COLOR = "0x27aae1"			; Savant combat intelligence text colour.


### PR DESCRIPTION
Modifies : UIPersonnel_SoldierListItem_LW.UpdateItemsForFocus

Formerly, a soldier list item's will value and combat intelligence icon would always be coloured, even if it was disabled. This did not fit with other attribute images and values (aim/defense ... etc.) which 'grey out' when disabled. Consequently, this has been fixed.

----------------------

Added : UIPersonnel_SoldierListItem_LW.GetWillValueColor and UIPersonnel_SoldierListItem_LW.GetCombatIntelligenceColor

The function GetWillValueColor determines the will value colour based upon a soldier list item's disabled and focused status.
The function GetCombatIntelligenceColor determines the combat intelligence image's colour based upon a soldier list item's disabled and focused status.

----------------------

Modifies : XComLW_UI.ini

Added configurable combat intelligence colours; these are referenced within UIPersonnel_SoldierListItem_LW. 

----------------------

Performed file cleanup (tabs and spaces)