### PR TITLE
Provide shorter Promotion screen option without panel tearing

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_UI.ini
+++ b/LongWarOfTheChosen/Config/XComLW_UI.ini
@@ -79,3 +79,6 @@ RECRUIT_FONT_SIZE_CTRL = 22					; Recruit screen font size for controller users.
 RECRUIT_Y_OFFSET_CTRL = -3					; Moves the stats up/down; negative numbers move up / positive numbers move down.
 RECRUIT_FONT_SIZE_MK = 20					; Recruit screen font size for mouse & keyboard users.
 RECRUIT_Y_OFFSET_MK = -2;					; Moves the stats up/down; negative numbers move up / positive numbers move down.
+
+[NewPromotionScreenByDefault_Integrated.NPSBDP_UIArmory_PromotionHero]
+USE_SHORTER_PROMOTION_SCREEN = false		; Use a slightly shorter promotion screen; this removes the panel tearing seen when cycling soldiers.

--- a/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
+++ b/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
@@ -21,6 +21,7 @@
     <Folder Include="Content\LW_Toolbox_Integrated\" />
     <Folder Include="Content\Maps\" />
     <Folder Include="Content\Missions\" />
+    <Folder Include="Content\NPSBD_Integrated" />
     <Folder Include="Content\Parcels\" />
     <Folder Include="Content\PCPs\" />
     <Folder Include="Content\Plots\" />
@@ -162,6 +163,12 @@
     <Content Include="Content\Missions\UMS_LWCommon.umap" />
     <Content Include="Content\Missions\UMS_LWContinuousReinforcements.umap" />
     <Content Include="Content\Missions\UMS_LWMissionTimer.umap" />
+    <Content Include="Content\NPSBD_Integrated\3DUIBP_Armory_Promotion_Hero.umap">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Content\NPSBD_Integrated\Readme.txt">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Content\Plots\Plot_ALB_AlienBase_01_LW.umap" />
     <Content Include="Content\Plots\Plot_ALB_AlienBase_02_LW.umap" />
     <Content Include="Content\Plots\Plot_ALB_AlienBase_03_LW.umap" />

--- a/LongWarOfTheChosen/Src/NewPromotionScreenByDefault_Integrated/Classes/NPSBDP_UIArmory_PromotionHeroColumn.uc
+++ b/LongWarOfTheChosen/Src/NewPromotionScreenByDefault_Integrated/Classes/NPSBDP_UIArmory_PromotionHeroColumn.uc
@@ -1,6 +1,85 @@
 class NPSBDP_UIArmory_PromotionHeroColumn extends UIArmory_PromotionHeroColumn;
 
 var int Offset;
