### PR TITLE
Fix Controller Tactical Ability Selection + Add Commander Range function

### DIFF
--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIScreenListener_TacticalHUD_LWOfficerPack.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UIScreenListener_TacticalHUD_LWOfficerPack.uc
@@ -1,70 +1,98 @@
 //---------------------------------------------------------------------------------------
 //  FILE:    UIScreenListener_TacticalHUD_LWOfficerPack
 //  AUTHOR:  Amineri (Pavonis Interactive)
-//
 //  PURPOSE: Adds button to toggle officer command range preview
-//
 //--------------------------------------------------------------------------------------- 
 
 class UIScreenListener_TacticalHUD_LWOfficerPack extends UIScreenListener;
 
-// This event is triggered after a screen is initialized
 event OnInit(UIScreen Screen)
 {
 	local UITacticalHUD HUDScreen;
-
-	`log("Starting TacticalHUD Listener OnInit");
-
-	if(Screen == none)
-	{
-		`RedScreen("UITacticalHUD ScreenListener: Screen == none");
-		return;
-	}
+	
 	HUDScreen = UITacticalHUD(Screen);
-	if(HUDScreen == none)
+	
+	if (HUDScreen == none)
 	{
 		`RedScreen("UITacticalHUD ScreenListener: HUDScreen == none");
 		return;
 	}
+
 	UpdateMouseControls(HUDScreen);
-
-	//Not working because can't create new archetype in UnrealEd
-	// now spawn the CommandRange Actor, passing in the Archetype reference as the template
-	//CRActor = ParentScreen.Spawn(class'LWCommandRange_Actor', ParentScreen, 'CommandRange',,,CRTemplate);
-
 	class'LWOfficerUtilities'.static.GCandValidationChecks();
+	`SCREENSTACK.SubscribeToOnInputForScreen(Screen, OnUITacticalHUDCommand);
 }
 
-// This event is triggered after a screen receives focus
-//event OnReceiveFocus(UIScreen Screen);
+event OnRemoved(UIScreen Screen)
+{
+	`SCREENSTACK.UnsubscribeFromOnInputForScreen(Screen, OnUITacticalHUDCommand);
+}
 
-// This event is triggered after a screen loses focus
-//event OnLoseFocus(UIScreen Screen);
+simulated protected function bool OnUITacticalHUDCommand(UIScreen Screen, int cmd, int arg)
+{
+	local bool bHandled, MenuIsRaised;
+	local UITacticalHUD TacticalHUD;
+	local UITacticalHUD_MouseControls_LWOfficerPack MouseControls;
 
-// This event is triggered when a screen is removed
-//event OnRemoved(UIScreen Screen);
+	bHandled = true;
 
+	if (!Screen.CheckInputIsReleaseOrDirectionRepeat(cmd, arg))
+	{
+		return false;
+	}
+
+	TacticalHUD = UITacticalHUD(Screen);
+	if (TacticalHUD == none)
+	{
+		return false;
+	}
+
+	switch (cmd)
+	{
+	// KDM : If an officer is on the mission, and the left trigger is pressed while the ability menu is open,
+	// the command range display is toggled on/off.
+	case (class'UIUtilities_Input'.const.FXS_BUTTON_LTRIGGER):
+		MenuIsRaised = TacticalHUD.IsMenuRaised();
+		MouseControls = UITacticalHUD_MouseControls_LWOfficerPack(TacticalHUD.m_kMouseControls);
+
+		if (MenuIsRaised && MouseControls != none && class'LWOfficerUtilities'.static.HasOfficerInSquad() &&
+			MouseControls.OfficerIcon != none)
+		{
+			MouseControls.OnClickedCallback();
+			TacticalHUD.CancelTargetingAction();
+		}
+		else
+		{
+			bHandled = false;
+		}
+		break;
+
+	default:
+		bHandled = false;
+		break;
+	}
+
+	return bHandled;
+}
+
+// KDM : UITacticalHUD_MouseControls_LWOfficerPack is now spawned for controller users as well, so they 
+// have access to an officer's 'command range' icon and ability.
 simulated function UpdateMouseControls(UITacticalHUD HUDScreen)
 {
-	//local UITacticalHUD HUDScreen;
-
-	//HUDScreen = UITacticalHUD(Screen);
-	if ((HUDScreen.m_kMouseControls != none) && (HUDScreen.Movie.IsMouseActive()))
+	if (HUDScreen.m_kMouseControls != none)
 	{
 		HUDScreen.m_kMouseControls.Remove();
-		HUDScreen.m_kMouseControls = HUDScreen.Spawn(class'UITacticalHUD_MouseControls_LWOfficerPack', HUDScreen);
-		HUDScreen.m_kMouseControls.InitMouseControls();
-		//HUDScreen.m_kMouseControls.UpdateControls();
 	}
-}
 
+	// KDM : These statements need not be placed within a (HUDScreen.m_kMouseControls != none) conditional because :
+	// 1.] When using a mouse and keyboard, UITacticalHUD always spawns m_kMouseControls within OnInit.
+	// 2.] When using a controller, UITacticalHUD never spawns m_kMouseControls; however, we still want to
+	// spawn the LW2 version, UITacticalHUD_MouseControls_LWOfficerPack.
+	HUDScreen.m_kMouseControls = HUDScreen.Spawn(class'UITacticalHUD_MouseControls_LWOfficerPack', HUDScreen);
+	HUDScreen.m_kMouseControls.InitMouseControls();
+}
 
 defaultProperties
 {
-	// Leaving this assigned to none will cause every screen to trigger its signals on this class
-	ScreenClass = UITacticalHUD
-	//ParticleSystemName = "LWCommandRange.Boundary.P_LeaderRange_Persistent"
-
-	//Not working because can't create new archetype in UnrealEd
-	//CRTemplate=LWCommandRange_Actor'LWCommandRange.LWCommandRange'
+	ScreenClass = UITacticalHUD;
 }

--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UITacticalHUD_MouseControls_LWOfficerPack.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/UITacticalHUD_MouseControls_LWOfficerPack.uc
@@ -1,9 +1,7 @@
 //---------------------------------------------------------------------------------------
 //  FILE:    UITacticalHUD_MouseControls_LWOfficerPack.uc
 //  AUTHOR:  Amineri (Pavonis Interactive)
-//
 //  PURPOSE: Overrides mouse controls in order to add button to toggle officer command range preview
-//
 //--------------------------------------------------------------------------------------- 
 
 class UITacticalHUD_MouseControls_LWOfficerPack extends UITacticalHUD_MouseControls;
@@ -17,33 +15,65 @@ var bool CRToggleOn;
 simulated function UpdateControls()
 {
 	local int ControlCount;
+	
+	// KDM : If a controller is active, hide all of the mouse controls since they overlap
+	// the 'Call Skyranger' navigation help in the top right corner of the screen.
+	if (`ISCONTROLLERACTIVE)
+	{
+		AS_SetHoverHelp("");
+		SetNumActiveControls(0);
+	}
+	else 
+	{
+		super.UpdateControls();
+	}
 
