### PR TITLE
Fix edge case generating invalid soldier

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/XComGameState_Unit_LWRandomizedStats.uc
+++ b/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/XComGameState_Unit_LWRandomizedStats.uc
@@ -99,20 +99,6 @@ function RandomizeInitialStats(XComGameState_Unit Unit)
 		ComIntTotalWeight += ComIntSwap.Weight;
 	}
 
-	//randomly apply a bunch of stat swaps to get starting stat offset
-	for(idx = 0; idx < NumSwaps; idx++)
-	{
-		do {
-			Swap = SelectRandomStatSwap(TotalWeight);
-		} until (IsValidSwap(Swap, Unit) || (++iterations > 1000));
-
-		if (iterations > 1000)
-		{
-			break;
-		}
-		CharacterInitialStats_Deltas[Swap.StatUp] += Swap.StatUp_Amount;
-		CharacterInitialStats_Deltas[Swap.StatDown] -= Swap.StatDown_Amount;
-	}
 	//Roll a chance for a stat swap and don't roll combat intelligence for rebels
 	if (`SYNC_RAND(100) < default.COMINT_BASE_SWAP_CHANCE && InStr(Unit.GetMyTemplateName(), "Rebel") != 0 )
 	{
@@ -120,8 +106,24 @@ function RandomizeInitialStats(XComGameState_Unit Unit)
 		{
 			ComIntSwap = SelectComIntStatSwap(ComIntTotalWeight);
 		} until (IsValidComIntSwap(ComIntSwap, Unit) || (++iterations > 1000));
-		CharacterInitialStats_Deltas[ComIntSwap.StatSwapped] += ComIntSwap.StatSwapped_Amount;
-		CharacterComIntDelta = ComIntSwap.ComIntStatchange;	
+		if (iterations <= 1000)
+		{
+			CharacterInitialStats_Deltas[ComIntSwap.StatSwapped] += ComIntSwap.StatSwapped_Amount;
+			CharacterComIntDelta = ComIntSwap.ComIntStatchange;	
+		}
+	}
+	//randomly apply a bunch of stat swaps to get starting stat offset
+	for(idx = 0; idx < NumSwaps; idx++)
+	{
+		do {
+			Swap = SelectRandomStatSwap(TotalWeight);
+		} until (IsValidSwap(Swap, Unit) || (++iterations > 1000));
+		if (iterations > 1000)
+		{
+			break;
+		}
+		CharacterInitialStats_Deltas[Swap.StatUp] += Swap.StatUp_Amount;
+		CharacterInitialStats_Deltas[Swap.StatDown] -= Swap.StatDown_Amount;
 	}
 
 	bInitialStatsRolled = true;

--- a/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/XComGameState_Unit_LWRandomizedStats.uc
+++ b/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/XComGameState_Unit_LWRandomizedStats.uc
@@ -106,6 +106,10 @@ function RandomizeInitialStats(XComGameState_Unit Unit)
 			Swap = SelectRandomStatSwap(TotalWeight);
 		} until (IsValidSwap(Swap, Unit) || (++iterations > 1000));
 
+		if (iterations > 1000)
+		{
+			break;
+		}
 		CharacterInitialStats_Deltas[Swap.StatUp] += Swap.StatUp_Amount;
 		CharacterInitialStats_Deltas[Swap.StatDown] -= Swap.StatDown_Amount;
 	}

--- a/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/XComGameState_Unit_LWRandomizedStats.uc
+++ b/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/XComGameState_Unit_LWRandomizedStats.uc
@@ -68,6 +68,8 @@ function RandomizeInitialStats(XComGameState_Unit Unit)
 	local ComIntStatSwap ComIntSwap;
 	local XComGameState_BattleData BattleData;
 	local bool bIsFirstMission;
+	
+	const MAX_SWAP_ATTEMPTS=1000;
 
 	BattleData = XComGameState_BattleData( `XCOMHISTORY.GetSingleGameStateObjectForClass( class'XComGameState_BattleData', true ));
 	if(BattleData != none)
@@ -105,20 +107,23 @@ function RandomizeInitialStats(XComGameState_Unit Unit)
 		do 
 		{
 			ComIntSwap = SelectComIntStatSwap(ComIntTotalWeight);
-		} until (IsValidComIntSwap(ComIntSwap, Unit) || (++iterations > 1000));
-		if (iterations <= 1000)
+		} until (IsValidComIntSwap(ComIntSwap, Unit) || (++iterations > MAX_SWAP_ATTEMPTS));
+		if (iterations <= MAX_SWAP_ATTEMPTS)
 		{
 			CharacterInitialStats_Deltas[ComIntSwap.StatSwapped] += ComIntSwap.StatSwapped_Amount;
 			CharacterComIntDelta = ComIntSwap.ComIntStatchange;	
 		}
 	}
+	
+	iterations = 0;
+	
 	//randomly apply a bunch of stat swaps to get starting stat offset
 	for(idx = 0; idx < NumSwaps; idx++)
 	{
 		do {
 			Swap = SelectRandomStatSwap(TotalWeight);
-		} until (IsValidSwap(Swap, Unit) || (++iterations > 1000));
-		if (iterations > 1000)
+		} until (IsValidSwap(Swap, Unit) || (++iterations > MAX_SWAP_ATTEMPTS));
+		if (iterations > MAX_SWAP_ATTEMPTS)
 		{
 			break;
 		}


### PR DESCRIPTION
It's pretty unlikely to happen, but this prevents a 0 hp soldier from being generated.

Previously if iterations ever reached 1000, all remaining stat swaps would be immediately processed regardless of whether they were valid. Now we will stop processing stat swaps when we reach our limit.

This fix could fractionally lower our chance of performing a ComInt swap, so I also moved that to be processed first so that COMINT_BASE_SWAP_CHANCE is more authoritative.