### PR TITLE
Change priority of Flashbanger and Smoker templates

### DIFF
--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
@@ -367,8 +367,9 @@ static function TrojanVirusVisualizationRemoved(XComGameState VisualizeGameState
 //this ability grants a free equip of a flashbang grenade
 static function X2AbilityTemplate AddFlashbanger()
 {
-	local X2AbilityTemplate			Template;
-	local X2Effect_TemporaryItem	TemporaryItemEffect;
+	local X2AbilityTemplate						Template;
+	local X2Effect_TemporaryItem				TemporaryItemEffect;
+	local X2AbilityTrigger_UnitPostBeginPlay	Trigger;
 
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'Flashbanger');
 
@@ -378,7 +379,11 @@ static function X2AbilityTemplate AddFlashbanger()
 	Template.Hostility = eHostility_Neutral;
 	Template.AbilityToHitCalc = default.DeadEye;
 	Template.AbilityTargetStyle = default.SelfTarget;
-	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
+	
+	Trigger = new class'X2AbilityTrigger_UnitPostBeginPlay';
+	Trigger.Priority -= 20; // delayed so that Full Kit happen first
+	Template.AbilityTriggers.AddItem(Trigger);
+	
 	Template.bIsPassive = true;
 	Template.bCrossClassEligible = true;
 	TemporaryItemEffect = new class'X2Effect_TemporaryItem';
@@ -400,9 +405,10 @@ static function X2AbilityTemplate AddFlashbanger()
 //this ability grants a free equip of a smoke grenade, dense smoke grenade, smoke bomb, or dense smoke bomb
 static function X2AbilityTemplate AddSmokeGrenade()
 {
-	local X2AbilityTemplate			Template;
-	local X2Effect_TemporaryItem	TemporaryItemEffect;
-	local ResearchConditional		Conditional;
+	local X2AbilityTemplate						Template;
+	local X2Effect_TemporaryItem				TemporaryItemEffect;
+	local ResearchConditional					Conditional;
+	local X2AbilityTrigger_UnitPostBeginPlay	Trigger;
 
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'SmokeGrenade');
 
@@ -412,7 +418,11 @@ static function X2AbilityTemplate AddSmokeGrenade()
 	Template.Hostility = eHostility_Neutral;
 	Template.AbilityToHitCalc = default.DeadEye;
 	Template.AbilityTargetStyle = default.SelfTarget;
-	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
+
+	Trigger = new class'X2AbilityTrigger_UnitPostBeginPlay';
+	Trigger.Priority -= 20; // delayed so that Full Kit happen first
+	Template.AbilityTriggers.AddItem(Trigger);
+
 	Template.bIsPassive = true;
 	Template.bCrossClassEligible = true;
 


### PR DESCRIPTION
Currently the interaction between Smoker/Flashbanger and Full Kit abilities depend on the order of which they were acquired. So, Full Kit is inconsistent in granting or not extra flashbang/smoke grenade. Additionally, per Full Kit description it is arguable that it should not apply to these extra grenades at all.
This changes priorities of Smoker/Flashbanger templates, so that they happen after Full Kit and therefore would not have extra charges.