-	super.UpdateControls();
-
+	// KDM : If the ability menu is raised, hide the 'officer range' icon.
 	if (UITacticalHUD(screen).m_isMenuRaised)
 	{
 		if (OfficerIcon != none)
+		{
 			OfficerIcon.Hide();
+		}
 	}
 	else
 	{
-		// Work out how many "command" controls there are. Base game has 5 + 1
-		// for the Chosen + 1 for any command abilities (presumably an unimplemented
-		// feature). We add an extra one for the Command Range button.
-		ControlCount = 5;
-		if (class'XComGameState_Unit'.static.GetActivatedChosen() != none)
-			ControlCount++;
-		if (CommandAbilities.Length > 0)
-			ControlCount ++;
-		SetNumActiveControls(ControlCount);
+		if (!`ISCONTROLLERACTIVE)
+		{
+			// LW : Work out how many "command" controls there are. Base game has 5 + 1
+			// for the Chosen + 1 for any command abilities (presumably an unimplemented
+			// feature). We add an extra one for the Command Range button.
+			ControlCount = 5;
+			if (class'XComGameState_Unit'.static.GetActivatedChosen() != none)
+				ControlCount++;
+			if (CommandAbilities.Length > 0)
+				ControlCount ++;
+			SetNumActiveControls(ControlCount);
+		}
 
+		// KDM : If the ability menu is lowered, and an officer is in the squad, show the 'officer range' icon.
 		if (class'LWOfficerUtilities'.static.HasOfficerInSquad())
 		{
 			if (OfficerIcon != none)
+			{
 				OfficerIcon.Show();
+			}
 			else
-				AddCommandRangeIcon((!`SecondWaveEnabled('EnableChosen')) ? -300 : -345, 4);
-				//AddCommandRangeIcon(-300, 200);  // For tooltip testing. Puts icon more in the middle of the screen.
+			{
+				// KDM : When using a controller, we want to position the 'officer range' icon a little differently
+				// than when using a mouse and keyboard.
+				if (`ISCONTROLLERACTIVE)
+				{
+					AddCommandRangeIcon(-250, 12);
+				}
+				else
+				{
+					AddCommandRangeIcon((!`SecondWaveEnabled('EnableChosen')) ? -300 : -345, 4);
+					
+					// For tooltip testing. Puts icon more in the middle of the screen.
+					// AddCommandRangeIcon(-300, 200);
+				}
+			}
 		}
 	}
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/UITacticalHUD_AbilityContainer_LWExtended.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/UITacticalHUD_AbilityContainer_LWExtended.uc
@@ -63,41 +63,15 @@ simulated function UpdateLeftRightButtonPositions()
  */
 simulated function OnScrollButtonClicked(UIButton Button)
 {
-	local int page, index, max;
-
-	page = m_iCurrentPage;
-	index = m_iCurrentIndex;
-
-	// Determine which button was clicked
 	if (Button == LeftButton)
 	{
-		// Decrement page and ability indexes
-		page -= 1;
-		index -= MaxAbilitiesPerPage;
+		// KDM : Show the 'previous' ability page.
+		ChangeAbilityPage(true);
 	}
 	else if (Button == RightButton)
 	{
-		// Increment page and ability indexes
-		page += 1;
-		index += MaxAbilitiesPerPage;
-		// Clamp ability index to not exceed total number of abilities and to not target a command ability
-		max = m_arrAbilities.Length - UITacticalHUD(screen).m_kMouseControls.CommandAbilities.Length;
-		if (index >= max)
-		{
-			index = max - 1;
-		}
-	}
-
-	if (m_iCurrentIndex != -1)
-	{
-		// Shot HUD is visible, change ability selection
-		self.SelectAbility(index);
-	}
-	else
-	{
-		// Refresh ability items without selecting
-		m_iCurrentPage = page;
-		self.PopulateFlash();
+		// KDM : Show the 'next' ability page.
+		ChangeAbilityPage(false);
 	}
 }
 
