### PR TITLE
Allow Hiding of 'Save Squad' button + Squad Container

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_UI.ini
+++ b/LongWarOfTheChosen/Config/XComLW_UI.ini
@@ -79,7 +79,3 @@ RECRUIT_FONT_SIZE_CTRL = 22					; Recruit screen font size for controller users.
 RECRUIT_Y_OFFSET_CTRL = -3					; Moves the stats up/down; negative numbers move up / positive numbers move down.
 RECRUIT_FONT_SIZE_MK = 20					; Recruit screen font size for mouse & keyboard users.
 RECRUIT_Y_OFFSET_MK = -2;					; Moves the stats up/down; negative numbers move up / positive numbers move down.
-
-[LW_Overhaul.UIScreenListener_SquadSelect_LW]
-HIDE_SAVESQUAD_BTN_WITH_CONTROLLER = false	; Hide the 'Save Squad' button which appears while viewing a Long War squad's soldiers.
-HIDE_SQUADCONTAINER_WITH_CONTROLLER = false	; Hide the 'Squad Container' which allows for squad selection on the Squad Select screen.

--- a/LongWarOfTheChosen/Config/XComLW_UI.ini
+++ b/LongWarOfTheChosen/Config/XComLW_UI.ini
@@ -79,3 +79,7 @@ RECRUIT_FONT_SIZE_CTRL = 22					; Recruit screen font size for controller users.
 RECRUIT_Y_OFFSET_CTRL = -3					; Moves the stats up/down; negative numbers move up / positive numbers move down.
 RECRUIT_FONT_SIZE_MK = 20					; Recruit screen font size for mouse & keyboard users.
 RECRUIT_Y_OFFSET_MK = -2;					; Moves the stats up/down; negative numbers move up / positive numbers move down.
+
+[LW_Overhaul.UIScreenListener_SquadSelect_LW]
+HIDE_SAVESQUAD_BTN_WITH_CONTROLLER = false	; Hide the 'Save Squad' button which appears while viewing a Long War squad's soldiers.
+HIDE_SQUADCONTAINER_WITH_CONTROLLER = false	; Hide the 'Squad Container' which allows for squad selection on the Squad Select screen.

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_SquadSelect_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_SquadSelect_LW.uc
@@ -24,8 +24,6 @@ var GeneratedMissionData MissionData;
 var config float SquadInfo_DelayedInit;
 var const array<string> PlotTypes;
 
