### PR TITLE
Option to restrict more classes from officer training

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_OfficerPack.ini
+++ b/LongWarOfTheChosen/Config/XComLW_OfficerPack.ini
@@ -12,6 +12,8 @@ COMMANDRANGEBUFFER = 3.0
 OTS_OFFICERTRAININGUPGRADE_UNLOCKRANK=2
 ;cost to upgrade OTS facility to add second officer training slot
 OTS_OFFICERTRAININGUPGRADESECONDSLOT_UNLOCKRANK=5
+; A list of soldier classes that will be unable to train as Officers
++CLASSES_INELIGIBLE_FOR_OFFICER_TRAINING="Spark"
 
 [LW_OfficerPack_Integrated.LWOfficerUtilities]
 MaxOfficerRank=7

--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2StrategyElement_LW_OTS_OfficerStaffSlot.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2StrategyElement_LW_OTS_OfficerStaffSlot.uc
@@ -8,6 +8,7 @@ class X2StrategyElement_LW_OTS_OfficerStaffSlot extends X2StrategyElement_Defaul
 
 var config int OTS_OFFICERTRAININGUPGRADE_UNLOCKRANK;
 var config int OTS_OFFICERTRAININGUPGRADESECONDSLOT_UNLOCKRANK;
+var config array<name> CLASSES_INELIGIBLE_FOR_OFFICER_TRAINING;
 
 //var localized string strOTSLocationDisplayString;
 
@@ -252,7 +253,7 @@ static function bool IsUnitValidForOTSOfficerSlot(XComGameState_StaffSlot SlotSt
 	
 	`log("LW Officer Pack, SlotTesting: IsPsiTraining=" $ string(Unit.IsPsiTraining()));
 
-	if (Unit.IsSoldier()
+	if (Unit.IsSoldier() && default.CLASSES_INELIGIBLE_FOR_OFFICER_TRAINING.Find(UnitState.GetSoldierClassTemplateName()) == INDEX_NONE)
 		&& !Unit.IsInjured()
 		&& !Unit.IsTraining()
 		&& !Unit.IsPsiTraining()
@@ -262,7 +263,6 @@ static function bool IsUnitValidForOTSOfficerSlot(XComGameState_StaffSlot SlotSt
 		&& !AtMaxOfficerRank
 		&& HasEligibleRegularRank
 		&& Unit.GetStatus() != eStatus_CovertAction // don't use DLC helpers here since sparks can't train as officers
-		&& Unit.GetSoldierClassTemplate() != none && Unit.GetSoldierClassTemplate().DataName != 'Spark')
 	{
 		return true;
 	}


### PR DESCRIPTION
Added feature for better compatibility with mods like Playable Aliens and MEC Troopers, whose units shouldn't really be Officers due partly to missing animations.