+var UIText RankLabelLine1, RankLabelLine2;
+
+function UIArmory_PromotionHeroColumn InitPromotionHeroColumn(int InitRank)
+{
+	super.InitPromotionHeroColumn(InitRank);
+
+	// KDM : Create the UIText's which will display the rank labels.
+	RankLabelLine1 = Spawn(class'UIText', self);
+	RankLabelLine1.InitText('RankLabelLine1', "");
+	RankLabelLine2 = Spawn(class'UIText', self);
+	RankLabelLine2.InitText('RankLabelLine2', "");
+
+	UpdateSizeAndPosition();
+
+	return self;
+}
+
+function UpdateSizeAndPosition()
+{
+	// KDM : The rank icon.
+	MC.ChildSetNum("rankMC", "_x", 41);
+	MC.ChildSetNum("rankMC", "_y", -8);
+
+	// KDM : The 'rank up' highlight.
+	MC.ChildSetNum("rankHighlight", "_x", 0);
+	MC.ChildSetNum("rankHighlight", "_y", -31);
+
+	// KDM : Rank label line 1.
+	RankLabelLine1.SetPosition(2, 52);
+	RankLabelLine1.SetWidth(145);
+
+	// KDM : Rank label line 2.
+	RankLabelLine2.SetPosition(2, 78);
+	RankLabelLine2.SetWidth(145);
+}
+
+function AS_SetData(bool ShowHighlight, string HighlightText, string RankIcon, string RankLabel)
+{
+	MC.BeginFunctionOp("SetData");
+	MC.QueueBoolean(ShowHighlight);
+	MC.QueueString(HighlightText);
+	MC.QueueString(RankIcon);
+	// KDM : We no longer want to set rankLabel, within Flash, since we will be dealing with
+	// multi-line rank labels by ourself.
+	MC.QueueString("");
+	MC.EndOp();
+
+	SetRankLabel(RankLabel);
+}
+
+function SetRankLabel(string RankLabel)
+{
+	local int i;
+	local string ConcatenatedString;
+	local array<string> RankLabelComponents;
+	
+	RankLabelComponents = SplitString(RankLabel, " ", true);
+	if (RankLabelComponents.Length >= 1)
+	{
+		RankLabelLine1.SetHtmlText(class'UIUtilities_Text'.static.GetColoredText(
+			RankLabelComponents[0], eUIState_Normal, 24, "CENTER"));
+
+		i = 1;
+		ConcatenatedString = "";
+		// KDM : Normally, a rank label will consist of 1 or 2 words; if it consists of more, any word after
+		// the 1st will be concatenated with spaces and placed in RankLabelLine2.
+		while (i < RankLabelComponents.Length)
+		{
+			ConcatenatedString $= RankLabelComponents[i];
+			if (i + 1 < RankLabelComponents.Length)
+			{
+				ConcatenatedString $= " ";
+			}
+			i++;
+		}
+		RankLabelLine2.SetHtmlText(class'UIUtilities_Text'.static.GetColoredText(
+			ConcatenatedString, eUIState_Normal, 24, "CENTER"));
+	}
+}
 
 function OnAbilityInfoClicked(UIButton Button)
 {
@@ -113,3 +192,4 @@ simulated function bool AttemptScroll(bool Up)
 {
 	return NPSBDP_UIArmory_PromotionHero(Screen).AttemptScroll(Up);
 }
+


### PR DESCRIPTION
NOTE : Whenever I refer to a promotion screen, I am referring to the "New Promotion Screen by Default" promotion screen.

------------------------------

**Problem** : If you enter a soldier's promotion screen then quickly cycle through soldiers, using a controller or a mouse and keyboard, you will notice strange panel tearing on the right side of the screen.

**Explanation** : It turns out that when you choose to view a soldier's promotions, you are actually viewing a 3D Flash movie which is embedded with : [1] a `NPSBDP_UIArmory_PromotionHero` promotion screen [2] a bunch of other stuff, including 3D models. Interestingly, it appears that the promotion screen is given a certain area of the movie with which to occupy; a viewport of sorts. Furthermore, the promotion screen appears incapable of moving outside of this bounding rectangle.

Now, if a soldier has more than 7 ranks, `NPSBDP_UIArmory_PromotionHero.OnInit` calls the function `ResizeScreenForBrigadierRank` whose goal is to add space for an 8th rank column. Within this function :

1. The promotion screen width is increased
2. A variety of background panel's have their width increased to fit the new 8th column.
3. The promotion screen is shifted to the right so that the 8th column is placed in the correct position.
4. Many of the panels, which are now too far to the right due to step #3, are moved back to the left a bit.

The main problem here is that the promotion screen width increase, combined with the UI element shifting, results in the main background panel being placed upon against the bounding rectangle given to the promotion screen by the 3D Flash movie. This, by itself, isn't a problem. However, when a distortion effect is added in, you end up with parts of the background panel moving outside of the promotion screen bounding rectangle and 'wrapping around' to the other side of the bounding rectangle.

**Solution** : One way in which this problem can be solved is by removing the distortion effect from the promotion screen. This works; however, it is not the method I ended up going with.

Here is what I did within `NPSBDP_UIArmory_PromotionHero.ResizeScreenForBrigadierRank` :

1. I removed the promotion screen width increase since it really wasn't needed. The promotion screen was already well over 1700 pixels; furthermore, elongating a `UIScreen` seems to actually stretch the panels placed upon it.
2. I increased the width of a variety of background `UIPanel`'s, much like in the original promotion screen, to make way for the 8th rank column.
3. I shifted the whole promotion screen away from the left side of its bounding rectangle; this could be done since, with a shorter promotion screen, it would no longer sneak behind the soldier pawn.
4. I modified the location of the 8th rank column so it wouldn't sit on top of the 7th rank column.
5. I made a few other minor UI location adjustments.

Since the promotion screen's panels were no longer close to the bounding rectangle, the distortion effect could safely play without resulting in any panel tearing/wrapping.

**Final thoughts** :

Ultimately, I kept the original promotion screen, and made it the default, since many people will be used to its width and location.

Within `XComLW_UI.ini` I created a config variable, `USE_SHORTER_PROMOTION_SCREEN`, which, when enabled, substitutes the 'original' promotion screen with the 'shortened' promotion screen. This way users can choose to use the longer promotion screen with panel tearing or the shorter promotion screen without panel tearing.

------------------------------

**Problem** : Since the shorter promotion screen was moved to the right, to prevent it from hitting the bounding rectangle given to it by the 3D flash movie, Sparks and any other large pawn'd characters would overlap the 8th rank column.

**Solution** : The 'hero' promotion screen umap file, `3DUIBP_Armory_Promotion_Hero.umap`, was modified in the following ways :
1. The camera was rotated a bit, with respect to the Z-Axis, so that the soldier pawn appears farther to the right.
2. The screen object, within the umap, was moved along the Y axis so that it appears farther to the left.

------------------------------

**Problem** : The scroll bar would change position when switching from 'fullscreen' mode to 'windowed' mode; in other words, it would look ok in one mode but not the other.

**Solution** : It turns out that this problem only occurred when the scrollbar was being anchored to the screen; consequently, anchoring was removed and its X location was updated accordingly within `NPSBDP_UIArmory_PromotionHero.InitPromotion`. Now, the scrollbar remains on the right side of the promotion screen regardless of the screen mode.

------------------------------

Modifies : `NPSBDP_UIArmory_PromotionHeroColumn.uc`

The Flash rank label has now been replaced with 2 `UIText`s; this allows a label such as 'Master Sergeant' to appear on 2 lines. Additionally, to make room for this change, the rank icon and 'rank up' icon have been moved up.

**NOTE** : The rank label `UIText`s are filled according to this algorithm : 
1. The rank label is split into a string array, using a space as the delimiter.
2. The 1st word, if it exists, goes into the 1st `UIText`.
3. The 2nd word, if it exists, goes into the 2nd `UIText`.
_If there are more than 2 words, the 2nd `UIText` is a concatenation of the 2nd word to the 'nth' word separated by spaces._