### PR TITLE
Allow Contacted Haven Cycling with Controller

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_UI.ini
+++ b/LongWarOfTheChosen/Config/XComLW_UI.ini
@@ -79,3 +79,6 @@ RECRUIT_FONT_SIZE_CTRL = 22					; Recruit screen font size for controller users.
 RECRUIT_Y_OFFSET_CTRL = -3					; Moves the stats up/down; negative numbers move up / positive numbers move down.
 RECRUIT_FONT_SIZE_MK = 20					; Recruit screen font size for mouse & keyboard users.
 RECRUIT_Y_OFFSET_MK = -2;					; Moves the stats up/down; negative numbers move up / positive numbers move down.
+
+[LW_Overhaul.UIScreenListener_UIStrategyMap]
+CYCLE_HAVENS_INSTANTLY = false				; When controller users cycle 'contacted' havens with the DPad, do we want the strategy map movement to be instantaneous or with acceleration/deceleration ?

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_UIStrategyMap.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_UIStrategyMap.uc
@@ -1,10 +1,12 @@
 //---------------------------------------------------------------------------------------
 //	FILE:		UIScreenListener_UIStrategyMap
 //	AUTHOR:		KDM
-//	PURPOSE:	Allow controller users to bring up the Resistance overview screen from the strategy map
+//	PURPOSE:	Provides additional functionality, on the strategy map, for controller users.
 //---------------------------------------------------------------------------------------
 