@@ -114,8 +88,10 @@ simulated function UpdateAbilitiesArray()
 	local GameRulesCache_Unit UnitInfoCache;
 	local array<AvailableAction> arrCommandAbilities;
 	local int bCommanderAbility;
-
 	local AvailableAction AbilityAvailableInfo; //Represents an action that a unit can perform. Usually tied to an ability.
+	local UITacticalHUD TacticalHUD;
+	
+	TacticalHUD = UITacticalHUD(screen);
 
 	// Hide any AOE indicators from old abilities
 	for (i = 0; i < m_arrAbilities.Length; i++)
@@ -161,15 +137,30 @@ simulated function UpdateAbilitiesArray()
 
 	PopulateFlash();
 
-	UITacticalHUD(screen).m_kShotInfoWings.Show();
-	UITacticalHUD(screen).m_kMouseControls.SetCommandAbilities(arrCommandAbilities);
-	UITacticalHUD(screen).m_kMouseControls.UpdateControls();
+	TacticalHUD.m_kShotInfoWings.Show();
+	// KDM : Follow the lead of UITacticalHUD_AbilityContainer.UpdateAbilitiesArray and, if using a controller,
+	// update the 'Call Skyranger' navigation help visibility.
+	if (`ISCONTROLLERACTIVE)
+	{
+		// KDM : If the ability menu is raised then hide the 'Call Skyranger' navigation help so it doesn't
+		// get in the way of target selection.
+		if (TacticalHUD.IsMenuRaised() && TacticalHUD.SkyrangerButton != none)
+		{
+			TacticalHUD.SkyrangerButton.Hide();
+		}
+		else
+		{
+			UITacticalHUD(screen).UpdateSkyrangerButton();
+		}
+	}
+	TacticalHUD.m_kMouseControls.SetCommandAbilities(arrCommandAbilities);
+	TacticalHUD.m_kMouseControls.UpdateControls();
 
 	//  jbouscher: I am 99% certain this call is entirely redundant, so commenting it out
 	//kUnit.UpdateUnitBuffs();
 
 	// If we're in shot mode, then set the current ability index based on what (if anything) was populated
-	if (UITacticalHUD(screen).IsMenuRaised() && (m_arrAbilities.Length > 0))
+	if (TacticalHUD.IsMenuRaised() && (m_arrAbilities.Length > 0))
 	{
 		if (m_iMouseTargetedAbilityIndex == -1)
 		{
@@ -306,17 +297,34 @@ simulated function PopulateFlash()
 }
 
 /**
- * Used by the mouse hover tooltip to figure out which ability to get info from.
- *
+ * LW : Used by the mouse hover tooltip to figure out which ability to get info from.
  * Overridden to hide tooltip when mousing over prev/next buttons.
+ *
+ * KDM : The LW description above is only partially true; within base XCom 2 GetAbilityAtIndex is called in 2 locations : 
+ * [A] UITacticalHUD_AbilityTooltip.RefreshData, where it is used to help determine appropriate tooltip text.
+ * [B] UITacticalHUD_AbilityContainer.GetCurrentSelectedAbility, where it helps get the ability state associated
+ * with the currently selected ability; this information is then used in various calling functions.
+ *
+ * This has now been changed so that :
+ * - UITacticalHUD_AbilityTooltip.RefreshData calls UITacticalHUD_AbilityContainer_LWExtended.GetAbilityAtIndex
+ * - GetCurrentSelectedAbility has been overridden and calls UITacticalHUD_AbilityContainer.GetAbilityAtIndex
+ *
+ * For a thorough discussion on the issues present please see the comments above GetCurrentSelectedAbility
+ * within this file.
  */
-simulated function XComGameState_Ability GetAbilityAtIndex( int AbilityIndex )
+simulated function XComGameState_Ability GetAbilityAtIndex(int AbilityIndex)
 {
-	local AvailableAction       AvailableActionInfo;
-	local XComGameState_Ability AbilityState;
 	local UITacticalHUD_AbilityTooltip TooltipAbility;
 
-	if( AbilityIndex < 0 || AbilityIndex >= MaxAbilitiesPerPage) // m_arrAbilities.Length )
+	// KDM : If the AbilityIndex is greater than or equal to the maximum number of abilties on an 'ability page' 
+	// then we are dealing with the 'previous page' or 'next page' button. How do we know this ?
+	// The 'previous page' button and 'next page' button have an AbilityIndex equal to their flash path index; 
+	// for example, the button _level0.theInterfaceMgr.UITacticalHUD_0.theTacticalHUD.AbilityContainerMC.UIButton_116.bg 
+	// has an AbilityIndex of 116. Now, since these buttons are spawned after super.InitAbilityContainer is called, 
+	// their flash path index will be greater than all conventional UITacticalHUD_AbilityContainer UI elements.
+	// Consequently, if there is more than one ability page, these two buttons will have indices greater than or equal
+	// to the maximum number of abilities on an 'ability page'; in fact, their indices will oftentimes be much larger.
+	if (AbilityIndex < 0 || AbilityIndex >= MaxAbilitiesPerPage)
 	{
 		TooltipAbility = UITacticalHUD_AbilityTooltip(Movie.Pres.m_kTooltipMgr.GetChildByName('TooltipAbility', false));
 		if (TooltipAbility != none)
@@ -327,7 +335,7 @@ simulated function XComGameState_Ability GetAbilityAtIndex( int AbilityIndex )
 			TooltipAbility.Cooldown.SetText( "" );
 			TooltipAbility.Effect.SetText( "" );
 
-			//can't hide because of interaction between Flash/TooltipMgr, so fill out with some help text instead
+			// LW : Can't hide because of interaction between Flash/TooltipMgr, so fill out with some help text instead
 			TooltipAbility.Title.SetHTMLText(class'UIUtilities_Text'.static.StyleText(strChangePageTitle, eUITextStyle_Tooltip_Title));
 			TooltipAbility.Desc.SetHTMLText( class'UIUtilities_Text'.static.StyleText(strChangePageDesc, eUITextStyle_Tooltip_Body) );
 
@@ -336,16 +344,13 @@ simulated function XComGameState_Ability GetAbilityAtIndex( int AbilityIndex )
 		return none;
 	}
 
+	// KDM : If we arrive here, we are dealing with an ability on the current 'ability page' which is NEITHER the
+	// 'previous page' button nor the 'next page' button. Since LW2 uses a single row / multi-page ability system, 
+	// we need to determine the abilities actual index.
 	AbilityIndex += m_iCurrentPage * MaxAbilitiesPerPage;
-	if (AbilityIndex < 0 || AbilityIndex >= m_arrAbilities.Length)
-	{
-		`redscreen("Attempt to get ability with illegal index: '" $ AbilityIndex $ "', numAbilities: '" $ m_arrAbilities.Length $ "'.");
-		return none;
-	}
-	AvailableActionInfo = m_arrAbilities[AbilityIndex];
-	AbilityState = XComGameState_Ability(`XCOMHISTORY.GetGameStateForObjectID(AvailableActionInfo.AbilityObjectRef.ObjectID));
-	`assert(AbilityState != none);
-	return AbilityState; 
+
+	// KDM : Get the abilities associated ability state and return it.
+	return super(UITacticalHUD_AbilityContainer).GetAbilityAtIndex(AbilityIndex);
 }
 
 /**
@@ -366,8 +371,80 @@ simulated function bool AbilityClicked(int index)
  */
 function DirectConfirmAbility(int index, optional bool ActivateViaHotKey)
 {
+	local int MaxIndex;
+
+	// LW : Get the 'real' index of the ability, taking into account which ability page we are on.
 	index += m_iCurrentPage * MaxAbilitiesPerPage;
-	super.DirectConfirmAbility(index, ActivateViaHotKey);
+
+	// XCom : For the tutorial, don't allow the user to bring up the HUD by clicking on it if the right trigger is disabled.
+	if (`BATTLE.m_kDesc.m_bIsTutorial)
+	{
+		if (XComTacticalInput(XComTacticalController(PC).PlayerInput).ButtonIsDisabled(class'UIUtilities_Input'.const.FXS_BUTTON_RTRIGGER))
+		{
+			PlaySound( SoundCue'SoundUI.NegativeSelection2Cue', true , true);
+			return;
+		}
+	}
+
+	// KDM : Originally, DirectConfirmAbility would only perform an ability if it was a 'normal' ability, not 
+	// a 'command' ability; mathematically, this was represented as : 
+	// (index >= m_arrAbilities.Length - UITacticalHUD(screen).m_kMouseControls.CommandAbilities.Length).
+	// 
+	// This works well for mouse and keyboard users since it prevents them from hitting a number key on the 
+	// keyboard and activating a 'command' ability which is not on the ability bar. Unfortunately, for controller users,
+	// the 'command' ability 'Call Skyranger' routes through DirectConfirmAbility, and was being ignored.
+	//
+	// Since the reason for ignoring 'command' abilities was to prevent users from activating abilities accidentally
+	// with number keys, something which controller users don't have to worry about, we can safely allow 'command'
+	// abilities through when a controller is active.
+	if (`ISCONTROLLERACTIVE)
+	{
+		MaxIndex = m_arrAbilities.Length;
+	}
+	else
+	{
+		MaxIndex = m_arrAbilities.Length - UITacticalHUD(screen).m_kMouseControls.CommandAbilities.Length;
+	}
+
+	// XCom : Check if it's in range, and bail if out of range 
+	if (index >= MaxIndex)
+	{
+		Movie.Pres.PlayUISound(eSUISound_MenuClose); 
+		return; 
+	}
+
+	if (m_iMouseTargetedAbilityIndex != index)
+	{
+		if (ActivateViaHotKey)
+		{
+			m_arrUIAbilities[m_iCurrentIndex].OnLoseFocus();
+		}
+		// XCom : Update the selection 
+		m_iMouseTargetedAbilityIndex = index;
+		if (ActivateViaHotKey)
+		{
+			if (!SelectAbility(m_iMouseTargetedAbilityIndex, ActivateViaHotKey))
+			{
+				UITacticalHUD(Owner).CancelTargetingAction();
+				return;
+			}
+		}
+		else
+		{
+			SelectAbility(m_iMouseTargetedAbilityIndex, ActivateViaHotKey);
+		}
+		Movie.Pres.PlayUISound(eSUISound_MenuSelect);
+		if (ActivateViaHotKey)
+		{
+			Invoke("Deactivate");
+			PopulateFlash();
+		}
+	}
+	else
+	{
+		m_iSelectionOnButtonDown = index;
+		OnAccept();
+	}
 }
 
 /**
@@ -425,56 +502,293 @@ simulated function bool SelectAbility(int index, optional bool ActivateViaHotKey
 	return false;
 }
 
-// override to remap X key to cycle through ability pages
+// KDM : Changes the ability page being looked at; if PreviousPage is true then look at the
+// 'previous' ability page, else look at the 'next' ability page.
+simulated function ChangeAbilityPage(bool PreviousPage, optional bool ResetMouse = false)
+{
+	local bool AbilityIsSelected;
+	local int AbilityIndex, AbilityPage, MaxAbilityIndex;
+	
+	// KDM : There is only 1 ability page so we can't change pages.
+	if (m_iPageCount == 1)
+	{
+		return;
+	}
+
+	AbilityIsSelected = (m_iCurrentIndex == -1) ? false : true;
+	AbilityPage = m_iCurrentPage;
+	
+	if (PreviousPage)
+	{
+		AbilityPage -= 1;
+		// KDM : If we are looking at the first ability page, then loop around to the last ability page.
+		if (AbilityPage < 0)
+		{
+			AbilityPage = m_iPageCount - 1;
+			AbilityIndex = ((m_iPageCount - 1) * MaxAbilitiesPerPage) + (m_iCurrentIndex % MaxAbilitiesPerPage);
+		}
+		else
+		{
+			AbilityIndex = m_iCurrentIndex - MaxAbilitiesPerPage;
+		}
+	}
+	else
+	{
+		AbilityPage += 1;
+		// LW + KDM : If we are looking at the last ability page, then loop around to the first ability page.
+		if (AbilityPage >= m_iPageCount)
+		{
+			AbilityPage = 0;
+			AbilityIndex = m_iCurrentIndex % MaxAbilitiesPerPage;
+		} 
+		else
+		{				
+			AbilityIndex = m_iCurrentIndex + MaxAbilitiesPerPage;
+		}
+	}
+
+	// KDM : If an ability was selected before the 'page change', make sure a suitable ability is 
+	// selected after the 'page change'. If an ability was not selected before the 'page change' then 
+	// we have no interest in ability selection; we will simply change the page and be done.
+	if (AbilityIsSelected)
+	{
+		// LW : Clamp the ability index; since 'command' abilities are always placed at the end of m_arrAbilities,
+		// due to UITacticalHUD_AbilityContainer.SortAbilities, this guarantees we won't select a 'command'
+		// ability.
+		MaxAbilityIndex = m_arrAbilities.Length - UITacticalHUD(screen).m_kMouseControls.CommandAbilities.Length;
+		
+		if (AbilityIndex >= MaxAbilityIndex)
+		{
+			AbilityIndex = MaxAbilityIndex - 1;
+			// KDM : AbilityIndex just changed; therefore, make sure AbilityPage is up-to-date.
+			AbilityPage = AbilityIndex / MaxAbilitiesPerPage;
+		}
+
+		if (ResetMouse)
+		{
+			self.ResetMouse();
+		}
+		// LW : Shot HUD is visible; therefore, change ability selection.
+		self.SelectAbility(AbilityIndex);
+	}
+	else
+	{
+		// LW : Refresh ability items without selecting.
+		m_iCurrentPage = AbilityPage;
+		self.PopulateFlash();
+	}
+}
+
+// KDM : CycleAbilitySelection has been modified to interact properly with LW2's 'single row' ability bar.
+// Previously, this function relied upon MAX_NUM_ABILITIES_PER_ROW_BAR to determine the number of abilites
+// per row; however, LW2 makes use of MaxAbilitiesPerPage to determine the number of abilities per page.
+simulated function CycleAbilitySelection(int Step)
+{
+	local int AbilityIndex, FirstIndexOfPage, LastIndexOfPage;
+	local int Counter;
+
+	// XCom : Ignore if index was never set (e.g. nothing was populated.).
+	if (m_iCurrentIndex == -1)
+	{
+		return;
+	}
+
+	Counter = 0;
+	AbilityIndex = m_iCurrentIndex;
+
+	FirstIndexOfPage = (AbilityIndex / MaxAbilitiesPerPage) * MaxAbilitiesPerPage;
+	LastIndexOfPage = FirstIndexOfPage + (MaxAbilitiesPerPage - 1);
+	if (LastIndexOfPage >= m_arrAbilities.Length)
+	{
+		LastIndexOfPage = m_arrAbilities.Length - 1;
+	}
+
+	do
+	{
+		// KDM : If we are cycling to the left then Step is -1; if we are cycling to the right then Step is 1.
+		AbilityIndex += Step;
+
+		// KDM : If we are cycling leftwards, loop from the front of the ability page to the end if necessary.
+		if (AbilityIndex < FirstIndexOfPage)
+		{
+			AbilityIndex = LastIndexOfPage;
+		}
+		// KDM : If we are cycling rightwards, loop from the end of the ability page to the front if necessary.
+		else if (AbilityIndex > LastIndexOfPage)
+		{
+			AbilityIndex = FirstIndexOfPage;
+		}
+
+		// KDM : This is a fail-safe which was never implemented in base XCom 2 code, and should never occur.
+		// Nonetheless, it will prevent a hang if, somehow, a command ability erroneously finds its way onto an 
+		// ability page with no 'normal' abilities.
+		Counter++;
+		if (Counter > MaxAbilitiesPerPage)
+		{
+			`log("KDM ERROR : UITacticalHUD_AbilityContainer_LWExtended.CycleAbilitySelection found no valid ability.");
+			return;
+		}
+	}
+	// KDM : Guarantee that the index doesn't correspond to a commander ability.
+	until (!IsCommmanderAbility(AbilityIndex));
+
+	ResetMouse();
+	SelectAbility(AbilityIndex);
+}
+
+// KDM : CycleAbilitySelectionRow has been modified to interact properly with LW2's 'single row' ability bar.
+// Cycling to the previous ability row is now equivalent to cycling to the previous ability page.
+// Cycling to the next ability row is now equivalent to cycling to the next ability page.
+simulated function CycleAbilitySelectionRow(int Step)
+{
+	// XCom : Ignore if index was never set (e.g. nothing was populated.).
+	if (m_iCurrentIndex == -1)
+	{
+		return;
+	}
+
+	// KDM : If we are cycling to the previous ability page, step = -1;
+	if (Step == -1)
+	{
+		ChangeAbilityPage(true, true);
+	}
+	// KDM : If we are cycling to the next ability page, step = 1;
+	else if (Step == 1)
+	{
+		ChangeAbilityPage(false, true);
+	}
+}
+
+simulated function NotifyCanceled()
+{
+	ResetMouse();
+	// XCom : Clears out any message when canceling the mode.
+	UpdateHelpMessage("");
+	// XCom : Animate back to top corner. Handle this here instead of in "clear", so that we prevent 
+	// unwanted animations when staying in show mode.
+	Invoke("Deactivate");  
+	
+	if (TargetingMethod != none)
+	{
+		TargetingMethod.Canceled();
+		TargetingMethod = none;
+	}
+
+	if (m_iCurrentIndex != -1)
+	{
+		// KDM : LW2 modified the usage of m_arrUIAbilities; rather than storing a UI element for each ability,
+		// it only stores a UI element for each ability 'on the currently selected ability page'. Consequently,
+		// the index into m_arrUIAbilities had to be modified, in order for focus to be lost on any ability which
+		// was not on the first ability page. 
+		m_arrUIAbilities[m_iCurrentIndex % MaxAbilitiesPerPage].OnLoseFocus();
+	}
+
+	// XCom : Force a show refresh, since the menu is canceling out.
+	RefreshTutorialShine(true); 
+	
+	m_iCurrentIndex = -1;
+
+	if (`ISCONTROLLERACTIVE)
+	{
+		// KDM : When we cancel out of ability selection make sure that we go back to the
+		// first ability page.
+		m_iCurrentPage = 0;
+	}
+}
+
+// KDM : After nearly a full day of research I have discovered that LW2 modified GetAbilityAtIndex in a
+// 'PROBLEMATIC' way. 
+// 
+// First off, UITacticalHUD_AbilityContainer.GetAbilityAtIndex is called in 2 locations : 
+// [A] UITacticalHUD_AbilityTooltip.RefreshData [B] UITacticalHUD_AbilityContainer.GetCurrentSelectedAbility. 
+//
+// [A] UITacticalHUD_AbilityTooltip.RefreshData is concerned with updating the ability tooltip for the 
+// the ability currently hovered over by the mouse; consequently, it sends GetAbilityAtIndex a
+// parameter ranging from 0 to the number of abilities visible on the ability bar minus 1.
+// [B] UITacticalHUD_AbilityContainer.GetCurrentSelectedAbility is concerned with retrieving the 
+// ability game state corresponding to the ability index sent into it; therefore, it sends GetAbilityAtIndex a
+// parameter ranging from 0 to the total number of abilities minus 1.
+//
+// LW2 modified GetAbilityAtIndex in the following way :
+// 1.] GetAbilityAtIndex now expected a parameter value to be between 0 and the number of abilities visible on the 
+// ability bar minus 1, (MaxAbilitiesPerPage - 1). 
+// 1A.] If this was the case, it determined the abilities 'true' index by adding (m_iCurrentPage * MaxAbilitiesPerPage)
+// to the parameter value, and then ultimately got and returned the ability's associated game state.
+// 1B.] If this was not the case, it : assumed we were dealing with with one of the page scrolling buttons, set
+// some tooltip text, then returned 'none'. This was a problem, since UITacticalHUD_AbilityContainer.GetCurrentSelectedAbility 
+// could send in a perfectly valid parameter greater than (MaxAbilitiesPerPage - 1) and less than (m_arrAbilities.Length - 1); 
+// yet, it would receive 'none' rather than a valid ability game state.
+// 
+// The issue I noticed, related to 1B, was that the enemy head icons, representing enemy targets, would never update 
+// when looking at an ability page greater than 1. Ultimately, after much research, I discovered that 
+// UITacticalHUD_Enemies.UpdateVisibleEnemies calls UITacticalHUD_AbilityContainer.GetCurrentSelectedAbility
+// and expects an ability game state. Instead, it can receive 'none', never fill out its target array, and never
+// update its visuals properly.
+//
+// THE SOLUTION : 
+// 1.] Allow UITacticalHUD_AbilityTooltip.RefreshData to continue calling the LW2 variant of GetAbilityAtIndex
+// since it sends in a parameter whose value is between 0 and (MaxAbilitiesPerPage - 1). If the parameter is out of
+// this range then we are dealing with the 'previous page' button or 'next page' button, and the situation is
+// dealt with accordingly.
+// 2.] Override GetCurrentSelectedAbility so it calls UITacticalHUD_AbilityContainer.GetAbilityAtIndex, a function 
+// which can accept a parameter value between 0 and (m_arrAbilities.Length - 1) without issue. It is important to note
+// that GetCurrentSelectedAbility is unconcerned with the 'previous page' button and the 'next page' button since these 
+// buttons are only activated via OnScrollButtonClicked. Consequently, it can safely skip page button related code.
+simulated function XComGameState_Ability GetCurrentSelectedAbility()
+{ 
+	if (m_iCurrentIndex == -1)
+	{
+		return none;
+	}
+	else
+	{
+		return super(UITacticalHUD_AbilityContainer).GetAbilityAtIndex(m_iCurrentIndex);
+	}
+}
+
+simulated public function bool OnAccept (optional string strOption = "")
+{
+	local int CurrentIndex;
+	
+	CurrentIndex = m_iCurrentIndex;
+	
+	if (ConfirmAbility())
+	{
+		// KDM : Only remove focus on an ability if it went through; if this is not done,
+		// selecting an inactive ability will remove its focus even though it is still focused.
+		// Additionally, since LW2 uses a 'single row' ability bar we need to index into m_arrUIAbilities
+		// with (CurrentIndex % MaxAbilitiesPerPage) rather than simply CurrentIndex.
+		m_arrUIAbilities[CurrentIndex % MaxAbilitiesPerPage].OnLoseFocus();
+		return true;
+	}
+	
+	return false;
+}
+
 simulated function bool OnUnrealCommand(int ucmd, int arg)
 {
-	local int page, index, max;
-
-	// Only allow releases through.
-	if ( ( arg & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) == 0 )
-		return false;
-
-	if( !CanAcceptAbilityInput() )
+	// XCom : Only allow releases through.
+	if ((arg & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) == 0)
 	{
 		return false;
 	}
 
-	//intercept the X key here
-	switch(ucmd)
+	if (!CanAcceptAbilityInput())
 	{
-		case (class'UIUtilities_Input'.const.FXS_BUTTON_X):
-		case (class'UIUtilities_Input'.const.FXS_KEY_X):
-			page = m_iCurrentPage;
-			index = m_iCurrentIndex;
+		return false;
+	}
 
-			// Increment page and ability indexes
-			page += 1;
-			if(page >= m_iPageCount)
-			{
-				page = 0;
-				index = m_iCurrentIndex % MaxAbilitiesPerPage;
-			} else {				
-				index += MaxAbilitiesPerPage;
-			}
-			// Clamp ability index to not exceed total number of abilities and to not target a command ability
-			max = m_arrAbilities.Length - UITacticalHUD(screen).m_kMouseControls.CommandAbilities.Length;
-			if (index >= max)
-			{
-				index = max - 1;
-			}
-			if (m_iCurrentIndex != -1)
-			{
-				// Shot HUD is visible, change ability selection
-				self.SelectAbility(index);
-			}
-			else
-			{
-				// Refresh ability items without selecting
-				m_iCurrentPage = page;
-				self.PopulateFlash();
-			}
-			return true;
-		}
+	// LW : X key cycles through ability pages for mouse and keyboard users.
+	// KDM : The X button no longer cycles through ability pages since controller users
+	// must raise the ability menu before choosing any abilities. Now DPad Up/Down cycles
+	// between ability pages once the ability menu has been raised.
+	switch (ucmd)
+	{
+	case (class'UIUtilities_Input'.const.FXS_KEY_X):
+		// KDM : Show the 'next' ability page.
+		ChangeAbilityPage(false);
+		return true;
+	}
 
 	return super.OnUnrealCommand(ucmd, arg);
 }
@@ -482,6 +796,7 @@ simulated function bool OnUnrealCommand(int ucmd, int arg)
 // ===========================================================================
 //  DEFAULTS:
 // ===========================================================================
+
 defaultproperties
 {
 	m_iCurrentPage = 0;


### PR DESCRIPTION
Modifies :  UITacticalHUD_AbilityContainer_LWExtended

1.] Adds : ChangeAbilityPage
Formerly, both OnScrollButtonClicked and OnUnrealCommand contained code capable of changing the ability page; consequently, there was a great deal of code duplication. This code has been consolidated into the new function ChangeAbilityPage; this function allows the ability page to be moved backwards or forwards, depending upon the parameter PreviousPage.

2.] Modifies : UpdateAbilitiesArray
Added a bit of code, previously only found in UITacticalHUD_AbilityContainer.UpdateAbilitiesArray, which updates the visibility of the 'Call Skyranger' navigation help. As a result, the navigation help appears whenever Skyranger Evac is possible, although it does hide this information when the ability menu is raised so as not to get in the way of enemy targeting.

3.] Modifies : DirectConfirmAbility
After activating UITacticalHUD_MouseControls_LWOfficerPack for controller users, so they could access 'officer range' functionality, the 'Call Skyranger' ability stopped working. The reason is that DirectConfirmAbility, which the 'Call Skyranger' ability makes use of, prevents 'command' abilities from going through. This works well for mouse and keyboard users since it prevents them from hitting a number key and activating an ability which is not on the ability menu. Since controller users can not hit number keys, DirectConfirmAbility need not ignore 'command' abilities, such as 'Call Skyranger', when a controller is active.

4.] Modifies : CycleAbilitySelection
CycleAbilitySelection is concerned with changing ability selection when either DPad left or DPad right is pressed; formerly, it was not working properly since it did not 'understand' LW2's new 'single row / multi page' ability system. Now, the user can press DPad left / Dpad right to move between a single ability page's abilities; furthermore, pressing DPad left on the first ability of a page wraps around to the last ability on a page while pressing DPad right on the last ability of a page wraps around to the first ability on a page.

5.] Modifies : CycleAbilitySelectionRow
CycleAbilitySelectionRow was originally concerned with changing the ability row when either DPad up or DPad down were pressed; it was not working properly since it did not 'understand' LW2's new 'single row / multi page' ability system. Now, the user can press DPad up / Dpad down to move between ability pages; furthermore, pressing DPad up on the first ability page wraps around to the last ability page while pressing DPad down on the last ability page wraps around to the first ability page.

6.] Modifies : NotifyCanceled
Now, when controller users lower the ability menu, ability item focus is properly lost and the first ability page will be shown.

7.] Modifies : GetCurrentSelectedAbility
There was a rather complicated issue, described in comments above the function, resulting in a situation whereby enemy target heads were not updating whenever ability selection was being changed on the second/third/forth ... etc. ability page. Luckily the fix turned out to be relatively straightforward; it involved calling the base code's GetAbilityAtIndex function, rather than the LW2 variant of GetAbilityAtIndex.

8.] Modifies : OnAccept
Makes sure that selecting an inactive ability no longer results in it losing 'visual' focus. Formerly, if you selected an inactive ability, its selection brackets would disappear, even though it was still actually focused.

9.] Modifies : OnUnrealCommand
Controller users can no longer change ability pages with the X button; this was killing the reload X button and is no longer needed since DPad up / DPad down change ability pages when the ability menu is raised.

------------------------------

Modifies : UIScreenListener_TacticalHUD_LWOfficerPack

UITacticalHUD_MouseControls_LWOfficerPack is now spawned for controller users so they have access to the 'Officer range' functionality built into LW2.

Toggling the 'officer range' graphic, assuming an officer is on the mission, is a 2 step process for a controller user :
A.] Bring up the ability menu with the right trigger.
B.] Click on the left trigger.

I created a mod a while back for Long War Rebalanced which follows a similar principle, if a user brings up the ability menu they can then quickly reload, hunker down, or place a soldier in standby via a particular button press. This gets around the issue of limited controller buttons; furthermore, since left trigger is not used when the ability menu is up, it does not get in the way of any other functionality.  Finally, having used it extensively within LWR, I have found it extremely quick and convenient to use.

------------------------------

Modifies : UITacticalHUD_MouseControls_LWOfficerPack

1.] Modifies UpdateControls
If a controller is active, the normal mouse buttons in the top right corner of the screen are hidden since they interfere with the 'Call Skyranger' navigation help. Additionally, the positioning of the officer range icon has been modified a bit.