### PR TITLE
Fix Dark Event Background and Resource Bar

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIAdventOperations_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIAdventOperations_LW.uc
@@ -49,6 +49,14 @@ simulated function BuildScreen( optional bool bAnimateIn = false )
 	// many active or pending dark events there are.
 	MC.FunctionNum("SetNumCards", 3);
 	RefreshNav();
+
+	// KDM : Previously, the flash call to AnimateIn had been commented out by Long War; however,
+	// this created a situation in which 2 flash elements, bottomShadow and hexBackground, were never
+	// made visible on the Dark Events screen.
+	if (bAnimateIn)
+	{ 
+		MC.FunctionVoid("AnimateIn");
+	}
 }
 
 // Returns the number of events in the list (whether it's the active or pending one)
@@ -250,8 +258,11 @@ simulated function BuildDarkEventPanel(int Index, bool bActiveDarkEvent)
 
 simulated function OnRevealClicked(int idx)
 {
-	local UIList DarkEventList;
 	local UIDarkEventListItem ListItem;
+	local UIList DarkEventList;
+	local XComHQPresentationLayer HQPres;
+
+	HQPres = `HQPRES;
 
 	DarkEventList = UIList(GetChildByName('DarkEventScrollableList_LW', false));
 	if (DarkEventList == none)
@@ -269,4 +280,8 @@ simulated function OnRevealClicked(int idx)
 	ListItem.DarkEventRef = ChosenDarkEvents[idx];
 	ListItem.Update();
 	ListItem.Show();
+
+	// KDM : If a dark event has been revealed, intel has been used; therefore, update
+	// the resource bar.
+	HQPres.m_kAvengerHUD.UpdateResources();
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Headquarters.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Headquarters.uc
@@ -313,14 +313,29 @@ static function EventListenerReturn OnUpdateResources_LW(Object EventData, Objec
 
 	HQPres = `HQPRES;
 
-	// KDM : If we are viewing the 'fixed' recruit screen, UIRecruitSoldiers_LW, or any other subclass of UIRecruitSoldiers,
-	// the resource display will not work as UIAvengerHUD only looks for the base screen, UIRecruitSoldiers. Therefore, 
-	// we need to set up the resource display ourself.
-	if (HQPres.ScreenStack.IsCurrentClass(class'UIRecruitSoldiers'))
+	// KDM : If we are viewing the 'fixed' recruit screen, UIRecruitSoldiers_LW, or any subclass of 
+	// UIRecruitSoldiers, the resource display will not work as UIAvengerHUD only looks for the base screen, 
+	// UIRecruitSoldiers. Therefore, we need to set up the resource display ourself.
+	//
+	// Note : We do not want to run this code if the screen we are looking at is of type UIRecruitSoldiers
+	// since it has already been dealt with in UIAvengerHUD, and this would display double.
+	if (HQPres.ScreenStack.IsCurrentClass(class'UIRecruitSoldiers') && 
+		!(HQPres.ScreenStack.GetCurrentClass() == class'UIRecruitSoldiers'))
 	{
 		// KDM : Display the same information a normal Recruit Screen would show.
 		HQPres.m_kAvengerHUD.UpdateMonthlySupplies();
 		HQPres.m_kAvengerHUD.UpdateSupplies();
+		HQPres.m_kAvengerHUD.ShowResources();
+	}
+	// KDM : If we are viewing the Long War Dark Event screen, UIAdventOperations_LW, or any subclass
+	// of UIAdventOperations, make sure the resource bar displays properly.
+	else if (HQPres.ScreenStack.IsCurrentClass(class'UIAdventOperations') && 
+		!(HQPres.ScreenStack.GetCurrentClass() == class'UIAdventOperations'))
+	{
+		// KDM : Display the same information a normal Dark Event Screen would show.
+		HQPres.m_kAvengerHUD.UpdateMonthlySupplies();
+		HQPres.m_kAvengerHUD.UpdateSupplies();
+		HQPres.m_kAvengerHUD.UpdateIntel();
 		HQPres.m_kAvengerHUD.ShowResources();
 	}
 


### PR DESCRIPTION
Problem 1 : The Dark Event background does not appear.
Modifies : UIAdventOperations_LW.BuildScreen

The Long War 2 Dark Events screen, UIAdventOperations_LW, is derived from the class UIAdventOperations; this class makes use of the graphics/flash package : gfxDarkEvents.upk. When looking at the flash code, it becomes apparent that 2 graphical elements, bottomShadow and hexBackground, are only made visible through the function AnimateIn(). Unfortunately, Long War had originally commented out this code, which was called within the UnrealScript function BuildScreen. Additionally, I subsequently removed this commented out code. Therefore, these flash elements were no longer being shown.

Adding the call to AnimateIn(), via MC.FunctionVoid("AnimateIn"), fixes this issue.

------------------------------

Problem 2 : The Dark Event resource bar doesn't appear
Modifies : X2EventListener_Headquarters.OnUpdateResources_LW

This is a common problem in various areas. UIAvengerHUD.UpdateResources shows the resource bar, with the appropriate resources, according to the screen being shown; unfortunately, it does not take subclasses into account. In this particular case, it looks for UIAdventOperations, but not the Long War subclass UIAdventOperations_LW. Consequently, an event listener needed to be set up to show the monthly supplies, supplies, and intel, just like in the base game.

------------------------------

Fixes X2EventListener_Headquarters.OnUpdateResources_LW logic

X2EventListener_Headquarters.OnUpdateResources_LW has been modified such that its code only runs if 'subclasses' are on top of the screen stack. This is because if, for some reason, this code is run on the base Recruit Screen, or base Dark Event Screen, we will see double resources since UIAvengerHUD.UpdateResources has already dealt with the resource bar.

------------------------------

Modifies : UIAdventOperations_LW.OnRevealClicked

When a dark event is revealed, intel has been used to do so; consequently, a call to UIAvegerHUD's UpdateResources is now made. This updates the resource bar which is now visible on the dark event screen.