### PR TITLE
Add compatibility with extra inventory slots

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
@@ -955,7 +955,6 @@ static function OnLoadoutLocked(UIButton kButton)
 	CannotEditSlots.AddItem(eInvSlot_Utility);
 	CannotEditSlots.AddItem(eInvSlot_Armor);
 	CannotEditSlots.AddItem(eInvSlot_GrenadePocket);
-	CannotEditSlots.AddItem(eInvSlot_GrenadePocket);
 	CannotEditSlots.AddItem(eInvSlot_PrimaryWeapon);
 	CannotEditSlots.AddItem(eInvSlot_SecondaryWeapon);
 	CannotEditSlots.AddItem(eInvSlot_HeavyWeapon);
@@ -966,6 +965,10 @@ static function OnLoadoutLocked(UIButton kButton)
 	CannotEditSlots.AddItem(eInvSlot_SeptenaryWeapon);
 	CannotEditSlots.AddItem(eInvSlot_AmmoPocket);
 	CannotEditSlots.AddItem(eInvSlot_Pistol);
+	CannotEditSlots.AddItem(eInvSlot_AuxiliaryWeapon);
+	CannotEditSlots.AddItem(eInvSlot_SparkGrenadePocket);
+	CannotEditSlots.AddItem(eInvSlot_ExtraBackpack);
+	CannotEditSlots.AddItem(eInvSlot_PsiAmp);
 
 	MainMenu = UIArmory_MainMenu(GetScreenOrChild('UIArmory_MainMenu'));
 	if (MainMenu == none) { return; }


### PR DESCRIPTION
This will add compatibility for Spark Arsenal's Auxiliary Slot, Spark Grenade Slot, and BIT Heavy Weapon Slot, as well as Psionics Overhaul V3's Psi Amp Slot, so that none of those equipment slots can be messed with on a soldier that's infiltrating. I also removed the duplicate GrenadePocket line because it doesn't really need to be there.