### PR TITLE
Personnel Screen Scrolling Fix :

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Headquarters.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Headquarters.uc
@@ -37,6 +37,7 @@ static function CHEventListenerTemplate CreateXComHQListeners()
 	Template.AddCHEvent('OverrideScienceScore', OverrideScienceScore, ELD_Immediate, GetListenerPriority());
 	Template.AddCHEvent('CanTechBeInspired', CanTechBeInspired, ELD_Immediate, GetListenerPriority());
 	Template.AddCHEvent('UIAvengerShortcuts_ShowCQResistanceOrders', ShowOrHideResistanceOrdersButton, ELD_Immediate, GetListenerPriority());
+	Template.AddCHEvent('UIPersonnel_OnSortFinished', OnUIPersonnelDataRefreshed, ELD_Immediate, GetListenerPriority());
 
 	Template.RegisterInStrategy = true;
 
@@ -179,6 +180,61 @@ static function EventListenerReturn ShowOrHideResistanceOrdersButton(
 
 	return ELR_NoInterrupt;
 }
+
+static function EventListenerReturn OnUIPersonnelDataRefreshed(
+	Object EventData,
+	Object EventSource,
+	XComGameState GameState,
+	Name EventID,
+	Object CallbackData)
+{
+	local UIList PersonnelList;
+	local UIPersonnel PersonnelScreen;
+	local UIScrollbar Scrollbar;
+	
+	PersonnelScreen = UIPersonnel(EventSource);
+
+	if (PersonnelScreen != none)
+	{
+		PersonnelList = PersonnelScreen.m_kList;
+		if (PersonnelList != none && PersonnelList.GetItemCount() > 1)
+		{
+			Scrollbar = PersonnelList.Scrollbar;
+			if (Scrollbar != none)
+			{
+				// KDM : If the personnel list needs a scrollbar, we know that the total height of the personnel rows
+				// exceeds the height of the personnel list. In this case, we want to make sure that the personnel
+				// list is scrolled to the appropriate location, so we see the selected personnel row.
+				//
+				// Now, when the personnel screen, UIPersonnel, receives focus, its list can potentially re-select a previously
+				// selected personnel row via RefreshData() --> UpdateList(). This behaviour is desirable, as you may have 
+				// chosen to view a particular soldier from the soldier list then cancelled back to the soldier list after 
+				// finishing whatever it was you were doing.
+				
+				// Unfortunately : 
+				// 1.] UIPersonnel's UpdateList() clears the list via ClearItems() which removes, and thus resets, the scrollbar.
+				// BUT
+				// 2.] UIPersonnel's UpdateList() calls SetSelectedIndex() on the list, and SetSelected() on the 
+				// list's navigator; however, neither function modifies the list's scroll position via Scrollbar.SetThumbAtPercent(). 
+				// This is because the only place the scrollbar is manipulated is within UIList's NavigatorSelectionChanged, which 
+				// is called via Navigator.OnSelectedIndexChanged. Navigator.OnSelectedIndexChanged is called in functions like 
+				// Prev(), Next(), SelectFirstAvailable(), and SelectFirstAvailableIfNoCurrentSelection(); however, it is not 
+				// called within SetSelected().
+				//
+				// The end result is that we can have a list item selected, but not be able to see it due to an inappropriate
+				// scrollbar value. Generally speaking, the scrollbar will be scrolled to the top, after being reset, while 
+				// the selected list item will be down below. Consequently, we set the scrollbar value here to make sure we 'see' 
+				// the currently selected list item.
+			 
+				Scrollbar.SetThumbAtPercent(float(PersonnelList.SelectedIndex) 
+					/ float(PersonnelList.GetItemCount() - 1));
+			}
+		}
+	}
+
+	return ELR_NoInterrupt;
+}
+
 
 // Don't give the rewards if the covert action failed.
 static function EventListenerReturn CAPreventRewardOnFailure(


### PR DESCRIPTION
Modifies : X2EventListener_Headquarters
Adds a listener function, OnUIPersonnelDataRefreshed, which listens for the event 'UIPersonnel_OnSortFinished', triggered within UIPersonnel.RefreshData.

The UIPersonnel screen scrolling problem can be seen most clearly via the "View Soldiers" screen while using a controller. If you enter the "View Soldiers" screen, click on a soldier to view their information, then exit back to the "View Soldiers" screen, you may notice that the soldier list item selection remains consistent. In other words, if you click on the list item corresponding to "Doug Smith", "Doug Smith" will still be selected when you return to the "View Soldiers" screen, after viewing his information/customization options/weapon etc.

The problem is that while list item selection remains consistent, the list scroll, required if the number of list items exceeds the height of the list, does not. So when you return to the "View Soldiers" screen, after viewing "Doug Smith's" information, you may not be able to see him any more, despite him still being selected. This is particularly evident in situations when you have, say, a list of 50 or 60 soldiers, and you choose the bottom-most soldier.

The underlying issue is that UIPersonnel's UpdateList function clears its list, thus removing and resetting its scrollbar, but never sets the scrollbar back to the appropriate location. To be more specific, as mentioned in my comments :

"UIPersonnel's UpdateList() calls SetSelectedIndex() on the list, and SetSelected() on the list's navigator; however, neither function modifies the list's scroll position via Scrollbar.SetThumbAtPercent(). This is because the only place the scrollbar is manipulated is within UIList's NavigatorSelectionChanged, which is called via Navigator.OnSelectedIndexChanged. Navigator.OnSelectedIndexChanged is called in functions like  Prev(), Next(), SelectFirstAvailable(), and SelectFirstAvailableIfNoCurrentSelection(); however, it is not called within SetSelected()."

This fix makes sure that the scrollbar, if one exists, is set correctly whenever RefreshData(), and consequently, UpdateList(), are called. This way we can always 'see' the selected list item.