-class UIScreenListener_UIStrategyMap extends UIScreenListener;
+class UIScreenListener_UIStrategyMap extends UIScreenListener config(LW_UI);
+
+var config bool CYCLE_HAVENS_INSTANTLY;
 
 event OnInit(UIScreen Screen)
 {
@@ -28,12 +30,19 @@ simulated protected function bool OnUIStrategyMapCommand(UIScreen Screen, int cm
 {
 	local bool bHandled;
 	local UIResistanceManagement_LW ResistanceOverviewScreen;
-	local UIStrategyMap StrategyMapScreen;
+	local UIStrategyMap StrategyMap;
 	local UIStrategyMapItem_Region_LW SelectedRegionMapItem;
 	local XComHQPresentationLayer HQPres;
 
-	HQPres = `HQPRES;
 	bHandled = true;
+	HQPres = `HQPRES;
+	StrategyMap = UIStrategyMap(Screen);
+
+	// XCom : No input during flight mode.
+	if (StrategyMap.IsInFlightMode())
+	{
+		return true;
+	}
 
 	if (!Screen.CheckInputIsReleaseOrDirectionRepeat(cmd, arg))
 	{
@@ -49,8 +58,7 @@ simulated protected function bool OnUIStrategyMapCommand(UIScreen Screen, int cm
 		// This needs to be done because the highlander deals with input before UIStrategyMap gets a chance; however, if a haven is selected,
 		// we want the input piped through UIStrategyMap down to the selected haven map item.
 		case class'UIUtilities_Input'.const.FXS_BUTTON_X:
-			StrategyMapScreen = UIStrategyMap(Screen);
-			SelectedRegionMapItem = UIStrategyMapItem_Region_LW(StrategyMapScreen.SelectedMapItem);
+			SelectedRegionMapItem = UIStrategyMapItem_Region_LW(StrategyMap.SelectedMapItem);
 			if (SelectedRegionMapItem != none && SelectedRegionMapItem.OutpostButton.bIsVisible)
 			{
 				// KDM : Make sure OnUnrealCommand() is called on the strategy map, which will then forward it onto the selected haven map item.
@@ -67,6 +75,16 @@ simulated protected function bool OnUIStrategyMapCommand(UIScreen Screen, int cm
 			}
 			break;
 
+		// KDM : DPad left cycles through 'contacted' havens/regions on the strategy map.
+		case class'UIUtilities_Input'.const.FXS_DPAD_LEFT:
+			CycleSelectedHaven(StrategyMap, true);
+			break;
+
+		// KDM : DPad right cycles through 'contacted' havens/regions on the strategy map.
+		case class'UIUtilities_Input'.const.FXS_DPAD_RIGHT:
+			CycleSelectedHaven(StrategyMap, false);
+			break;
+
 		default:
 			bHandled = false;
 			break;
@@ -75,8 +93,123 @@ simulated protected function bool OnUIStrategyMapCommand(UIScreen Screen, int cm
 	return bHandled;
 }
 
+simulated function CycleSelectedHaven(UIStrategyMap StrategyMap, bool CyclePrevious)
+{
+	local int i, SelectedMapItemIndex;
+	local array<UIStrategyMapItem_Region> RegionMapItems;
+	local UIStrategyMapItem_Region RegionMapItem, SelectedMapItem;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_LWOutpost OutpostState;
+	local XComGameState_WorldRegion RegionState;
+	local XComGameStateHistory History;
+	
+	History = `XCOMHISTORY;
+	XComHQ = StrategyMap.XCOMHQ();
+
+	// KDM : SelectedMapItem will be 'none' if either:
+	// 1.] There is currently no selected map item on the strategy map. 
+	// 2.] The currently selected map item, on the strategy map, is not a 'region' map item.
+	SelectedMapItem = UIStrategyMapItem_Region(StrategyMap.SelectedMapItem);
+
+	// KDM : If a haven/region is not currently selected, just select the starting haven/region.
+	if (SelectedMapItem == none)
+	{
+		RegionState = XComGameState_WorldRegion(History.GetGameStateForObjectID(XComHQ.StartingRegion.ObjectID));
+		RegionMapItem = UIStrategyMapItem_Region(StrategyMap.GetMapItem(RegionState));
+	}
+	else
+	{
+		i = 0;
+		SelectedMapItemIndex = -1;
+		foreach History.IterateByClassType(class'XComGameState_LWOutpost', OutpostState)
+		{
+			RegionState = XComGameState_WorldRegion(History.GetGameStateForObjectID(OutpostState.Region.ObjectID));
+			// KDM : We only want to select from havens/regions which have been 'contacted'.
+			if (RegionState.HaveMadeContact())
+			{
+				RegionMapItem = UIStrategyMapItem_Region(StrategyMap.GetMapItem(RegionState));
+				RegionMapItems.AddItem(RegionMapItem);
+				
+				// KDM : If we find our currently selected haven/region, store this information; it will be 
+				// needed in a bit.
+				if (RegionMapItem == SelectedMapItem)
+				{
+					SelectedMapItemIndex = i;
+				}
+				i++;
+			}
+		}
+
+		// KDM : No 'contacted' region map items existed; this should never happen !
+		if (RegionMapItems.Length == 0)
+		{
+			`log("KDM ERROR : UIScreenListener_UIStrategyMap.CycleSelectedHaven : No region map items found !");
+			return;
+		}
+		// KDM : If only 1 'contacted' region map item exists, or if the selected region map item corresponds
+		// to an 'uncontacted' region, just select the starting haven/region.
+		else if (RegionMapItems.Length == 1 || SelectedMapItemIndex == -1)
+		{
+			RegionState = XComGameState_WorldRegion(History.GetGameStateForObjectID(XComHQ.StartingRegion.ObjectID));
+			RegionMapItem = UIStrategyMapItem_Region(StrategyMap.GetMapItem(RegionState));
+		}
+		else
+		{
+			// KDM : Cycle from right to left array-wise; if we are already at the start
+			// of the array then loop back around to the back of the array.
+			if (CyclePrevious)
+			{
+				if (SelectedMapItemIndex == 0)
+				{
+					RegionMapItem = RegionMapItems[RegionMapItems.Length - 1];
+				}
+				else
+				{
+					RegionMapItem = RegionMapItems[SelectedMapItemIndex - 1];
+				}
+			}
+			// KDM : Cycle from left to right array-wise; if we are already at the end
+			// of the array then loop around to the front of the array.
+			else
+			{
+				if (SelectedMapItemIndex == RegionMapItems.Length - 1)
+				{
+					RegionMapItem = RegionMapItems[0];
+				}
+				else
+				{
+					RegionMapItem = RegionMapItems[SelectedMapItemIndex + 1];
+				}
+			}
+		}
+	}
+
+	if (RegionMapItem != none)
+	{
+		// KDM : As per XComGameState_HeadquartersXCom.SetPendingPointOfTravel, we will set LastSelectedMapItem to
+		// our chosen region map item then select it; apparently, according to XCom comments, this makes 
+		// sure certain issues don't arise.
+		//
+		// The code below is a slight modification of that found in UIStrategyMap.SelectLastSelectedMapItem.
+		
+		StrategyMap.LastSelectedMapItem = RegionMapItem;
+		if (CYCLE_HAVENS_INSTANTLY)
+		{
+			// KDM : Move to the 'newly selected' region map item instantly.
+			`EARTH.SetViewLocation(StrategyMap.LastSelectedMapItem.Cached2DWorldLocation);
+		}
+		else
+		{
+			// KDM : Move to the 'newly selected' map item with acceleration/deceleration.
+			XComHQPresentationLayer(StrategyMap.Movie.Pres).CAMLookAtEarth(StrategyMap.LastSelectedMapItem.Cached2DWorldLocation);
+		}
+		StrategyMap.SetSelectedMapItem(StrategyMap.LastSelectedMapItem);
+		StrategyMap.HideTooltip();
+		StrategyMap.LastSelectedMapItem = none;
+	}
+}
+
 defaultProperties
 {
 	ScreenClass = UIStrategyMap;
 }
-


### PR DESCRIPTION
Modifies : UIScreenListener_UIStrategyMap.uc

Controller users can now cycle through 'contacted' havens/regions on the strategy map using DPad left and DPad right. The following rules are followed :
1.] If a 'contacted' region is currently not selected, then a DPad press will select the starting region.
2.] If a 'contacted' region is currently selected, then DPad left will cycle 'contacted' regions from right to left. Although there is no way to define which regions are to the left/right of others, since this is based upon XComGameStateHistory's storage of outposts, selection order always remains consistent. During testing, this seemed to be a completely acceptable limitation, as map items can be cycled through quite quickly.
3.] If a 'contacted' region is currently selected, then DPad right will cycle 'contacted' regions from left to right.

------------------------------

Modifies XComLW_UI.ini

Adds a config variable, CYCLE_HAVENS_INSTANTLY, which allows you to determine if haven cycling should be instantaneous or with acceleration/deceleration. The latter is the default option, as instantaneous movement, while much faster, can look a tad jarring.

------------------------------

Fix in : UIScreenListener_UIStrategyMap.uc

All controller button presses are now ignored if the Avenger is in flight mode; this is consistant with default XCom 2 code.