### PR TITLE
Remove "Mental" damage type from Sting Grenades and Concussion Rocket

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_TechnicalAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_TechnicalAbilitySet.uc
@@ -1180,7 +1180,7 @@ static function X2AbilityTemplate CreateConcussionRocketAbility()
 	//Template.AddTargetEffect(StunnedEffect);
 	Template.AddMultiTargetEffect(StunnedEffect);
 
-	DisorientedEffect = class'X2StatusEffects'.static.CreateDisorientedStatusEffect();
+	DisorientedEffect = class'X2StatusEffects'.static.CreateDisorientedStatusEffect(, , false);
 	DisorientedEffect.ApplyChanceFn = ApplyChance_Concussion_Disoriented;
 	//Template.AddTargetEffect(DisorientedEffect);
 	Template.AddMultiTargetEffect(DisorientedEffect);

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Item_StingGrenade.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Item_StingGrenade.uc
@@ -42,7 +42,7 @@ static function X2DataTemplate CreateStingGrenade()
 	Template.bFriendlyFireWarning = false;
 	Template.Abilities.AddItem('ThrowGrenade');
 
-	Template.ThrownGrenadeEffects.AddItem(class'X2StatusEffects'.static.CreateDisorientedStatusEffect());
+	Template.ThrownGrenadeEffects.AddItem(class'X2StatusEffects'.static.CreateDisorientedStatusEffect(, , false));
 
 	//We need to have an ApplyWeaponDamage for visualization, even if the grenade does 0 damage (makes the unit flinch, shows overwatch removal)
 	WeaponDamageEffect = new class'X2Effect_ApplyWeaponDamage';
@@ -54,7 +54,7 @@ static function X2DataTemplate CreateStingGrenade()
 	UnitCondition.IncludeWeakAgainstTechLikeRobot = false;
 	UnitCondition.ExcludeFriendlyToSource = false;
 
-	StunnedEffect = class'X2StatusEffects'.static.CreateStunnedStatusEffect(default.STING_GRENADE_STUN_LEVEL, default.STING_GRENADE_STUN_CHANCE);
+	StunnedEffect = class'X2StatusEffects'.static.CreateStunnedStatusEffect(default.STING_GRENADE_STUN_LEVEL, default.STING_GRENADE_STUN_CHANCE, false);
 	StunnedEffect.SetDisplayInfo(ePerkBuff_Penalty, class'X2StatusEffects'.default.StunnedFriendlyName, class'X2StatusEffects'.default.StunnedFriendlyDesc, "img:///UILibrary_PerkIcons.UIPerk_stun");
 	StunnedEffect.TargetConditions.AddItem(UnitCondition);
 	Template.ThrownGrenadeEffects.AddItem(StunnedEffect);


### PR DESCRIPTION
Currently, the Sting Grenades replacement items are created with their disorient and stun effects set to have "Mental" damage type (which is the default value of CreateDisorientedStatusEffect() and CreateStunnedStatusEffect() functions). This is unlike normal flashbang grenades, which are created without this damage type. Therefore, it leads to the situation where Grenadier who bought Sting Grenades perk suddenly can't disorient certain enemies which he previously could, for example Spectres.
This change make their sting grenades grenades consistent with flashbangs, if a bit stronger (which they probably did not need, but oh well).

As for the Concussion Rocket, it had only disorient effect created with default arguments, so you could stun but not disorient Spectres, for no apparent reason. This change make it consistent as well.

Additionally, I want to mention the explicit immunities for PsiZombie, AdvPsiWitchM2 and AdvPsiWitchM3 to all effects of Concussion Rocket, including damage. I found it absolutely counter-intuitive (damage immunity in particular), and don't know why it have to be there, but I left it there for others to decide whether it should be fixed design-wise.