### PR TITLE
Config option to disable other mods' GTS upgrades

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1267,6 +1267,9 @@ AutopsyAdventPsiWitchIntelCost=0
 +GTSTable=(GTSProjectTemplateName="SquadSizeIIUnlock",			SupplyCost=75,	RankRequired=8,		HideIfInsufficientRank=true,	UniqueClass="Ranger");
 +GTSTable=(GTSProjectTemplateName="FNGUnlock",					SupplyCost=375,	RankRequired=9,		HideIfInsufficientRank=true,	UniqueClass="Ranger");
 
+; This option will let you disable and hide GTS unlocks from other mods.
+;+GTSUnlocksToRemove=""
+
 ; GTS edits
 +GTSTable=(GTSProjectTemplateName="VengeanceUnlock",			SupplyCost=25,	RankRequired=0,		HideIfInsufficientRank=false,	UniqueClass="");
 +GTSTable=(GTSProjectTemplateName="WetWorkUnlock",				SupplyCost=75,	RankRequired=2,		HideIfInsufficientRank=false,	UniqueClass="");

--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1268,7 +1268,7 @@ AutopsyAdventPsiWitchIntelCost=0
 +GTSTable=(GTSProjectTemplateName="FNGUnlock",					SupplyCost=375,	RankRequired=9,		HideIfInsufficientRank=true,	UniqueClass="Ranger");
 
 ; This option will let you disable and hide GTS unlocks from other mods.
-;+GTSUnlocksToRemove=""
+;+GTSUnlocksToRemove="SquadSizeIUnlock"
 
 ; GTS edits
 +GTSTable=(GTSProjectTemplateName="VengeanceUnlock",			SupplyCost=25,	RankRequired=0,		HideIfInsufficientRank=false,	UniqueClass="");

--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1267,8 +1267,16 @@ AutopsyAdventPsiWitchIntelCost=0
 +GTSTable=(GTSProjectTemplateName="SquadSizeIIUnlock",			SupplyCost=75,	RankRequired=8,		HideIfInsufficientRank=true,	UniqueClass="Ranger");
 +GTSTable=(GTSProjectTemplateName="FNGUnlock",					SupplyCost=375,	RankRequired=9,		HideIfInsufficientRank=true,	UniqueClass="Ranger");
 
-; This option will let you disable and hide GTS unlocks from other mods.
-;+GTSUnlocksToRemove="SquadSizeIUnlock"
+; This option will let you disable and hide GTS unlocks, including those from other mods.
++GTSUnlocksToRemove="SquadSizeIUnlock"
++GTSUnlocksToRemove="SquadSizeIIUnlock"
++GTSUnlocksToRemove="HuntersInstinctUnlock"
++GTSUnlocksToRemove="HitWhereItHurtsUnlock"
++GTSUnlocksToRemove="CoolUnderPressureUnlock"
++GTSUnlocksToRemove="BiggestBoomsUnlock"
++GTSUnlocksToRemove="MeditationPreparationUnlock"
++GTSUnlocksToRemove="ParkourUnlock"
++GTSUnlocksToRemove="InfiltrationUnlock"
 
 ; GTS edits
 +GTSTable=(GTSProjectTemplateName="VengeanceUnlock",			SupplyCost=25,	RankRequired=0,		HideIfInsufficientRank=false,	UniqueClass="");

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -3472,15 +3472,6 @@ function ReconfigFacilities(X2StrategyElementTemplate Template, int Difficulty)
 	{
 		if (FacilityTemplate.DataName == 'OfficerTrainingSchool')
 		{
-			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('HuntersInstinctUnlock');
-			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('HitWhereItHurtsUnlock');
-			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('CoolUnderPressureUnlock');
-			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('BiggestBoomsUnlock');
-			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('SquadSizeIUnlock');
-			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('SquadSizeIIUnlock');
-			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('MeditationPreparationUnlock');
-			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('ParkourUnlock');
-			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('InfiltrationUnlock');
 			for (i = 0 ; i < default.GTSUnlocksToRemove.length ; i++)
 			{
     			FacilityTemplate.SoldierUnlockTemplates.RemoveItem(default.GTSUnlocksToRemove[i]);

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -3472,7 +3472,7 @@ function ReconfigFacilities(X2StrategyElementTemplate Template, int Difficulty)
 	{
 		if (FacilityTemplate.DataName == 'OfficerTrainingSchool')
 		{
-			for (i = 0 ; i < default.GTSUnlocksToRemove.length ; i++)
+			for (i = 0 ; i < default.GTSUnlocksToRemove.Length ; i++)
 			{
     			FacilityTemplate.SoldierUnlockTemplates.RemoveItem(default.GTSUnlocksToRemove[i]);
 			}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -3481,7 +3481,10 @@ function ReconfigFacilities(X2StrategyElementTemplate Template, int Difficulty)
 			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('MeditationPreparationUnlock');
 			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('ParkourUnlock');
 			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('InfiltrationUnlock');
-			FacilityTemplate.SoldierUnlockTemplates.RemoveItem(default.GTSUnlocksToRemove);
+			for (i = 0 ; i < default.GTSUnlocksToRemove.length ; i++)
+			{
+    			FacilityTemplate.SoldierUnlockTemplates.RemoveItem(default.GTSUnlocksToRemove[i]);
+			}
 			FacilityTemplate.SoldierUnlockTemplates.AddItem('VultureUnlock');
 			FacilityTemplate.SoldierUnlockTemplates.AddItem('VengeanceUnlock');
 			FacilityTemplate.SoldierUnlockTemplates.AddItem('WetWorkUnlock');

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -223,6 +223,8 @@ var config array<GTSTableEntry> GTSTable;
 var config array<FacilityTableEntry> FacilityTable;
 var config array<FacilityUpgradeTableEntry> FacilityUpgradeTable;
 
+var config array<name> GTSUnlocksToRemove;
+
 var config int ResistanceCommunicationsIntelCost;
 var config int ResistanceRadioIntelCost;
 var config int AlienEncryptionIntelCost;
@@ -3479,6 +3481,7 @@ function ReconfigFacilities(X2StrategyElementTemplate Template, int Difficulty)
 			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('MeditationPreparationUnlock');
 			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('ParkourUnlock');
 			FacilityTemplate.SoldierUnlockTemplates.RemoveItem('InfiltrationUnlock');
+			FacilityTemplate.SoldierUnlockTemplates.RemoveItem(default.GTSUnlocksToRemove);
 			FacilityTemplate.SoldierUnlockTemplates.AddItem('VultureUnlock');
 			FacilityTemplate.SoldierUnlockTemplates.AddItem('VengeanceUnlock');
 			FacilityTemplate.SoldierUnlockTemplates.AddItem('WetWorkUnlock');


### PR DESCRIPTION
This is so users can add GTS upgrades from other class mods to be disabled and hidden for the sake of consistency.