### PR TITLE
Allow usage of 'Squad Management For LWotC' mod

### DIFF
--- a/LongWarOfTheChosen/Src/LWUtilities/Classes/Helpers_LW.uc
+++ b/LongWarOfTheChosen/Src/LWUtilities/Classes/Helpers_LW.uc
@@ -725,6 +725,34 @@ static function bool CovertActionHasReward(XComGameState_CovertAction ActionStat
 	}
 }
 
+// KDM : Determines if a screen of type UIPersonnel_SquadBarracks_ForControllers is on the screen stack.
+// The screen is checked by name so that my controller-capable Squad Management system, whose chief class 
+// derives from UIPersonnel rather than UIPersonnel_SquadBarracks, can exist as a separate mod.
+static function bool ControllerCapableSquadBarracksIsOnStack()
+{
+	return (`ISCONTROLLERACTIVE && (GetFirstScreenByName('UIPersonnel_SquadBarracks_ForControllers') != none));
+}
+
+// KDM : Returns the first screen, on the screen stack, with a class name of ScreenType.
+// If no such screen exists, returns none.
+static function UIScreen GetFirstScreenByName(name ScreenType)
+{
+	local int i;
+	local UIScreenStack ScreenStack;
+	
+	ScreenStack = `SCREENSTACK;
+	
+	for (i = 0; i < ScreenStack.Screens.Length; i++)
+	{
+		if (ScreenStack.Screens[i].IsA(ScreenType))
+		{
+			return ScreenStack.Screens[i];
+		}
+	}
+	
+	return none; 
+}
+
 defaultproperties
 {
 	CA_FAILURE_RISK_MARKER="CovertActionRisk_Failure"

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
@@ -250,7 +250,10 @@ static protected function EventListenerReturn OnOverridePersonnelStatus(Object E
 			}
 		}
 	}
-	else if (GetScreenOrChild('UIPersonnel_SquadBarracks') == none)
+	// KDM : Only override the personnel status string if we are dealing with neither the
+	// Squad Management screen, nor the controller-capable Squad Management screen.
+	else if (GetScreenOrChild('UIPersonnel_SquadBarracks') == none &&
+		!class'Helpers_LW'.static.ControllerCapableSquadBarracksIsOnStack())
 	{
 		if (`XCOMHQ.IsUnitInSquad(UnitState.GetReference()) && GetScreenOrChild('UISquadSelect') != none)
 		{

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWSquadManager.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWSquadManager.uc
@@ -145,7 +145,11 @@ simulated function GoToSquadManagement(optional StateObjectReference Facility)
     SubMenu.Message.Label = LabelBarracks_SquadManagement;
     Shortcuts.UpdateSubMenu(eUIAvengerShortcutCat_Barracks, SubMenu);
 
-	if (HQPres.ScreenStack.IsNotInStack(class'UIPersonnel_SquadBarracks'))
+	// KDM : If the 'Squad Management' Avenger button is clicked and neither the Squad Management screen,
+	// nor the controller-capable Squad Management screen is on the screen stack, then push the Squad
+	// Management screen onto the stack.
+	if (HQPres.ScreenStack.IsNotInStack(class'UIPersonnel_SquadBarracks') &&
+		!class'Helpers_LW'.static.ControllerCapableSquadBarracksIsOnStack())
 	{
 		kPersonnelList = HQPres.Spawn(class'UIPersonnel_SquadBarracks', HQPres);
 		kPersonnelList.onSelectedDelegate = OnPersonnelSelected;


### PR DESCRIPTION
Provides the code necessary for my mod, 'Squad Management For LWotC' - https://steamcommunity.com/sharedfiles/filedetails/?id=2314584410, to be used with LWotC. This mod provides an entirely new interface to the Squad Management system for controller users.

**I'm keeping the mod separate for several reasons.**
1.] I want to keep complete control of the code right now so I can change/modify it whenever I find an issue or something I want to change.
2.] It is large, and fairly complicated; although I have done a bunch of testing, there are no guarantees that it is devoid of bugs.

------------------------------

Modifies : Helpers_LW
Adds GetFirstScreenByName and ControllerCapableSquadBarracksIsOnStack

Helper functions used to determine if the controller-capable Squad Management screen is on the screen stack; this is necessary since my main controller-capable screen class inherits from the base UIPersonnel, rather than LW's UIPersonnel_SquadBarracks. I didn't want to inherit from UIPersonnel_SquadBarracks because I wanted to start with a clean slate for an entirely new interface.

The function GetFirstScreenByName allows the screen stack to be checked by name so neither the 'Squad Management For LWotC' mod, nor its classes/code, need to be integrated into LWotC.

------------------------------

Modifies : X2EventListener_Soldiers.OnOverridePersonnelStatus

Formerly, if the Squad Management screen was being looked at, the personnel status string would not be manipulated under various circumstances.
Now, if the Squad Management screen or the controller-capable Squad Management screen are being looked at, the personnel status string will not be manipulated under various circumstances.

------------------------------

Modifies : XComGameState_LWSquadManager.GoToSquadManagement

Makes sure that, when the Squad Management Avenger button is pressed, a Squad Management screen is pushed onto the screen stack if and only if there is no (base or controller-capable) Squad Management screen currently on the stack.

------------------------------

Modifies : UIScreenListener_SquadSelect_LW.OnInit

1.] Removes the 'Infiltration Help' button if the controller is active since it can't be clicked.
2.] Hides the 'Save Squad' button if a controller is active; I don't think this functionality worked anyways.
3.] Only creates a SquadContainer, on the Squad Select screen, if a controller is not active; the controller-capable Squad Management system creates its own container.