### PR TITLE
Disable RecruitScreen Screen Listener so Recruit Screen is moddable

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_RecruitSoldiers.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_RecruitSoldiers.uc
@@ -1,12 +1,23 @@
 //---------------------------------------------------------------------------------------
 //  FILE:    UIScreenListener_RecruitSoldiers
 //  AUTHOR:  Peter Ledbrook
-//
 //  PURPOSE: A big ball of event listeners we need to set up for tactical games.
+//
+//	KDM : This recruit screen 'screen listener' has been disabled so that the recruit screen can be modded.
+//
+//	The former implementation was problematic for 2 reasons :
+//	1.] When you recruited a soldier from the recruit screen, the screen reverted to its base game 'look'.
+//	2.] Recruit attribute text did not change colour when different recruit rows were selected. 
+//	This is because, while the screen listener implemented OnReceiveFocus and OnLoseFocus, these were only 
+//	called when the screen itself received and lost focus; they were not called when individual list 
+//	items received and lost focus.
+//
+//	My fixed recruit screen mod can be found at : https://steamcommunity.com/sharedfiles/filedetails/?id=2116413401
 //--------------------------------------------------------------------------------------- 
 
 class UIScreenListener_RecruitSoldiers extends UIScreenListener config(LW_Overhaul);
 
+/*
 event OnInit(UIScreen Screen)
 {
     local UIRecruitSoldiers RecruitScreen;
@@ -65,3 +76,4 @@ defaultProperties
 	// Leaving this assigned to none will cause every screen to trigger its signals on this class
 	ScreenClass = none
 }
+*/


### PR DESCRIPTION
Comments out : UIScreenListener_RecruitSoldiers

The current Recruit Screen implementation is problematic for 2 reasons :

1.] When you recruit a soldier from the recruit screen, the screen reverts to its base game 'look'.
2.] Recruit attribute text does not change colour when different recruit rows are selected. This is because, while the screen listener implements OnReceiveFocus and OnLoseFocus, these are only called when the screen itself receives and loses focus; they are not called when individual list items receive and lose focus.

I remember reading a long time ago, in the LWotC issues section, about this problem; however, I can not find that post. Nonetheless, it was mentioned that it would likely be best to allow people to mod the recruit screen to suit their needs, just in case additional information needs to be added or removed from it.

To this effect, UIScreenListener_RecruitSoldiers has been commented out and I created, a number of months ago, a recruit screen mod that fixes these issues. The mod can be found at : https://steamcommunity.com/sharedfiles/filedetails/?id=2116413401.