### PR TITLE
Allow rescuing multiple captured soldiers

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Activities.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Activities.ini
@@ -644,6 +644,7 @@ POLITICAL_PRISONERS_REGIONAL_COOLDOWN_HOURS_MAX=456
 POLITICAL_PRISONERS_REBEL_REWARD_MIN=3
 ; Note the max is hardcoded to be limited for the first few months
 POLITICAL_PRISONERS_REBEL_REWARD_MAX=6 ; Do not set to more than 6 without updating parcels to contain more rescue objectives.
+MAX_CAPTURED_SOLDIER_REWARDS=3  ; Maximum number of captured soldiers that can be rescued in a Jailbreak
 
 LOGISTICS_REGIONAL_COOLDOWN_HOURS_MIN=336
 LOGISTICS_REGIONAL_COOLDOWN_HOURS_MAX=456


### PR DESCRIPTION
Jailbreaks can now have multiple captured soldiers as rewards on a single mission, making it far less troublesome to recover soldiers when the Chosen have been kidnapping a whole bunch of them.

A lot of this code is designed to ensure that each captured soldier can only be the reward for a single mission or covert action. Neither vanilla not LW2 handled this properly.