-var config(LW_UI) bool HIDE_SAVESQUAD_BTN_WITH_CONTROLLER, HIDE_SQUADCONTAINER_WITH_CONTROLLER;
-
 // This event is triggered after a screen is initialized
 event OnInit(UIScreen Screen)
 {
@@ -67,7 +65,7 @@ event OnInit(UIScreen Screen)
 	bInSquadEdit = `SCREENSTACK.IsInStack(class'UIPersonnel_SquadBarracks');
 	if(bInSquadEdit)
 	{
-		if(`ISCONTROLLERACTIVE && HIDE_SAVESQUAD_BTN_WITH_CONTROLLER)
+		if (`ISCONTROLLERACTIVE)
 		{
 			// KDM : Hide the 'Save Squad' button which appears while viewing a Long War squad's soldiers.
 			// As an aside, I don't believe this functionality actually works.
@@ -115,7 +113,7 @@ event OnInit(UIScreen Screen)
 		// KDM : Allow the 'Squad Container', which deals with squad selection on the Squad Select screen,
 		// to be hidden through non-creation. My controller-capable Squad Management mod has its own squad 
 		// selection and display UI which overlaps with LW2's UI.
-		if(!(`ISCONTROLLERACTIVE && HIDE_SQUADCONTAINER_WITH_CONTROLLER))
+		if (!`ISCONTROLLERACTIVE)
 		{
 			// LW : Create the SquadContainer on a timer, to avoid creation issues that can arise when creating it immediately, when no pawn loading is present
 			SquadContainer = SquadSelect.Spawn(class'UISquadContainer', SquadSelect);

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_SquadSelect_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_SquadSelect_LW.uc
@@ -24,6 +24,8 @@ var GeneratedMissionData MissionData;
 var config float SquadInfo_DelayedInit;
 var const array<string> PlotTypes;
 
+var config(LW_UI) bool HIDE_SAVESQUAD_BTN_WITH_CONTROLLER, HIDE_SQUADCONTAINER_WITH_CONTROLLER;
+
 // This event is triggered after a screen is initialized
 event OnInit(UIScreen Screen)
 {
@@ -65,9 +67,18 @@ event OnInit(UIScreen Screen)
 	bInSquadEdit = `SCREENSTACK.IsInStack(class'UIPersonnel_SquadBarracks');
 	if(bInSquadEdit)
 	{
-		SquadSelect.LaunchButton.OnClickedDelegate = OnSaveSquad;
-		SquadSelect.LaunchButton.SetText(strSquad);
-		SquadSelect.LaunchButton.SetTitle(strSave);
+		if(`ISCONTROLLERACTIVE && HIDE_SAVESQUAD_BTN_WITH_CONTROLLER)
+		{
+			// KDM : Hide the 'Save Squad' button which appears while viewing a Long War squad's soldiers.
+			// As an aside, I don't believe this functionality actually works.
+			SquadSelect.LaunchButton.Hide();
+		}
+		else
+		{
+			SquadSelect.LaunchButton.OnClickedDelegate = OnSaveSquad;
+			SquadSelect.LaunchButton.SetText(strSquad);
+			SquadSelect.LaunchButton.SetTitle(strSave);
+		}
 
 		SquadSelect.m_kMissionInfo.Remove();
 	} 
@@ -100,10 +111,17 @@ event OnInit(UIScreen Screen)
 				InfilRequirementText.SetAlpha(66);
 			}
 		}
-		// create the SquadContainer on a timer, to avoid creation issues that can arise when creating it immediately, when no pawn loading is present
-		SquadContainer = SquadSelect.Spawn(class'UISquadContainer', SquadSelect);
-		SquadContainer.CurrentSquadRef = SquadMgr.LaunchingMissionSquad;
-		SquadContainer.DelayedInit(default.SquadInfo_DelayedInit);
+
+		// KDM : Allow the 'Squad Container', which deals with squad selection on the Squad Select screen,
+		// to be hidden through non-creation. My controller-capable Squad Management mod has its own squad 
+		// selection and display UI which overlaps with LW2's UI.
+		if(!(`ISCONTROLLERACTIVE && HIDE_SQUADCONTAINER_WITH_CONTROLLER))
+		{
+			// LW : Create the SquadContainer on a timer, to avoid creation issues that can arise when creating it immediately, when no pawn loading is present
+			SquadContainer = SquadSelect.Spawn(class'UISquadContainer', SquadSelect);
+			SquadContainer.CurrentSquadRef = SquadMgr.LaunchingMissionSquad;
+			SquadContainer.DelayedInit(default.SquadInfo_DelayedInit);
+		}
 
 		// 
 


### PR DESCRIPTION
Provides 2 config variables which allow a controller user to hide the 1.] 'Save Squad' button and the 2.] Squad Container. These are turned OFF by default.

1.] The 'Save Squad' button appears while viewing a Long War squad's soldiers; controller users can not click it and, in fact, it appears not to 'do anything'.
2.] The 'Squad Container' allows mouse and keyboard users to perform squad selection on the Squad Select screen, as well as display the currently active squad. Once again, controller users can not click it, and my controller-capable Squad Management system - https://steamcommunity.com/sharedfiles/filedetails/?id=2314584410 - creates its own squad selection and display UI which overlaps with LW2's.

Both of these UI elements are created within UIScreenListener_SquadSelect_LW.OnInit; furthermore, the 'Squad Container' is actually initialized on a timed delay. Consequently, I am unable to hide these elements within my controller-capable Squad Management system without worrying about mod load order and timers. Therefore, the simplest course of action is to allow users to hide them via config variables.