### PR TITLE
Alien Overwatch AI

### DIFF
--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -1158,7 +1158,8 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 ; AvoidDoubleMove - Conditions for which we should try to avoid double moving, and instead overwatch.
 ; Currently: If we can see any enemies, it's preferable to OW instead of taking a second move. This avoids enemies move/OWing instead of
 ; trying to catch up to XCOM when they're being outrun.
-+Behaviors=(BehaviorName=AvoidDoubleMove, NodeType=Selector, Child[0]=AnyLivingEnemyVisible)
+; Also aggressively overwatch with last action instead of double move if near evac
++Behaviors=(BehaviorName=AvoidDoubleMove, NodeType=Selector, Child[0]=AnyLivingEnemyVisible, Child[1]=EvacWithinVisRange)
 
 ; TryOverwatchLastAction - If this is the last action and we're in double-move avoidance mode, overwatch if it is available.
 +Behaviors=(BehaviorName=TryOverwatchLastAction, NodeType=Sequence, Child[0]=IsLastActionPoint, Child[1]=AvoidDoubleMove, Child[2]=TryOverwatch)
@@ -1271,6 +1272,8 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 -Behaviors=(BehaviorName=FirstTurnMoveForPriorityHarborWave, NodeType=Sequence, Child[0]=NotLastActionPoint, Child[1]=ChosenSafeToMove, Child[2]=IsAbilityAvailable-StandardMove, Child[3]=FindMultiTargetDestination-HarborWavePrefTargetProfile, Child[4]=SelectAbility-StandardMove, Child[5]=SSSetPreselectedAbility-HarborWave)
 +Behaviors=(BehaviorName=FirstTurnMoveForPriorityHarborWave, NodeType=Sequence, Child[0]=IsAbilityAvailable-HarborWave, Child[1]=NotLastActionPoint, Child[2]=ChosenSafeToMove, Child[3]=IsAbilityAvailable-StandardMove, Child[4]=FindMultiTargetDestination-HarborWavePrefTargetProfile, Child[5]=SelectAbility-StandardMove, Child[6]=SSSetPreselectedAbility-HarborWave)
 
+-Behaviors=(BehaviorName=TryPartingSilk, NodeType=Sequence, Child[0]=IsAbilityAvailable-PartingSilk, Child[1]=ChosenSafeToMove, Child[2]=FindPartingSilkTarget, Child[3]=SelectAbility-PartingSilk, Child[4]=DisableExtractThisTurn)
++Behaviors=(BehaviorName=TryPartingSilk, NodeType=Sequence, Child[0]=IsAbilityAvailable-PartingSilk, Child[1]=FindPartingSilkTarget, Child[2]=SelectAbility-PartingSilk)
 
 +Behaviors=(BehaviorName="ChosenAssassinFirstActionSelector", NodeType=Selector, \\
 			Child[0]=TryGrenade, \\
@@ -1502,6 +1505,23 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 +Behaviors=(BehaviorName=PrimeFallBackUnsafe, NodeType=Sequence, Child[0]=IsAbilityAvailable-StandardMove, Child[1]=ResetDestinationSearch, Child[2]=FindBestPrimeFallbackDestination, Child[3]=SelectAbility-StandardMove)
 +Behaviors=(BehaviorName=FindBestPrimeFallbackDestination, NodeType=Selector, Child[0]=FindDestination-ChosenPrimeFallback, Child[1]=FindDestination-MWP_FallBack, Child[2]=FindDestination-MWP_Defensive)
 +Behaviors=(BehaviorName=FindDestination-ChosenPrimeFallback, NodeType=Action)
+
+; Allow ChosenSafeToMove to recognize new overwatch counter strengths
+-Behaviors=(BehaviorName=UpdateChosenOverwatchEffectVar, NodeType=Selector, \\
+	Child[0]=ChosenOverwatch_HasShadowstep, \\
+	Child[1]=ChosenOverwatch_HasOverwatchersLowHealth, \\
+	Child[2]=ChosenOverwatch_MultipleOverwatchers, \\
+	Child[3]=ChosenOverwatch_SingleOverwatcher, \\
+	Child[4]=SetChosenOverwatchEffectNormal )
++Behaviors=(BehaviorName=UpdateChosenOverwatchEffectVar, NodeType=Selector, \\
+	Child[0]=ChosenOverwatch_HasOverwatchCounter, \\
+	Child[1]=ChosenOverwatch_HasOverwatchersLowHealth, \\
+	Child[2]=ChosenOverwatch_MultipleOverwatchers, \\
+	Child[3]=ChosenOverwatch_SingleOverwatcher, \\
+	Child[4]=SetChosenOverwatchEffectNormal )
++Behaviors=(BehaviorName=ChosenOverwatch_HasOverwatchCounter, NodeType=Sequence, Child[0]=HasOverwatchCounter, Child[1]=SetChosenOverwatchEffectNormal)
++Behaviors=(BehaviorName=HasOverwatchCounter, NodeType=Selector, Child[0]=AffectedByEffect-Shadowstep, Child[1]=AffectedByEffect-LightningReflexes_LW)
++Behaviors=(BehaviorName=AffectedByEffect-LightningReflexes_LW, NodeType=Condition)
 
 ;------------------
 ;Civvies


### PR DESCRIPTION
* Removed ChosenSafeToMove from TryPartingSilk as Grobobobo suggests, as testing revealed that overwatches had significant chance of preventing guaranteed melee attack. Also removed outdated and unnecessary DisableExtractThisTurn child.

* Allowed ChosenSafeToMove to recognize LightningReflexes_LW as well, instead of only Shadowstep.

* EvacWithinVisRange added to AvoidDoubleMove.
When trying to sneak a unit to evac near activated enemies, completely breaking line of sight is extremely effective as no enemy visibility makes ConsiderTakingOverwatchEvac check fail; all enemies will choose to double move instead of overwatching near evac.
Added EvacWithinVisRange check to LW2 AvoidDoubleMove behavior, so enemy near evac knows to overwatch with their last action to prevent escape, even when they do not have enemy visibility on their current position.
AvoidDoubleMove is last child called by TryOverwatchLastAction, which is the last child of TryShootOrReloadOrOverwatch. This therefore have no impact during active engagement and only serves as counter to stealth strategy.