### PR TITLE
Fix Recruitment Screen

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_UI.ini
+++ b/LongWarOfTheChosen/Config/XComLW_UI.ini
@@ -66,3 +66,9 @@ SHOW_REGION_TOOLTIPS_CTRL = false			; Shows the region tooltips when using a con
 
 [LW_Overhaul.UIStrategyMapItem_Mission_LW]
 SHOW_MISSION_TOOLTIPS_CTRL = true			; Shows tooltips for missions when using a controller. These tooltips are the same as what you would see on the bottom UI bar when using a mouse & keyboard.
+
+[LW_Overhaul.UIRecruitmentListItem_LWOTC]
+RECRUIT_FONT_SIZE_CTRL = 22					; Recruit screen font size for controller users.
+RECRUIT_Y_OFFSET_CTRL = -3					; Moves the stats up/down; negative numbers move up / positive numbers move down.
+RECRUIT_FONT_SIZE_MK = 20					; Recruit screen font size for mouse & keyboard users.
+RECRUIT_Y_OFFSET_MK = -2;					; Moves the stats up/down; negative numbers move up / positive numbers move down.

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIRecruitSoldiers_LWOTC.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIRecruitSoldiers_LWOTC.uc
@@ -1,0 +1,46 @@
+//---------------------------------------------------------------------------------------
+//  FILE:	 UIRecruitSoldiers_LWOTC.uc
+//  AUTHOR:	 KDM
+//  PURPOSE: Long War of the Chosen compatible recruit screen.
+//--------------------------------------------------------------------------------------- 
+
+class UIRecruitSoldiers_LWOTC extends UIRecruitSoldiers;
+
+simulated function UpdateData()
+{
+	local int i;
+	local XComGameState_Unit Recruit;
+	local XComGameStateHistory History;
+	local XComGameState_HeadquartersResistance ResistanceHQ;
+
+	AS_SetTitle(m_strListTitle);
+
+	List.ClearItems();
+	m_arrRecruits.Length = 0;
+
+	History = `XCOMHISTORY;
+	ResistanceHQ = XComGameState_HeadquartersResistance(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersResistance'));
+
+	if (ResistanceHQ != none)
+	{
+		for (i = 0; i < ResistanceHQ.Recruits.Length; i++)
+		{
+			Recruit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(ResistanceHQ.Recruits[i].ObjectID));
+			m_arrRecruits.AddItem(Recruit);
+			// KDM : Create and add our custom list item to the list.
+			UIRecruitmentListItem_LWOTC(List.CreateItem(class'UIRecruitmentListItem_LWOTC')).InitRecruitItem(Recruit);
+		}
+	}
+
+	if (m_arrRecruits.Length > 0)
+	{
+		// KDM : If we don't call RealizeList(), the bottom of the list gets cut off after recruiting a soldier.
+		List.RealizeList();
+		List.SetSelectedIndex(0, true);
+	}
+	else
+	{
+		List.SetSelectedIndex(-1, true);
+		AS_SetEmpty(m_strNoRecruits);
+	}
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIRecruitmentListItem_LWOTC.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIRecruitmentListItem_LWOTC.uc
@@ -1,0 +1,209 @@
+//---------------------------------------------------------------------------------------
+//  FILE:	 UIRecruitmentListItem_LWOTC.uc
+//  AUTHOR:	 KDM
+//  PURPOSE: A slightly modified version of UIRecruitmentListItem_LW, making the recruit
+//	list items compatible with Long War of the Chosen.
+//--------------------------------------------------------------------------------------- 
+
+class UIRecruitmentListItem_LWOTC extends UIRecruitmentListItem config(LW_UI);
+
+var config int RECRUIT_FONT_SIZE_CTRL;
+var config int RECRUIT_Y_OFFSET_CTRL;
+var config int RECRUIT_FONT_SIZE_MK;
+var config int RECRUIT_Y_OFFSET_MK;
+
+simulated function InitRecruitItem(XComGameState_Unit Recruit)
+{
+	super.InitRecruitItem(Recruit);
+
+	UpdateExistingUI();
+	AddIcons(Recruit);
+
+	// LW : Hack : Undo the height override set by UIListItemString; don't use SetHeight, as UIListItemString can't handle it.
+	Height = 64;
+	MC.ChildSetNum("theButton", "_height", 64);
+	List.OnItemSizeChanged(self);
+}
+
+// KDM : This is called when the confirm button's size is realized; I need to override it to set the x location manually.
+simulated function RefreshConfirmButtonLocation()
+{
+	if (`ISCONTROLLERACTIVE)
+	{
+		ConfirmButton.SetX(352);
+	}
+	else
+	{
+		ConfirmButton.SetX(350);
+	}
+
+	RefreshConfirmButtonVisibility();
+}
+
+function UpdateExistingUI()
+{
+	local UIPanel DividerLine;
+
+	bAnimateOnInit = false;
+
+	// LW : Move confirm button up.
+	if (`ISCONTROLLERACTIVE)
+	{
+		ConfirmButton.SetY(-3);
+	}
+	else
+	{
+		ConfirmButton.SetY(-1);
+	}
+	
+	// LW : Move soldier name up
+	MC.ChildSetNum("soldierName", "_y", 5);
+	
+	// LW : Update flag size and position
+	MC.BeginChildFunctionOp("flag", "setImageSize");  
+	MC.QueueNumber(81);
+	MC.QueueNumber(42);
+	MC.EndOp();
+	MC.ChildSetNum("flag", "_x", 7);
+	MC.ChildSetNum("flag", "_y", 10.5);
+	
+	// LW : Extend divider line
+	DividerLine = Spawn(class'UIPanel', self);
+	DividerLine.bIsNavigable = false;
+	DividerLine.InitPanel('', class'UIUtilities_Controls'.const.MC_GenericPixel);
+	DividerLine.SetColor(class'UIUtilities_Colors'.const.NORMAL_HTML_COLOR);
+	DividerLine.SetSize(1, 21.5);
+	DividerLine.SetPosition(90.6, 36.75);
+	DividerLine.SetAlpha(66.40625);
+}
+
+function AddIcons(XComGameState_Unit Recruit)
+{
+	local bool PsiStatIsVisible;
+	local float XLoc, YLoc, XDelta;
+	
+	PsiStatIsVisible = `XCOMHQ.IsTechResearched('AutopsySectoid');
+
+	// KDM : Stat icons, and their associated stat values, have to be manually placed.
+	XLoc = 97;
+	YLoc = 34.5f;
+	XDelta = 65.0f;
+
+	if (PsiStatIsVisible)
+	{
+		XDelta -= 10.0f;
+	}
+
+	InitIconValuePair(Recruit, eStat_Offense, "Aim", "UILibrary_LWToolbox.StatIcons.Image_Aim", XLoc, YLoc);
+	XLoc += XDelta;
+	InitIconValuePair(Recruit,	eStat_Defense, "Defense", "UILibrary_LWToolbox.StatIcons.Image_Defense", XLoc, YLoc);
+	XLoc += XDelta;
+	InitIconValuePair(Recruit, eStat_HP, "Health", "UILibrary_LWToolbox.StatIcons.Image_Health", XLoc, YLoc);
+	XLoc += XDelta;
+	InitIconValuePair(Recruit, eStat_Mobility, "Mobility", "UILibrary_LWToolbox.StatIcons.Image_Mobility", XLoc, YLoc);
+	XLoc += XDelta;
+	InitIconValuePair(Recruit, eStat_Will, "Will", "UILibrary_LWToolbox.StatIcons.Image_Will", XLoc, YLoc);
+	XLoc += XDelta;
+	InitIconValuePair(Recruit, eStat_Hacking, "Hacking", "UILibrary_LWToolbox.StatIcons.Image_Hacking", XLoc, YLoc);
+	XLoc += XDelta;
+	InitIconValuePair(Recruit, eStat_Dodge, "Dodge", "UILibrary_LWToolbox.StatIcons.Image_Dodge", XLoc, YLoc);
+	
+	if (PsiStatIsVisible)
+	{
+		XLoc += XDelta;
+		InitIconValuePair(Recruit, eStat_PsiOffense, "Psi", "gfxXComIcons.promote_psi", XLoc, YLoc);
+	}
+}
+
+function InitIconValuePair(XComGameState_Unit Recruit, ECharStatType StatType, string MCRoot, string ImagePath, float XLoc, float YLoc)
+{
+	local float IconScale, XOffset, YOffset;
+	local UIImage StatIcon;
+	local UIText StatValue;
+	
+	IconScale = 0.65f;
+	XOffset = 26.0f;
+	
+	if (GetLanguage() == "JPN")
+	{
+		YOffset = -3.0;
+	}
+
+	if (`ISCONTROLLERACTIVE)
+	{
+		YOffset += RECRUIT_Y_OFFSET_CTRL;
+	}
+	else
+	{
+		YOffset += RECRUIT_Y_OFFSET_MK;
+	}
+	
+	if (StatIcon == none)
+	{
+		StatIcon = Spawn(class'UIImage', self);
+		StatIcon.bAnimateOnInit = false;
+		StatIcon.InitImage(, ImagePath);
+		StatIcon.SetScale(IconScale);
+		StatIcon.SetPosition(XLoc, YLoc);
+	}
+	
+	if (StatValue == none)
+	{
+		StatValue = Spawn(class'UIText', self);
+		StatValue.bAnimateOnInit = false;
+		// KDM : Give each UIText a unique name, so that it can be accessed by that name when list item focus changes.
+		StatValue.InitText(name(MCRoot $ "_LWOTC"));
+		StatValue.SetPosition(XLoc + XOffset, YLoc + YOffset);
+	}
+
+	StatValue.Text = string(int(Recruit.GetCurrentStat(StatType)));
+	StatValue.SetHtmlText(class'UIUtilities_Text'.static.GetColoredText(StatValue.Text, eUIState_Normal, GetFontSize()));
+}
+
+simulated function OnReceiveFocus()
+{
+	super.OnReceiveFocus();
+	RefreshStatText();
+}
+
+simulated function OnLoseFocus()
+{
+	super.OnLoseFocus();
+	RefreshStatText();
+}
+
+function RefreshStatText()
+{
+	UpdateText("Aim");
+	UpdateText("Defense");
+	UpdateText("Health");
+	UpdateText("Mobility");
+	UpdateText("Will");
+	UpdateText("Hacking");
+	UpdateText("Dodge");
+	UpdateText("Psi");
+}
+
+function UpdateText(string MCRoot)
+{
+	local bool Focused;
+	local string OriginalText;
+	local UIText StatValue;
+
+	Focused = bIsFocused;
+	
+	// KDM : Get the UIText according to its name.
+	StatValue = UIText(GetChildByName(name(MCRoot $ "_LWOTC"), false));
+	
+	if (StatValue != none)
+	{
+		OriginalText = StatValue.Text;
+		// KDM : Change the text colour based on whether this list item is focused or not.
+		StatValue.SetHtmlText(class'UIUtilities_Text'.static.GetColoredText(OriginalText, (Focused ? -1 : eUIState_Normal), GetFontSize()));
+	}
+}
+
+function int GetFontSize()
+{
+	return (`ISCONTROLLERACTIVE) ? RECRUIT_FONT_SIZE_CTRL : RECRUIT_FONT_SIZE_MK;
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_RecruitSoldiers.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_RecruitSoldiers.uc
@@ -1,67 +1,26 @@
 //---------------------------------------------------------------------------------------
-//  FILE:    UIScreenListener_RecruitSoldiers
-//  AUTHOR:  Peter Ledbrook
-//
-//  PURPOSE: A big ball of event listeners we need to set up for tactical games.
+//  FILE:	 UIScreenListener_RecruitSoldiers.uc
+//  AUTHOR:	 KDM
+//  PURPOSE: Pushes a Long War of the Chosen compatible recruit screen onto the screen stack
+//	in place of the base recruit screen.
 //--------------------------------------------------------------------------------------- 
 
-class UIScreenListener_RecruitSoldiers extends UIScreenListener config(LW_Overhaul);
+class UIScreenListener_RecruitSoldiers extends UIScreenListener;
 
 event OnInit(UIScreen Screen)
 {
-    local UIRecruitSoldiers RecruitScreen;
-    local int i;
+	local UIRecruitSoldiers_LWOTC RecruitScreen;
+	local XComHQPresentationLayer HQPres;
+	
+	HQPres = `HQPRES;
 
-    RecruitScreen = UIRecruitSoldiers(Screen);
-    if (RecruitScreen == none)
-    {
-        return;
-    }
-
-    for (i = 0; i < RecruitScreen.List.ItemContainer.ChildPanels.Length; i++)
-    {
-        class'UIRecruitmentListItem_LW'.static.AddRecruitStats(
-                RecruitScreen.m_arrRecruits[i],
-                UIRecruitmentListItem(RecruitScreen.List.ItemContainer.ChildPanels[i]));
-    }
+	HQPres.ScreenStack.Pop(Screen);
+	RecruitScreen = HQPres.Spawn(class'UIRecruitSoldiers_LWOTC', HQPres);
+	HQPres.ScreenStack.Push(RecruitScreen);
 }
 
-event OnReceiveFocus(UIScreen Screen)
-{
-    local UIRecruitSoldiers RecruitScreen;
-    local int i;
-
-    RecruitScreen = UIRecruitSoldiers(Screen);
-    if (RecruitScreen == none)
-    {
-        return;
-    }
-
-    for (i = 0; i < RecruitScreen.List.ItemContainer.ChildPanels.Length; i++)
-    {
-        class'UIRecruitmentListItem_LW'.static.UpdateItemsForFocus(UIRecruitmentListItem(RecruitScreen.List.ItemContainer.ChildPanels[i]));
-    }
-}
-
-event OnLoseFocus(UIScreen Screen)
-{
-    local UIRecruitSoldiers RecruitScreen;
-    local int i;
-
-    RecruitScreen = UIRecruitSoldiers(Screen);
-    if (RecruitScreen == none)
-    {
-        return;
-    }
-
-    for (i = 0; i < RecruitScreen.List.ItemContainer.ChildPanels.Length; i++)
-    {
-        class'UIRecruitmentListItem_LW'.static.UpdateItemsForFocus(UIRecruitmentListItem(RecruitScreen.List.ItemContainer.ChildPanels[i]));
-    }
-}
-
-defaultProperties
-{
-	// Leaving this assigned to none will cause every screen to trigger its signals on this class
-	ScreenClass = none
+defaultproperties
+{ 
+	// KDM : Only listen for the UIRecruitSoldiers screen.
+	ScreenClass = class'UIRecruitSoldiers';
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_UpdateResources_RecruitScreen.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_UpdateResources_RecruitScreen.uc
@@ -1,0 +1,51 @@
+//---------------------------------------------------------------------------------------
+//  FILE:	 X2EventListener_UpdateResources_RecruitScreen.uc
+//  AUTHOR:	 KDM
+//  PURPOSE: UIAvengerHUD updates its resource display based upon the screen being shown; unfortunately, 
+//	it will update itself for the base Recruit Screen, UIRecruitSoldiers, but not our custom variant, UIRecruitSoldiers_LWOTC. 
+//	Therefore, we need to create a listener which listens for the Community Highlander event 'UpdateResources', 
+//	so we can set up the resource display ourself.
+//--------------------------------------------------------------------------------------- 
+
+class X2EventListener_UpdateResources_RecruitScreen extends X2EventListener;
+
+static function array<X2DataTemplate> CreateTemplates()
+{
+	local array<X2DataTemplate> Templates;
+
+	Templates.AddItem(CreateListenerTemplate_OnUpdateResources_RecruitScreen());
+	
+	return Templates;
+}
+
+static function CHEventListenerTemplate CreateListenerTemplate_OnUpdateResources_RecruitScreen()
+{
+	local CHEventListenerTemplate Template;
+
+	`CREATE_X2TEMPLATE(class'CHEventListenerTemplate', Template, 'UpdateResources_RecruitScreen');
+
+	Template.RegisterInTactical = false;
+	Template.RegisterInStrategy = true;
+
+	Template.AddCHEvent('UpdateResources', OnUpdateResources_RecruitScreen, ELD_Immediate);
+
+	return Template;
+}
+
+static function EventListenerReturn OnUpdateResources_RecruitScreen(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComHQPresentationLayer HQPres;
+
+	HQPres = `HQPRES;
+
+	// KDM : We are only interested when our custom Recruit Screen is on the top of the screen stack.
+	if (HQPres.ScreenStack.GetCurrentClass() == class'UIRecruitSoldiers_LWOTC')
+	{
+		// KDM : Display the same information a normal Recruit Screen would show.
+		HQPres.m_kAvengerHUD.UpdateMonthlySupplies();
+		HQPres.m_kAvengerHUD.UpdateSupplies();
+		HQPres.m_kAvengerHUD.ShowResources();
+	}
+
+	return ELR_NoInterrupt;
+}

--- a/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/UIRecruitmentListItem_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/UIRecruitmentListItem_LW.uc
@@ -2,9 +2,13 @@
 //  FILE:    UIRecruitmentListItem_LW.uc
 //  AUTHOR:  Amineri / Pavonis Interactive
 //  PURPOSE: This is an extension for RecruitmentListItem that allows displays stats, called via registered events
+//
+//	KDM :	 UIRecruitmentListItem_LWOTC is now used in place of UIRecruitmentListItem_LW.
 //---------------------------------------------------------------------------------------
+
 class UIRecruitmentListItem_LW extends Object;
 
+/*
 static function AddRecruitStats(XComGameState_Unit Recruit, UIRecruitmentListItem ListItem)
 {
 	local UIPanel kLine;
@@ -133,3 +137,4 @@ static function UpdateText(UIRecruitmentListItem ListItem, string MCRoot, bool b
 		Value.SetHtmlText(class'UIUtilities_Text'.static.GetColoredText(OldText, (bReverse ? -1 : eUIState_Normal)));
 	}
 }
+*/

--- a/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/XComGameState_LWToolboxOptions.uc
+++ b/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/XComGameState_LWToolboxOptions.uc
@@ -522,11 +522,13 @@ simulated function RegisterListeners()
 	// angle rotation
 	EventManager.RegisterForEvent(ThisObj, 'OverrideCameraRotationAngle', OnGetCameraRotationAngle, ELD_Immediate,,,true);
 
-	// recruit listitem modification
-	EventManager.RegisterForEvent(ThisObj, 'OnRecruitmentListItemInit', AddRecruitStats, ELD_Immediate,,,true);
-	EventManager.RegisterForEvent(ThisObj, 'OnRecruitmentListItemUpdateFocus', UpdateRecruitFocus, ELD_Immediate,,,true);
+	// Recruit list item modification
+	// KDM : These events are no longer needed with our Long War of the Chosen compatible recruit screen, UIRecruitSoldiers_LWOTC.
+	// EventManager.RegisterForEvent(ThisObj, 'OnRecruitmentListItemInit', AddRecruitStats, ELD_Immediate,,,true);
+	// EventManager.RegisterForEvent(ThisObj, 'OnRecruitmentListItemUpdateFocus', UpdateRecruitFocus, ELD_Immediate,,,true);
 }
 
+/* 
 // adds elements to Recruit list items
 static function EventListenerReturn AddRecruitStats(Object EventData, Object EventSource, XComGameState GameState, Name EventID, Object CallbackData)
 {
@@ -549,7 +551,9 @@ static function EventListenerReturn AddRecruitStats(Object EventData, Object Eve
 
 	return ELR_NoInterrupt;
 }
+*/
 
+/*
 // updates recruit list item for focus changes
 static function EventListenerReturn UpdateRecruitFocus(Object EventData, Object EventSource, XComGameState GameState, Name EventID, Object CallbackData)
 {
@@ -565,6 +569,7 @@ static function EventListenerReturn UpdateRecruitFocus(Object EventData, Object 
 
 	return ELR_NoInterrupt;
 }
+*/
 
 //API access for other mods to directly change max squad size
 static function SetMaxSquadSize(int NewSize)


### PR DESCRIPTION
The original Recruit Screen implementation was problematic for several reasons :

1.] When you recruited a soldier from the recruit screen, the screen reverted to its base game 'look'.
2.] Recruit attribute text did not change colour when different recruit rows were selected. This is because, while the screen listener implemented OnReceiveFocus and OnLoseFocus, these were only called when the screen itself received and lost focus; they were not called when individual list items received and lost focus.
3.] When there were many recruits available, the list fell off the recruit panel and wasn't scrollable.

----------------------

Modifies : UIScreenListener_RecruitSoldiers.uc

Makes sure the new Long War of the Chosen recruit screen, UIRecruitSoldiers_LWOTC, is pushed onto the screen stack instead of the base game's recruit screen.

----------------------

Added : UIRecruitSoldiers_LWOTC.uc

A recruitment screen which makes sure Long War of the Chosen recruitment list items, UIRecruitmentListItem_LWOTC, are pushed onto the recruitment list.

----------------------

Added : UIRecruitmentListItem_LWOTC.uc
Commented out code from : UIRecruitmentListItem_LW.uc

UIRecruitmentListItem_LWOTC is a slightly modified version of UIRecruitmentListItem_LW; it makes sure that stat text, within list items, changes colour based upon focus status.

----------------------

Added : X2EventListener_UpdateResources_RecruitScreen.uc

Makes sure that the resource bar, located in the top right corner of the screen, shows supplies and monthly supplies when the new recruitment screen is being displayed.

----------------------

Commented out code from : XComGameState_LWToolboxOptions.uc

Several event related functions are no longer needed with the new recruitment implementation.

----------------------

Modified : XComLW_UI.ini

Added a few config variables which determine recruit stat text size and location.