### PR TITLE
Active Soldier list item colour fix

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIPersonnel_SoldierListItem_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIPersonnel_SoldierListItem_LW.uc
@@ -28,7 +28,10 @@ simulated function UIButton SetDisabled(bool disabled, optional string TooltipTe
 {
 	super.SetDisabled(disabled, TooltipText);
 	UpdateDisabled();
-	UpdateItemsForFocus(false);
+	// KDM : Originally, UpdateItemsForFocus was called with the parameter 'false'; however, this was problematic
+	// since ability text colour would no longer depend upon the list item's focus state; it would always 'assume'
+	// it was unfocused. In order to take the list item's focus into account, we need to send in bIsFocused.
+	UpdateItemsForFocus(bIsFocused);
 	return self;
 }
 


### PR DESCRIPTION
This issue is best seen while using a controller; in order to see it do the following :
1.] Go to "View Soldiers".
2.] Click on an active soldier, someone who is infiltrating or is a haven advisor, to view their information.
3.] Exit out of the soldiers information screen back to the "View Soldiers" screen.
4.] The soldiers list item is still selected; however, ability (aim/defense/will ... etc.) text colours are not working properly.

------------------------------

For the following discussion it is important to note that the "View Soldiers" screen is of type UIPersonnel_Armory, which inherits from UIPersonnel.

Now, when UIPersonnel_Armory recieves focus it calls RefreshData() and eventually UpdateList().
1.] UpdateList, within the base class UIPersonnel, places focus on the soldier who was previously selected; consequently, the soldier's list item button is highlighted. So far so good !
2.] After UIPersonnel.UpdateList is finished, UIPersonnel_Armory.UpdateList "Disables any soldiers who are away on Covert Actions" via a call to UnitItem.SetDisabled(true).
3.] Apparently this is an issue for Long War, likely because you still want to be able to view soldiers who are infiltrating/haven advisors; therefore, LW_Overhaul.EnableButtonsForSoldiersOnMissions, via a screen listener, "Re-enables any soldiers who are away on Covert Actions" via a call to UnitItem.SetDisabled(false).

The crux of the problem is this :

When a Long War soldier list item, UIPersonnel_SoldierListItem_LW, receives focus it ends up calling UpdateItemsForFocus(true); this makes sure that ability text colours display in the appropriate colour. If a list item is focused, then we want the text colours to be black, since we don't want their colour to clash with the highlighted background button.

Unforunately, within UIPersonnel_SoldierListItem_LW, the function SetDisabled calls UpdateItemsForFocus(false); it is ALWAYS updating text colour as if the list item focus is "false". Therefore, even if a list item is focused, when SetDisabled is called, text colours are modified as if it is NOT focused.

------------------------------

The solution itself is quite easy. We replace UpdateItemsForFocus(false) with UpdateItemsForFocus(bIsFocused); consequently, list item text colour now takes into account a list item's disabled status AND its focus status.