### PR TITLE
Make Resistance/Outpost Screen controls a bit more consistent.

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIOutpostManagement.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIOutpostManagement.uc
@@ -609,8 +609,8 @@ simulated function RefreshNavHelp()
 		// KDM : Bumper left/right changes all rebel jobs.
 		NavHelp.AddLeftHelp(ChangeAllJobsStr, class'UIUtilities_Input'.static.GetGamepadIconPrefix() $ class'UIUtilities_Input'.const.ICON_RB_R1);
 
-		// KDM : Right stick click changes the haven's adviser.
-		NavHelp.AddLeftHelp(CAPS(m_strLiaisonTitle), class'UIUtilities_Input'.static.GetGamepadIconPrefix() $ class'UIUtilities_Input'.const.ICON_RSCLICK_R3);
+		// KDM : X button changes the haven's adviser.
+		NavHelp.AddLeftHelp(CAPS(m_strLiaisonTitle), class'UIUtilities_Input'.static.GetGamepadIconPrefix() $ class'UIUtilities_Input'.const.ICON_X_SQUARE);
 
 		// KDM : Y button brings up the option to build a haven relay, if certain conditions are met.
 		if (ControllerCanBuildRelay())
@@ -716,22 +716,22 @@ simulated function bool OnUnrealCommand(int cmd, int arg)
 
 	switch (cmd)
 	{
-		case class'UIUtilities_Input'.const.FXS_BUTTON_A:
+		case class'UIUtilities_Input'.static.GetAdvanceButtonInputCode():
 		case class'UIUtilities_Input'.const.FXS_KEY_ENTER:
 		case class'UIUtilities_Input'.const.FXS_KEY_SPACEBAR:
 			OnAccept();
 			break;
 
-		case class'UIUtilities_Input'.const.FXS_BUTTON_B:
+		case class'UIUtilities_Input'.static.GetBackButtonInputCode():
 		case class'UIUtilities_Input'.const.FXS_KEY_ESCAPE:
 		case class'UIUtilities_Input'.const.FXS_R_MOUSE_DOWN:
 			OnCancel();
 			break;
 
-		// KDM : Right stick click either :
+		// KDM : X button either :
 		// [1] Opens the haven adviser selection screen, if no haven adviser currently exists.
 		// [2] Removes the haven adviser, if one currently exists.
-		case class'UIUtilities_Input'.const.FXS_BUTTON_R3:
+		case class'UIUtilities_Input'.const.FXS_BUTTON_X:
 			OnLiaisonClicked(none);
 			break;
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIResistanceManagement_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIResistanceManagement_LW.uc
@@ -435,13 +435,13 @@ simulated function RefreshNavHelp()
 	// KDM : Controller specific navigation help
 	if (`ISCONTROLLERACTIVE)
 	{
-		// KDM : A button opens the Haven screen
-		NavHelp.AddLeftHelp(ViewHavenStr, class'UIUtilities_Input'.static.GetAdvanceButtonIcon());
+		// KDM : X button opens the Haven screen
+		NavHelp.AddLeftHelp(ViewHavenStr, class'UIUtilities_Input'.static.GetGamepadIconPrefix() $ class'UIUtilities_Input'.const.ICON_X_SQUARE);
 
-		// KDM : Right stick click sends the Avenger to the selected haven, if on the strategy map.
+		// KDM : A button sends the Avenger to the selected haven, if on the strategy map.
 		if (class'Utilities_LW'.static.IsOnStrategyMap())
 		{
-			NavHelp.AddLeftHelp(FlyToHavenStr, class'UIUtilities_Input'.static.GetGamepadIconPrefix() $ class'UIUtilities_Input'.const.ICON_RSCLICK_R3);
+			NavHelp.AddLeftHelp(FlyToHavenStr, class'UIUtilities_Input'.static.GetAdvanceButtonIcon());
 		}
 	}
 	else
@@ -539,14 +539,14 @@ simulated function bool OnUnrealCommand(int cmd, int arg)
 
 	switch (cmd)
 	{
-		case class'UIUtilities_Input'.const.FXS_BUTTON_B:
+		case class'UIUtilities_Input'.static.GetBackButtonInputCode():
 		case class'UIUtilities_Input'.const.FXS_KEY_ESCAPE:
 		case class'UIUtilities_Input'.const.FXS_R_MOUSE_DOWN:
 			OnCancel();
 			break;
 
-		// KDM : Right stick click sends the Avenger to the selected haven, if on the strategy map.
-		case class'UIUtilities_Input'.const.FXS_BUTTON_R3:
+		// KDM : A button sends the Avenger to the selected haven, if on the strategy map.
+		case class'UIUtilities_Input'.static.GetAdvanceButtonInputCode():
 			if (class'Utilities_LW'.static.IsOnStrategyMap())
 			{
 				FlyToSelectedHaven();
@@ -554,7 +554,7 @@ simulated function bool OnUnrealCommand(int cmd, int arg)
 			break;
 
 		default:
-			// KDM : Formerly, the A button, Enter key, and Spacebar called OnAccept() which did nothing; they will now
+			// KDM : Formerly, the Enter key and Spacebar called OnAccept() which did nothing; they will now
 			// trickle down to the selected list item's OnUnrealCommand() and simulate a click.
 			bHandled = super.OnUnrealCommand(cmd, arg);
 			if (!bHandled)

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIResistanceManagement_ListItem.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIResistanceManagement_ListItem.uc
@@ -249,8 +249,8 @@ simulated function bool OnUnrealCommand(int cmd, int arg)
 
 	switch (cmd)
 	{
-		// KDM : A button opens the corresponding haven screen.
-		case class'UIUtilities_Input'.const.FXS_BUTTON_A:
+		// KDM : X button opens the corresponding haven screen.
+		case class'UIUtilities_Input'.const.FXS_BUTTON_X:
 		case class'UIUtilities_Input'.const.FXS_KEY_ENTER:
 		case class'UIUtilities_Input'.const.FXS_KEY_SPACEBAR:
 			index = List.GetItemIndex(self);


### PR DESCRIPTION
When viewing the strategy map, the X button brings up the Resistance Management screen. Consequently, I think it is more consistent if, while on the Resistance Management screen, the X button brings up the selected haven rather than the A button. Furthermore, it feels better if pressing the X button on a Haven screen modifies the haven adviser, rather than through right stick click.

------------------------------

Modifies : UIResistanceManagement_LW.uc

On the Resistance Management screen the A button sends the Avenger to the selected haven; formerly, this was attached to right stick click.

------------------------------

Modifies : UIResistanceManagement_ListItem.uc

On the Resistance Management screen the X button opens the corresponding haven screen; formerly, this was attached to the A button.

------------------------------

Modifies : UIOutpostManagement.uc

When viewing a particular haven, the X button now [1] Opens the haven adviser selection screen, if no haven adviser currently exists. [2] Removes the haven adviser, if one currently exists. Formerly, this was attached to right stick click.