### PR TITLE
Make Mission Screens hotlink compatible for controllers and keyboard …

### DIFF
--- a/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
+++ b/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
@@ -500,6 +500,21 @@
     <Content Include="Src\LW_Overhaul\Classes\SeqAct_GetXComUnits.uc" />
     <Content Include="Src\LW_Overhaul\Classes\UIRecruitmentListItem_LW.uc" />
     <Content Include="Src\LW_Overhaul\Classes\UIRecruitSoldiers_LW.uc" />
+    <Content Include="Src\LW_Overhaul\Classes\UIScreenListener_Mission_ChosenAvengerAssault.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\LW_Overhaul\Classes\UIScreenListener_Mission_ChosenStronghold.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\LW_Overhaul\Classes\UIScreenListener_Mission_GoldenPath.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\LW_Overhaul\Classes\UIScreenListener_Mission_GPIntelOptions.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\LW_Overhaul\Classes\UIScreenListener_UFOAttack.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\LW_Overhaul\Classes\X2Action_IRI_PsiPinion.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_IRI_SoulStorm.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_NullWard.uc" />

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
@@ -12,12 +12,13 @@
 
 class UIMission_LWCustomMission extends UIMission config(LW_Overhaul);
 
+// LW2 : Don't use eMissionUI_GoldenPath for the final mission.
 enum EMissionUIType
 {
 	eMissionUI_GuerrillaOps,
 	eMissionUI_SupplyRaid,
 	eMissionUI_LandedUFO,
-	eMissionUI_GoldenPath,   // don't use this for the final mission
+	eMissionUI_GoldenPath,
 	eMissionUI_AlienFacility,
 	eMissionUI_GPIntel,
 	eMissionUI_Council,
@@ -27,10 +28,19 @@ enum EMissionUIType
 };
 
 var UIButton IgnoreButton;
+// KDM : MissionInfoText is now a UIVerticalScrollingText2 rather than a UITextContainer. UIVerticalScrollingText2
+// is a LW created text container which fixes UITextContainer's inability to display auto-scrolled text.
+// More specifically, when using a UITextContainer, text which starts outside of the text container's visible 
+// area remains invisible even when scrolling into view.
+//
+// UIVerticalScrollingText2's only allow for auto-scroll; therefore, MissionInfoText will auto-scroll for 
+// both controller users and mouse and keyboard users. This is not a problem though as :
+// 1.] This is consistant with other UI elements on the Guerrilla Ops mission panel, which also auto-scroll.
+// 2.] Very rarely will scrolling be necessary since the mission info text tends to be quite short, and its 
+// font size, particularly for mouse and keyboard users, is very small.
+var UIVerticalScrollingText2 MissionInfoText;
 
-var UITextContainer MissionInfoText;
-
-// for customizing per mission
+// MissionUIType tells us which type of mission is being dealt with; this allows us to customize the UI accordingly.
 var EMissionUIType MissionUIType;
 var name LibraryID;
 var string GeoscapeSFX;
@@ -43,15 +53,18 @@ var localized string m_strInvasionMission;
 var localized string m_strInvasionWarning;
 var localized string m_strInvasionDesc;
 
+// ----------------------------------------------------------------------
+// ----------------- STEP 1. INITIALIZE THE SCREEN ----------------------
+// ----------------------------------------------------------------------
+
 simulated function InitScreen(XComPlayerController InitController, UIMovie InitMovie, optional name InitName)
 {
 	local XComGameState_LWAlienActivity AlienActivity;
 
 	super.InitScreen(InitController, InitMovie, InitName);
 
-	//FindMission('MissionSource_Council'); // we're doing a specific mission here, so set it before invoking InitScreen
 	AlienActivity = GetAlienActivity();
-	if (AlienActivity == none) // sanity check
+	if (AlienActivity == none)
 	{
 		CloseScreen();
 		return;
@@ -60,130 +73,9 @@ simulated function InitScreen(XComPlayerController InitController, UIMovie InitM
 	BuildScreen();
 }
 
-simulated function Name GetLibraryID()
-{
-	//allow manual overrides
-	if(LibraryID != '')
-		return LibraryID;
-
-	switch(MissionUIType)
-	{
-		case eMissionUI_GuerrillaOps:
-			return 'Alert_GuerrillaOpsBlades';
-		case eMissionUI_SupplyRaid:
-		case eMissionUI_LandedUFO:
-			return 'Alert_SupplyRaidBlades';  // used for Supply Raid, Landed UFO
-		case eMissionUI_GoldenPath:
-		case eMissionUI_AlienFacility:
-		case eMissionUI_GPIntel:
-			return 'Alert_GoldenPath';  // used for AlienFacility, GoldenPath, GPIntel
-		case eMissionUI_Council:
-			return 'Alert_CouncilMissionBlades';
-		case eMissionUI_Retaliation:
-        case eMissionUI_Rendezvous:
-		case eMissionUI_Invasion:
-			return 'Alert_RetaliationBlades';
-		default:
-			return 'Alert_GuerrillaOpsBlades';
-	}
-}
-
-// Override, because we use a DefaultPanel in the AlienFacility
-simulated function BindLibraryItem()
-{
-	local Name AlertLibID;
-	local UIPanel DefaultPanel;
-
-	switch(MissionUIType)
-	{
-		case eMissionUI_AlienFacility:
-		case eMissionUI_GoldenPath:
-			AlertLibID = GetLibraryID();
-			if( AlertLibID != '' )
-			{
-				LibraryPanel = Spawn(class'UIPanel', self);
-				LibraryPanel.bAnimateOnInit = false;
-				LibraryPanel.InitPanel('', AlertLibID);
-				LibraryPanel.SetSelectedNavigation();
-
-				DefaultPanel = Spawn(class'UIPanel', LibraryPanel);
-				DefaultPanel.bAnimateOnInit = false;
-				DefaultPanel.bCascadeFocus = false;
-				DefaultPanel.InitPanel('DefaultPanel');
-				DefaultPanel.SetSelectedNavigation();
-
-				ConfirmButton = Spawn(class'UIButton', DefaultPanel);
-				ConfirmButton.SetResizeToText(false);
-				ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked);
-
-				ButtonGroup = Spawn(class'UIPanel', DefaultPanel);
-				ButtonGroup.InitPanel('ButtonGroup', '');
-
-				Button1 = Spawn(class'UIButton', ButtonGroup);
-				Button1.SetResizeToText(false);
-				Button1.InitButton('Button0', "");
-
-				Button2 = Spawn(class'UIButton', ButtonGroup);
-				Button2.SetResizeToText(false);
-				Button2.InitButton('Button1', "");
-
-				Button3 = Spawn(class'UIButton', ButtonGroup);
-				Button3.SetResizeToText(false);
-				Button3.InitButton('Button2', "");
-
-				ShadowChamber = Spawn(class'UIAlertShadowChamberPanel', LibraryPanel);
-				ShadowChamber.InitPanel('ShadowChamber');
-
-				SitrepPanel = Spawn(class'UIAlertSitRepPanel', LibraryPanel);
-				SitrepPanel.InitPanel('SitRep', 'Alert_SitRep');
-				SitrepPanel.SetTitle(m_strSitrepTitle);
-
-				ChosenPanel = Spawn(class'UIPanel', LibraryPanel).InitPanel(, 'Alert_ChosenRegionInfo');
-				ChosenPanel.DisableNavigation();
-			}
-
-			break;
-		default:
-			super.BindLibraryItem();
-		    break;
-	}
-}
-
-simulated function string GetSFX()
-{
-	//allow manual overrides
-	if(GeoscapeSFX != "")
-		return GeoscapeSFX;
-
-	switch(MissionUIType)
-	{
-		case eMissionUI_GuerrillaOps:
-			return "GeoscapeFanfares_GuerillaOps";
-		case eMissionUI_SupplyRaid:
-			return "Geoscape_Supply_Raid_Popup";
-		case eMissionUI_LandedUFO:
-			return "Geoscape_UFO_Landed";
-		case eMissionUI_GoldenPath:
-		case eMissionUI_GPIntel:
-			return "GeoscapeFanfares_GoldenPath";
-		case eMissionUI_AlienFacility:
-        case eMissionUI_Rendezvous:
-			return "GeoscapeFanfares_AlienFacility";
-		case eMissionUI_Council:
-			return "Geoscape_NewResistOpsMissions";
-		case eMissionUI_Retaliation:
-		case eMissionUI_Invasion:
-			return "GeoscapeFanfares_Retaliation";
-		default:
-			return "Geoscape_NewResistOpsMissions";
-	}
-}
-
-simulated function String GetMissionTitle()
-{
-	return GetMission().GetMissionDescription();
-}
-
+// ----------------------------------------------------------------------
+// ----------------- STEP 2. BUILD THE SCREEN ---------------------------
+// ----------------------------------------------------------------------
 
 simulated function BuildScreen()
 {
@@ -192,168 +84,148 @@ simulated function BuildScreen()
 	`HQPres.StrategyMap2D.HideCursor();
 
 	if(bInstantInterp)
+	{
 		XComHQPresentationLayer(Movie.Pres).CAMLookAtEarth(GetMission().Get2DLocation(), CAMERA_ZOOM, 0);
+	}
 	else
+	{
 		XComHQPresentationLayer(Movie.Pres).CAMLookAtEarth(GetMission().Get2DLocation(), CAMERA_ZOOM);
+	}
 
-	// Add Interception warning and Shadow Chamber info
+	// LW2 : Add interception warning and Shadow Chamber information.
 	`LWACTIVITYMGR.UpdateMissionData(GetMission());
 
-	// Base version is responsible for showing most mission info, including the mission and options panels,
-	// shadow chamber, chosen, sitreps, etc.
+	// KDM : UIMission.BuildScreen is concerned with :
+	// 1.] Creating common buttons and panels, and binding them to their Flash counterparts via BindLibraryItem. 
+	// 2.] Updating a variety of mission information via UpdateData.
+	// 3.] Building the 'Mission Panel' found on the left side of the screen via BuildMissionPanel.
+	// 4.] Building the 'Options Panel' found on the right side of the screen via BuildOptionsPanel.
 	super.BuildScreen();
 
-	// Add the LW-specific mission info: squad size, concealment type, evac mode, etc.
+	// LW2 : Create a Long War specific 'mission information' panel which includes a variety of extra information
+	// including : squad size, concealment type, evacuation mode ... etc.
 	class'UIUtilities_LW'.static.BuildMissionInfoPanel(self, MissionRef, false);
 
-	// This call does nothing, but is left in for comparison to the original UIMission_GOps class.
-	//BuildConfirmPanel();
+	// KDM : Any calls to BuildConfirmPanel are unneccessary because :
+	// GetLibraryID never returns ''; therefore, LibraryPanel is never 'none' and, consequently,
+	// BuildConfirmPanel always exits without performing any actions.
 }
 
-// Called when screen is removed from Stack
-simulated function OnRemoved()
+// ----------------------------------------------------------------------
+// ---- STEP 3. CREATE COMMON BUTTONS/PANELS + BIND THEM TO FLASH UI ----
+// ----------------------------------------------------------------------
+
+simulated function BindLibraryItem()
 {
-	super.OnRemoved();
+	local Name AlertLibID;
+	local UIPanel DefaultPanel;
 
-	//Restore the saved camera location
-	if(GetMission().GetMissionSource().DataName != 'MissionSource_Final' || class'XComGameState_HeadquartersXCom'.static.GetObjectiveStatus('T5_M3_CompleteFinalMission') != eObjectiveState_InProgress)
-	{
-		HQPRES().CAMRestoreSavedLocation();
-	}
-
-	`HQPRES.m_kAvengerHUD.NavHelp.ClearButtonHelp();
-
-	class'UIUtilities_Sound'.static.PlayCloseSound();
-}
-
-
-simulated function BuildMissionPanel()
-{
 	switch(MissionUIType)
 	{
-		case eMissionUI_GuerrillaOps:
-			BuildGuerrillaOpsMissionPanel();
-			break;
-		case eMissionUI_SupplyRaid:
-			BuildSupplyRaidMissionPanel();
-			break;
-		case eMissionUI_LandedUFO:
-			BuildLandedUFOMissionPanel();
-			break;
-		case eMissionUI_GoldenPath:
-			BuildGoldenPathMissionPanel();
-			break;
-		case eMissionUI_GPIntel:
-			BuildGoldenPathMissionPanel();
-			break;
-		case eMissionUI_AlienFacility:
-			BuildAlienFacilityMissionPanel();
-			break;
-		case eMissionUI_Council:
-			BuildCouncilMissionPanel();
-			break;
-		case eMissionUI_Retaliation:
-			BuildRetaliationMissionPanel();
-			break;
-        case eMissionUI_Rendezvous:
-            BuildRendezvousMissionPanel();
-			break;
-		case eMissionUI_Invasion:
-			BuildInvasionMissionPanel();
-            break;
-		default:
-			BuildGuerrillaOpsMissionPanel();
-			break;
-	}
-}
-
-simulated function BuildOptionsPanel()
-{
-	switch(MissionUIType)
-	{
-		case eMissionUI_GuerrillaOps:
-			BuildGuerrillaOpsOptionsPanel();
-			break;
-		case eMissionUI_SupplyRaid:
-			BuildSupplyRaidOptionsPanel();
-			break;
-		case eMissionUI_LandedUFO:
-			BuildLandedUFOOptionsPanel();
-			break;
-		case eMissionUI_GoldenPath:
-			BuildGoldenPathOptionsPanel();
-			break;
-		case eMissionUI_GPIntel:
-			BuildGoldenPathOptionsPanel();
-			break;
-		case eMissionUI_AlienFacility:
-			BuildAlienFacilityOptionsPanel();
-			break;
-		case eMissionUI_Council:
-			BuildCouncilOptionsPanel();
-			break;
-		case eMissionUI_Retaliation:
-			BuildRetaliationOptionsPanel();
-			break;
-        case eMissionUI_Rendezvous:
-            BuildRendezvousOptionsPanel();
-            break;
-		case eMissionUI_Invasion:
-			BuildInvasionOptionsPanel();
-			break;
-		default:
-			BuildGuerrillaOpsOptionsPanel();
-			break;
-	}
-}
-
-simulated function AddIgnoreButton()
-{
-	//Button is controlled by flash and shows by default. Hide if need to.
-	//local UIButton IgnoreButton;
-
-	IgnoreButton = Spawn(class'UIButton', LibraryPanel);
-	if(CanBackOut())
-	{
-		if( `ISCONTROLLERACTIVE == false )
+	// LW2 : Alien facilities and golden path missions make use of a special 'DefaultPanel'; therefore,
+	// they must be overridden here.
+	case eMissionUI_AlienFacility:
+	case eMissionUI_GoldenPath:
+		AlertLibID = GetLibraryID();
+		if (AlertLibID != '')
 		{
-			IgnoreButton.SetResizeToText(false);
-			IgnoreButton.InitButton('IgnoreButton', "", OnCancelClicked);
-		}
-		else
-		{
-			IgnoreButton.InitButton('IgnoreButton', "", OnCancelClicked, eUIButtonStyle_HOTLINK_WHEN_SANS_MOUSE);
-			IgnoreButton.SetGamepadIcon(class'UIUtilities_Input'.static.GetBackButtonIcon());
-			//IgnoreButton.OnSizeRealized = OnIgnoreButtonSizeRealized;
-			IgnoreButton.SetX(1450.0);
-			IgnoreButton.SetY(644.0);
-		}
+			// KDM : Navigation setup is dealt with in RefreshNavigation; therefore, navigation calls
+			// have been removed here. Additionally, UI styling has been moved to the bottom of this function
+			// so they apply to all mission types.
+			LibraryPanel = Spawn(class'UIPanel', self);
+			LibraryPanel.bAnimateOnInit = false;
+			LibraryPanel.InitPanel('', AlertLibID);
+			
+			DefaultPanel = Spawn(class'UIPanel', LibraryPanel);
+			DefaultPanel.bAnimateOnInit = false;
+			DefaultPanel.InitPanel('DefaultPanel');
+			
+			ConfirmButton = Spawn(class'UIButton', DefaultPanel);
+			ConfirmButton.InitButton('ConfirmButton', "", OnLaunchClicked);
+			
+			ButtonGroup = Spawn(class'UIPanel', DefaultPanel);
+			ButtonGroup.InitPanel('ButtonGroup', '');
+			
+			Button1 = Spawn(class'UIButton', ButtonGroup);
+			Button1.InitButton('Button0', "");
+			
+			Button2 = Spawn(class'UIButton', ButtonGroup);
+			Button2.InitButton('Button1', "");
+			
+			Button3 = Spawn(class'UIButton', ButtonGroup);
+			Button3.InitButton('Button2', "");
+			
+			ShadowChamber = Spawn(class'UIAlertShadowChamberPanel', LibraryPanel);
+			// KDM : The parameters to ShadowChamber.InitPanel have been updated to stay consistent with
+			// UIMission.BindLibraryItem, UIMission_AlienFacility.BindLibraryItem and UIMission_GoldenPath.BindLibraryItem.
+			// I think this is correct; however, I'm keeping the old code 'just in case'.
+			ShadowChamber.InitPanel('UIAlertShadowChamberPanel', 'Alert_ShadowChamber');
+			// ShadowChamber.InitPanel('ShadowChamber');
+			
+			SitrepPanel = Spawn(class'UIAlertSitRepPanel', LibraryPanel);
+			SitrepPanel.InitPanel('SitRep', 'Alert_SitRep');
+			SitrepPanel.SetTitle(m_strSitrepTitle);
 
-		IgnoreButton.DisableNavigation();
+			ChosenPanel = Spawn(class'UIPanel', LibraryPanel);
+			ChosenPanel.InitPanel(, 'Alert_ChosenRegionInfo');
+		}
+		break;
+
+	// KDM : For most mission screens we just want to call UIMission.BindLibraryItem.
+	default:
+		super.BindLibraryItem();
+		break;
 	}
-	else
+
+	// KDM : Display parent-panel centered hotlinks for controller users, and parent-panel centered buttons
+	// for mouse and keyboard users. Generally speaking, Button1 is a 'launch mission' hotlink/button while 
+	// Button2 is a 'cancel mission' hotlink/button.
+	//
+	// The 'Guerrilla Ops' option panel is distinct since Button1 is used to display a region name rather 
+	// than act as a 'clickable' button. Consequently, Button1 on the Guerrilla Ops screen should never be
+	// a hotlink, nor should it resize itself.
+	if (`ISCONTROLLERACTIVE && !IsGuerrillaOpMission())
 	{
-		IgnoreButton.InitButton('IgnoreButton').Hide();
+		// KDM : Allow the hotlink to be shorter than 150 pixels, its flash-based default.
+		Button1.MC.SetNum("MIN_WIDTH", 50);
+		// KDM : Actually 'make' it a hotlink with a gamepad icon; furthermore, enable resizing.
+		Button1.SetStyle(eUIButtonStyle_HOTLINK_BUTTON, , true);
+		Button1.SetGamepadIcon(class'UIUtilities_Input'.static.GetAdvanceButtonIcon());
+		// KDM : Center the hotlink within its parent panel, once it has been realized.
+		Button1.OnSizeRealized = OnUnlockedButtonSizeRealized;
+
+		Button2.MC.SetNum("MIN_WIDTH", 50);
+		Button2.SetStyle(eUIButtonStyle_HOTLINK_BUTTON, , true);
+		Button2.SetGamepadIcon(class'UIUtilities_Input'.static.GetBackButtonIcon());
+		Button2.OnSizeRealized = OnUnlockedButtonSizeRealized;
+
+		Button3.SetResizeToText(false);
+	}
+	else if (!`ISCONTROLLERACTIVE)
+	{
+		// KDM : Turn off text resizing, for mouse and keyboard users, so their buttons are nice and wide.
+		Button1.SetResizeToText(false);
+		Button2.SetResizeToText(false);
+		Button3.SetResizeToText(false);
+		ConfirmButton.SetResizeToText(false);
 	}
 }
 
-simulated function OnButtonSizeRealized()
-{
-	// Override - do nothing. The base version will alter the position of the
-	// confirm button, so an empty version is necessary to suppress that.
-}
+// ----------------------------------------------------------------------
+// ----------------- STEP 4. UPDATE NECESSARY DATA ----------------------
+// ----------------------------------------------------------------------
 
 simulated function UpdateData()
 {
-	// WOTC TODO different sfx for different missions?
+	// WOTC TODO : Should we use different sound effects for different missions ?
 	`XSTRATEGYSOUNDMGR.PlaySoundEvent("Geoscape_AlienOperation");
-	XComHQPresentationLayer(Movie.Pres).CAMLookAtEarth(GetMission().Get2DLocation(), CAMERA_ZOOM);
+	
+	// KDM : The following function calls are not needed :
+	// - XComHQPresentationLayer.CAMLookAtEarth, since it is already called in self.BuildScreen.
+	// - BuildMissionPanel, since it is already called in super.BuildScreen.
 
-	BuildMissionPanel();
-	//RefreshNavigation();
-
-	// Region Panel
-	if( LibraryPanel == none )
+	// XCom : Region panel.
+	if (LibraryPanel == none)
 	{
 		UpdateTitle('Region', GetRegion().GetMyTemplate().DisplayName, GetLabelColor(), 50);
 	}
@@ -370,6 +242,753 @@ simulated function UpdateData()
 	UpdateShadowChamber();
 	UpdateSitreps();
 	UpdateChosen();
+	/*********************************** Issue #140 ***********************************
+	* This is the end of the code replacing the call to super.UpdateData().
+	**********************************************************************************/
+
+	// KDM : 
+	// 1.] Within WotC, UIMission_SupplyRaid and UIMission_LandedUFO override UpdateData so they can
+	// call BuildOptionsPanel after super.UpdateData. This is not needed since BuildOptionsPanel is already
+	// called in super.BuildScreen; therefore, no modifications need to be made for them.
+	// 2.] Within WotC, UIMission_GPIntelOptions overrides UpdateData so it can call UpdateDisplay after
+	// super.UpdateData. We need not worry about UIMission_GPIntelOptions since it is a special screen for 
+	// end game missions and is not considered a 'LW Custom Mission'.
+}
+
+// ----------------------------------------------------------------------
+// ------ STEP 5. BUILD MISSION PANEL ON LEFT SIDE OF THE SCREEN --------
+// ----------------------------------------------------------------------
+
+simulated function BuildMissionPanel()
+{
+	switch(MissionUIType)
+	{
+	case eMissionUI_GuerrillaOps:
+		BuildGuerrillaOpsMissionPanel();
+		break;
+	case eMissionUI_SupplyRaid:
+		BuildSupplyRaidMissionPanel();
+		break;
+	case eMissionUI_LandedUFO:
+		BuildLandedUFOMissionPanel();
+		break;
+	case eMissionUI_GoldenPath:
+		BuildGoldenPathMissionPanel();
+		break;
+	case eMissionUI_GPIntel:
+		BuildGoldenPathMissionPanel();
+		break;
+	case eMissionUI_AlienFacility:
+		BuildAlienFacilityMissionPanel();
+		break;
+	case eMissionUI_Council:
+		BuildCouncilMissionPanel();
+		break;
+	case eMissionUI_Retaliation:
+		BuildRetaliationMissionPanel();
+		break;
+	case eMissionUI_Rendezvous:
+		BuildRendezvousMissionPanel();
+		break;
+	case eMissionUI_Invasion:
+		BuildInvasionMissionPanel();
+		break;
+	default:
+		BuildGuerrillaOpsMissionPanel();
+		break;
+	}
+}
+
+// ----------------------------------------------------------------------
+// ------ STEP 6. BUILD OPTIONS PANEL ON RIGHT SIDE OF THE SCREEN -------
+// ----------------------------------------------------------------------
+
+simulated function BuildOptionsPanel()
+{
+	switch(MissionUIType)
+	{
+	case eMissionUI_GuerrillaOps:
+		BuildGuerrillaOpsOptionsPanel();
+		break;
+	case eMissionUI_SupplyRaid:
+		BuildSupplyRaidOptionsPanel();
+		break;
+	case eMissionUI_LandedUFO:
+		BuildLandedUFOOptionsPanel();
+		break;
+	case eMissionUI_GoldenPath:
+		BuildGoldenPathOptionsPanel();
+		break;
+	case eMissionUI_GPIntel:
+		BuildGoldenPathOptionsPanel();
+		break;
+	case eMissionUI_AlienFacility:
+		BuildAlienFacilityOptionsPanel();
+		break;
+	case eMissionUI_Council:
+		BuildCouncilOptionsPanel();
+		break;
+	case eMissionUI_Retaliation:
+		BuildRetaliationOptionsPanel();
+		break;
+	case eMissionUI_Rendezvous:
+		BuildRendezvousOptionsPanel();
+		break;
+	case eMissionUI_Invasion:
+		BuildInvasionOptionsPanel();
+		break;
+	default:
+		BuildGuerrillaOpsOptionsPanel();
+		break;
+	}
+}
+
+// ----------------------------------------------------------------------
+// ----------- BUILD MISSION PANEL (MISSION SPECIFIC) CODE --------------
+// ----------------------------------------------------------------------
+
+simulated function BuildGuerrillaOpsMissionPanel()
+{
+	local bool HasDarkEvent;
+	local int MissionInfoFontSize;
+	local string DarkEventLabel, DarkEventValue, DarkEventTime;
+	local XComGameState_LWAlienActivity AlienActivity;
+	local XComGameState_MissionSite MissionState;
+
+	MissionState = GetMission();
+	HasDarkEvent = MissionState.HasDarkEvent();
+
+	if (HasDarkEvent)
+	{
+		DarkEventLabel = class'UIMission_GOps'.default.m_strDarkEventLabel;
+		DarkEventValue = MissionState.GetDarkEvent().GetDisplayName();
+		DarkEventTime = MissionState.GetDarkEvent().GetPreMissionText();
+	}
+	else
+	{
+		DarkEventLabel = "";
+		DarkEventValue = "";
+		DarkEventTime = "";
+	}
+
+	LibraryPanel.MC.BeginFunctionOp("UpdateGuerrillaOpsInfoBlade");
+	LibraryPanel.MC.QueueString(GetRegion().GetMyTemplate().DisplayName);
+	LibraryPanel.MC.QueueString(class'UIMission_GOps'.default.m_strGOpsTitle);
+	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strMissionLabel);				// defined in UIMission
+	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
+	LibraryPanel.MC.QueueString(GetObjectiveString());			// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strMissionDifficulty_start);	// defined locally
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text_LW'.static.GetDifficultyString(GetMission()));	// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strReward);					// defined in UIX2SimpleScreen
+	LibraryPanel.MC.QueueString(GetModifiedRewardString());		// defined in UIMission
+	LibraryPanel.MC.QueueString(DarkEventLabel);				// defined locally
+	LibraryPanel.MC.QueueString(DarkEventValue);				// defined locally
+	LibraryPanel.MC.QueueString(DarkEventTime);					// defined locally
+	LibraryPanel.MC.QueueString(GetRewardIcon());				// defined in UIMission
+	LibraryPanel.MC.EndOp();
+
+	// KDM : Add a LW2 specific text container.
+	if (MissionInfoText == none)
+	{
+		MissionInfoText = Spawn(class'UIVerticalScrollingText2', LibraryPanel);
+		MissionInfoText.bAnimateOnInit = false;
+		MissionInfoText.MCName = 'MissionInfoText_LW';
+		if (HasDarkEvent)
+		{
+			MissionInfoText.InitVerticalScrollingText('MissionInfoText_LW', , 212, 822 + 15, 320, 87);
+		}
+		else
+		{
+			// LW2 : MissionInfoText can take up more vertical space if there is no dark event text displayed
+			// in the Guerrilla Ops mission panel.
+			MissionInfoText.InitVerticalScrollingText('MissionInfoText_LW', , 212, 822 - 80, 320, 87 + 80);
+		}
+	}
+
+	MissionInfoText.Show();
+
+	AlienActivity = `LWACTIVITYMGR.FindAlienActivityByMission(MissionState);
+	if(AlienActivity != none)
+	{
+		// KDM : Display LW specific mission information; make the text a bit bigger for controller users
+		// since it can be quite difficult to read.
+		MissionInfoFontSize = `ISCONTROLLERACTIVE ? 20 : 16;
+		MissionInfoText.SetHTMLText(
+			class'UIUtilities_Text'.static.GetColoredText(AlienActivity.GetMissionDescriptionForActivity(), 
+			eUIState_Normal, MissionInfoFontSize));
+	}
+	else
+	{
+		MissionInfoText.Hide();
+	}
+}
+
+// KDM : I believe this function is never called since eMissionUI_Council is never referenced within 
+// XComLW_Activities.ini
+simulated function BuildCouncilMissionPanel()
+{
+	// KDM : UpdateCouncilInfoBlade takes 11 parameters, not 13 !
+	LibraryPanel.MC.BeginFunctionOp("UpdateCouncilInfoBlade");
+	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
+	LibraryPanel.MC.QueueString("../AssetLibraries/ProtoImages/Proto_HeadFirebrand.tga");
+	LibraryPanel.MC.QueueString("../AssetLibraries/TacticalIcons/Objective_VIPGood.tga");
+	LibraryPanel.MC.QueueString(class'UIMission_Council'.default.m_strImageGreeble);
+	LibraryPanel.MC.QueueString(GetRegion().GetMyTemplate().DisplayName);
+	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
+	LibraryPanel.MC.QueueString(GetObjectiveString());			// defined in UIMission
+	LibraryPanel.MC.QueueString(GetRewardIcon());				// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strReward);					// defined in UIX2SimpleScreen
+	LibraryPanel.MC.QueueString(GetModifiedRewardString());		// defined in UIMission
+	LibraryPanel.MC.EndOp();
+
+	// KDM : Option panel buttons should be dealt with in BuildCouncilOptionsPanel, not here.
+}
+
+// KDM : The code within BuildSupplyRaidMissionPanel and BuildSupplyRaidOptionsPanel has been swapped
+// since mission panels should deal with 'info blades' and option panels should deal with 'button blades'.
+simulated function BuildSupplyRaidMissionPanel()
+{
+	// KDM : UpdateSupplyRaidInfoBlade takes 7 parameters, not 11 !
+	LibraryPanel.MC.BeginFunctionOp("UpdateSupplyRaidInfoBlade");
+	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
+	LibraryPanel.MC.QueueString(class'UIMission_SupplyRaid'.default.m_strSupplyMission);
+	LibraryPanel.MC.QueueString(GetRegion().GetMyTemplate().DisplayName);
+	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
+	LibraryPanel.MC.QueueString(GetObjectiveString());			// defined in UIMission
+	LibraryPanel.MC.QueueString(class'UIMission_SupplyRaid'.default.m_strSupplyRaidGreeble);
+	LibraryPanel.MC.EndOp();
+}
+
+// KDM : The code within BuildLandedUFOMissionPanel and BuildLandedUFOOptionsPanel has been swapped
+// since mission panels should deal with 'info blades' and option panels should deal with 'button blades'.
+simulated function BuildLandedUFOMissionPanel()
+{
+	// KDM : UpdateSupplyRaidInfoBlade takes 7 parameters, not 11 !
+	LibraryPanel.MC.BeginFunctionOp("UpdateSupplyRaidInfoBlade");
+	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
+	LibraryPanel.MC.QueueString(class'UIMission_LandedUFO'.default.m_strLandedUFOMission);
+	LibraryPanel.MC.QueueString(GetRegion().GetMyTemplate().DisplayName);
+	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
+	LibraryPanel.MC.QueueString(GetObjectiveString());			// defined in UIMission
+	LibraryPanel.MC.QueueString(class'UIMission_LandedUFO'.default.m_strLandedUFOGreeble);
+	LibraryPanel.MC.EndOp();
+}
+
+simulated function BuildRetaliationMissionPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationInfoBlade");
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.static.CapsCheckForGermanScharfesS(GetRegion().GetMyTemplate().DisplayName));
+	LibraryPanel.MC.QueueString(class'UIMission_Retaliation'.default.m_strRetaliationMission);
+	LibraryPanel.MC.QueueString(class'UIMission_Retaliation'.default.m_strRetaliationWarning);
+	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
+	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
+	LibraryPanel.MC.QueueString(GetObjectiveString());			// defined in UIMission
+	LibraryPanel.MC.EndOp();
+}
+
+simulated function BuildRendezvousMissionPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationInfoBlade");
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.static.CapsCheckForGermanScharfesS(GetRegion().GetMyTemplate().DisplayName));
+	LibraryPanel.MC.QueueString(m_strRendezvousMission);
+	LibraryPanel.MC.QueueString(m_strUrgent);
+	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
+	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
+	LibraryPanel.MC.QueueString(GetObjectiveString());			// defined in UIMission
+	LibraryPanel.MC.EndOp();
+}
+
+simulated function BuildInvasionMissionPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationInfoBlade");
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.static.CapsCheckForGermanScharfesS(GetRegion().GetMyTemplate().DisplayName));
+	LibraryPanel.MC.QueueString(m_strInvasionMission);
+	LibraryPanel.MC.QueueString(m_strInvasionWarning);
+	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
+	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
+	LibraryPanel.MC.QueueString(GetObjectiveString());			// defined in UIMission
+	LibraryPanel.MC.EndOp();
+}
+
+simulated function BuildAlienFacilityMissionPanel()
+{
+	local XComGameState_LWAlienActivity Activity;
+
+	Activity = GetAlienActivity();
+
+	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathInfoBlade");
+	LibraryPanel.MC.QueueString(GetMissionTitle());
+	LibraryPanel.MC.QueueString(GetRegionName());				// defined in UIMission
+	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
+	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
+	LibraryPanel.MC.QueueString(super.GetObjectiveString());	// defined in UIMission -- don't pull the activity subobjective string
+	
+	if (Activity == none)
+	{
+		LibraryPanel.MC.QueueString(class'UIMission_AlienFacility'.default.m_strFlavorText);
+	}
+	else
+	{
+		LibraryPanel.MC.QueueString(Activity.GetMissionDescriptionForActivity());
+	}
+	
+	if (GetMission().GetRewardAmountString() != "")
+	{
+		LibraryPanel.MC.QueueString(m_strReward $ ":");
+		LibraryPanel.MC.QueueString(GetMission().GetRewardAmountString());
+	}
+	
+	LibraryPanel.MC.EndOp();
+}
+
+simulated function BuildGoldenPathMissionPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathInfoBlade");
+	LibraryPanel.MC.QueueString(GetMissionTitle());				// defined in UIMission
+	LibraryPanel.MC.QueueString(class'UIMission_GoldenPath'.default.m_strGPMissionSubtitle);
+	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
+	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
+	LibraryPanel.MC.QueueString(GetObjectiveString());			// defined in UIMission *
+	LibraryPanel.MC.QueueString(GetMission().GetMissionSource().MissionFlavorText);	// defined in UIMission
+	
+	if (GetMission().GetRewardAmountString() != "")				// defined in UIMission
+	{
+		LibraryPanel.MC.QueueString(m_strReward $ ":");			// defined in UIMission
+		LibraryPanel.MC.QueueString(GetMission().GetRewardAmountString());	// defined in UIMission
+	}
+	
+	LibraryPanel.MC.EndOp();
+}
+
+// ----------------------------------------------------------------------
+// ----------- BUILD OPTIONS PANEL (MISSION SPECIFIC) CODE --------------
+// ----------------------------------------------------------------------
+
+simulated function BuildGuerrillaOpsOptionsPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateGuerrillaOpsButtonBlade");
+	LibraryPanel.MC.QueueString(class'UIMission_GOps'.default.m_strGOpsSite);
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString(GetRegionName());
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericConfirm);
+	LibraryPanel.MC.QueueString(CanBackOut() ? m_strIgnore : "");	// defined in UIX2SimpleScreen
+	LibraryPanel.MC.EndOp();
+
+	Button1.SetText(GetRegionName());
+	// KDM : Focus Button1, the region's name, so it appears highlighted; this is purely cosmetic.
+	Button1.OnReceiveFocus();
+	// LW2 : Guerrilla Ops only display 1 mission; therefore, hide Button2 and Button3.
+	Button2.Hide();
+	Button3.Hide();
+	AddIgnoreButton();
+
+	// KDM : UpdateGOpButtons need not be called since :
+	// 1.] Button2 and Button3 are already hidden. 
+	// 2.] RefreshNavigation is already called in super.BuildScreen, after option panel setup.
+}
+
+// KDM : I believe this function is never called since eMissionUI_Council is never referenced within 
+// XComLW_Activities.ini
+simulated function BuildCouncilOptionsPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateCouncilButtonBlade");
+	LibraryPanel.MC.QueueString(class'UIMission_Council'.default.m_strCouncilMission);
+	LibraryPanel.MC.QueueString(m_strLaunchMission);			// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strIgnore);					// defined in UIX2SimpleScreen
+	LibraryPanel.MC.EndOp();
+
+	Button1.OnClickedDelegate = OnLaunchClicked;
+	Button2.OnClickedDelegate = OnCancelClicked;
+
+	Button3.Hide();
+	ConfirmButton.Hide();
+}
+
+simulated function BuildSupplyRaidOptionsPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateSupplyRaidButtonBlade");
+	LibraryPanel.MC.QueueString(class'UIMission_SupplyRaid'.default.m_strSupplyRaidTitleGreeble);
+	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(class'UIMission_SupplyRaid'.default.m_strRaidDesc));
+	LibraryPanel.MC.QueueString(m_strLaunchMission);			// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strIgnore);					// defined in UIX2SimpleScreen
+	LibraryPanel.MC.EndOp();
+
+	Button1.OnClickedDelegate = OnLaunchClicked;
+	Button2.OnClickedDelegate = OnCancelClicked;	
+	
+	Button3.Hide();
+	ConfirmButton.Hide();
+}
+
+simulated function BuildLandedUFOOptionsPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateSupplyRaidButtonBlade");
+	LibraryPanel.MC.QueueString(class'UIMission_LandedUFO'.default.m_strLandedUFOTitleGreeble);
+	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(class'UIMission_LandedUFO'.default.m_strMissionDesc));
+	LibraryPanel.MC.QueueString(m_strLaunchMission);			// defined in UIMission
+	LibraryPanel.MC.QueueString(m_strIgnore);					// defined in UIX2SimpleScreen
+	LibraryPanel.MC.EndOp();
+
+	Button1.OnClickedDelegate = OnLaunchClicked;
+	Button2.OnClickedDelegate = OnCancelClicked;
+
+	Button3.Hide();
+	ConfirmButton.Hide();
+}
+
+simulated function BuildRetaliationOptionsPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationButtonBlade");
+	LibraryPanel.MC.QueueString(class'UIMission_Retaliation'.default.m_strRetaliationWarning);
+	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(class'UIMission_Retaliation'.default.m_strRetaliationDesc));
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericConfirm);
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
+	LibraryPanel.MC.QueueString("");							// LockedTitle
+	LibraryPanel.MC.QueueString("");							// LockedDesc
+	LibraryPanel.MC.QueueString("");							// LockedOKButton
+	LibraryPanel.MC.EndOp();
+
+	Button1.SetText(class'UIUtilities_Text'.default.m_strGenericConfirm);
+	Button1.SetBad(true);
+	Button1.OnClickedDelegate = OnLaunchClicked;
+
+	Button2.SetText(class'UIUtilities_Text'.default.m_strGenericCancel);
+	Button2.SetBad(true);
+	Button2.OnClickedDelegate = OnCancelClicked;
+
+	Button3.Hide();
+	ConfirmButton.Hide();
+}
+
+simulated function BuildRendezvousOptionsPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationButtonBlade");
+	LibraryPanel.MC.QueueString(m_strUrgent);
+	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(m_strRendezvousDesc));
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericConfirm);
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
+	LibraryPanel.MC.QueueString("");							// LockedTitle
+	LibraryPanel.MC.QueueString("");							// LockedDesc
+	LibraryPanel.MC.QueueString("");							// LockedOKButton
+	LibraryPanel.MC.EndOp();
+
+	Button1.SetText(class'UIUtilities_Text'.default.m_strGenericConfirm);
+	Button1.SetBad(true);
+	Button1.OnClickedDelegate = OnLaunchClicked;
+
+	Button2.SetText(class'UIUtilities_Text'.default.m_strGenericCancel);
+	Button2.SetBad(true);
+	Button2.OnClickedDelegate = OnCancelClicked;
+
+	Button3.Hide();
+	ConfirmButton.Hide();
+}
+
+simulated function BuildInvasionOptionsPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationButtonBlade");
+	LibraryPanel.MC.QueueString(m_strInvasionWarning);
+	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(m_strInvasionDesc));
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericConfirm);
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
+	LibraryPanel.MC.QueueString("");							// LockedTitle
+	LibraryPanel.MC.QueueString("");							// LockedDesc
+	LibraryPanel.MC.QueueString("");							// LockedOKButton
+	LibraryPanel.MC.EndOp();
+
+	Button1.SetText(class'UIUtilities_Text'.default.m_strGenericConfirm);
+	Button1.SetBad(true);
+	Button1.OnClickedDelegate = OnLaunchClicked;
+
+	Button2.SetText(class'UIUtilities_Text'.default.m_strGenericCancel);
+	Button2.SetBad(true);
+	Button2.OnClickedDelegate = OnCancelClicked;
+
+	Button3.Hide();
+	ConfirmButton.Hide();
+}
+
+simulated function BuildAlienFacilityOptionsPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathIntel");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.EndOp();
+
+	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathButtonBlade");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString(class'UIMission_AlienFacility'.default.m_strLaunchMission);
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
+
+	if (!CanTakeAlienFacilityMission())
+	{
+		LibraryPanel.MC.QueueString(m_strLocked);
+		LibraryPanel.MC.QueueString(class'UIMission_AlienFacility'.default.m_strLockedHelp);
+		LibraryPanel.MC.QueueString(m_strOK);					// OnCancelClicked
+	}
+	LibraryPanel.MC.EndOp();
+
+	if (!CanTakeAlienFacilityMission())
+	{
+		// XCom : Hook up to the flash assets for locked info.
+		LockedPanel = Spawn(class'UIPanel', LibraryPanel);
+		LockedPanel.InitPanel('lockedMC', '');
+
+		LockedButton = Spawn(class'UIButton', LockedPanel);
+		LockedButton.InitButton('ConfirmButton', "", OnCancelClicked);
+		
+		// KDM : LockedButton should be a parent-panel centered hotlink for controller users, and a parent-panel 
+		// centered button for mouse and keyboard users.
+		if (`ISCONTROLLERACTIVE)
+		{
+			// KDM : Allow the hotlink to be shorter than 150 pixels, its flash-based default.
+			LockedButton.MC.SetNum("MIN_WIDTH", 50);
+			// KDM : Actually 'make' it a hotlink with a gamepad icon; furthermore, enable resizing.
+			LockedButton.SetStyle(eUIButtonStyle_HOTLINK_BUTTON, , true);
+			LockedButton.SetGamepadIcon(class'UIUtilities_Input'.static.GetBackButtonIcon());
+			// KDM : Center the hotlink within its parent panel, once it has been realized.
+			LockedButton.OnSizeRealized = OnLockedButtonSizeRealized;
+		}
+		else
+		{
+			// KDM : Turn off text resizing, for mouse and keyboard users, so LockedButton is nice and wide.
+			LockedButton.SetResizeToText(false);
+			LockedButton.SetPosition(50, 120);
+		}
+
+		LockedButton.SetText(m_strOK);
+		LockedButton.Show();
+	}
+	else
+	{
+		Button1.OnClickedDelegate = OnLaunchClicked;
+		Button2.OnClickedDelegate = OnCancelClicked;
+	}
+
+	Button1.SetBad(true);
+	Button2.SetBad(true);
+
+	if (!CanTakeAlienFacilityMission())
+	{
+		Button1.Hide();
+		Button2.Hide();
+	}
+	Button3.Hide();
+	ConfirmButton.Hide();
+}
+
+simulated function BuildGoldenPathOptionsPanel()
+{
+	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathIntel");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.EndOp();
+
+	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathButtonBlade");
+	LibraryPanel.MC.QueueString("");
+	LibraryPanel.MC.QueueString(m_strLaunchMission);			// defined in UIMission
+	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
+
+	if (!CanTakeMission())
+	{
+		LibraryPanel.MC.QueueString(m_strLocked);
+		LibraryPanel.MC.QueueString(class'UIMission_GoldenPath'.default.m_strLockedHelp);
+		LibraryPanel.MC.QueueString(m_strOK);					// OnCancelClicked
+	}
+	LibraryPanel.MC.EndOp();
+
+	if (!CanTakeMission())
+	{
+		// XCom : Hook up to the flash assets for locked info.
+		LockedPanel = Spawn(class'UIPanel', LibraryPanel);
+		LockedPanel.InitPanel('lockedMC', '');
+
+		LockedButton = Spawn(class'UIButton', LockedPanel);
+		LockedButton.InitButton('ConfirmButton', "", OnCancelClicked);
+		
+		// KDM : LockedButton should be a parent-panel centered hotlink for controller users, and a parent-panel 
+		// centered button for mouse and keyboard users.
+		if (`ISCONTROLLERACTIVE)
+		{
+			// KDM : Allow the hotlink to be shorter than 150 pixels, its flash-based default.
+			LockedButton.MC.SetNum("MIN_WIDTH", 50);
+			// KDM : Actually 'make' it a hotlink with a gamepad icon; furthermore, enable resizing.
+			LockedButton.SetStyle(eUIButtonStyle_HOTLINK_BUTTON, , true);
+			LockedButton.SetGamepadIcon(class'UIUtilities_Input'.static.GetBackButtonIcon());
+			// KDM : Center the hotlink within its parent panel, once it has been realized.
+			LockedButton.OnSizeRealized = OnLockedButtonSizeRealized;
+		}
+		else
+		{
+			// KDM : Turn off text resizing, for mouse and keyboard users, so LockedButton is nice and wide.
+			LockedButton.SetResizeToText(false);
+			LockedButton.SetPosition(50, 120);
+		}
+
+		LockedButton.SetText(m_strOK);
+		LockedButton.Show();
+		
+		Button1.SetDisabled(true);
+		Button2.SetDisabled(true);
+	}
+	else
+	{
+		Button1.OnClickedDelegate = OnLaunchClicked;
+		Button2.OnClickedDelegate = OnCancelClicked;
+	}
+
+	Button1.SetBad(true);
+	Button2.SetBad(true);
+
+	if (!CanTakeMission())
+	{
+		Button1.Hide();
+		Button2.Hide();
+	}
+	Button3.Hide();
+	ConfirmButton.Hide();
+}
+
+// ----------------------------------------------------------------------
+// -------------------------- HELPER FUNCTIONS --------------------------
+// ----------------------------------------------------------------------
+
+simulated function Name GetLibraryID()
+{
+	// LW2 : Allows for manual overrides.
+	if (LibraryID != '')
+	{
+		return LibraryID;
+	}
+
+	switch(MissionUIType)
+	{
+	case eMissionUI_GuerrillaOps:
+		return 'Alert_GuerrillaOpsBlades';
+	case eMissionUI_SupplyRaid:
+	case eMissionUI_LandedUFO:
+		return 'Alert_SupplyRaidBlades';			// Used for 'Supply Raid' and 'Landed UFO' missions.
+	case eMissionUI_GoldenPath:
+	case eMissionUI_AlienFacility:
+	case eMissionUI_GPIntel:
+		return 'Alert_GoldenPath';					// Used for 'Alien Facility', 'Golden Path', and 'GPIntel' missions.
+	case eMissionUI_Council:
+		return 'Alert_CouncilMissionBlades';		// KDM : Likely never used since it's not referenced within XComLW_Activities.ini.
+	case eMissionUI_Retaliation:
+	case eMissionUI_Rendezvous:
+	case eMissionUI_Invasion:
+		return 'Alert_RetaliationBlades';
+	default:
+		return 'Alert_GuerrillaOpsBlades';
+	}
+}
+
+simulated function string GetSFX()
+{
+	// LW2 : Allows for manual overrides.
+	if (GeoscapeSFX != "")
+	{
+		return GeoscapeSFX;
+	}
+
+	switch(MissionUIType)
+	{
+	case eMissionUI_GuerrillaOps:
+		return "GeoscapeFanfares_GuerillaOps";
+	case eMissionUI_SupplyRaid:
+		return "Geoscape_Supply_Raid_Popup";
+	case eMissionUI_LandedUFO:
+		return "Geoscape_UFO_Landed";
+	case eMissionUI_GoldenPath:
+	case eMissionUI_GPIntel:
+		return "GeoscapeFanfares_GoldenPath";
+	case eMissionUI_AlienFacility:
+	case eMissionUI_Rendezvous:
+		return "GeoscapeFanfares_AlienFacility";
+	case eMissionUI_Council:
+		return "Geoscape_NewResistOpsMissions";
+	case eMissionUI_Retaliation:
+	case eMissionUI_Invasion:
+		return "GeoscapeFanfares_Retaliation";
+	default:
+		return "Geoscape_NewResistOpsMissions";
+	}
+}
+
+simulated function OnUnlockedButtonSizeRealized()
+{
+	local int XOffset, YOffset;
+
+	// KDM : Supply Raid and Landed UFO option panels look different from other option panels; therefore,
+	// their buttons need to be re-positioned a bit.
+	XOffset = 0;
+	YOffset = (IsSupplyRaidMission() || IsLandedUFOMission()) ? -20 : 0;
+
+	Button1.SetX((-Button1.Width / 2.0) + XOffset);
+	Button2.SetX((-Button2.Width / 2.0) + XOffset);
+	
+	Button1.SetY(10.0 + YOffset);
+	Button2.SetY(40.0 + YOffset);
+}
+
+simulated function OnLockedButtonSizeRealized()
+{
+	LockedButton.SetX(200 - LockedButton.Width / 2.0);
+	LockedButton.SetY(125.0);
+}
+
+simulated function OnButtonSizeRealized()
+{
+	// LW2 : Override this function to suppress UIMission.OnButtonSizeRealized which modifies the confirm 
+	// button's X location.
+}
+
+simulated function bool IsAlienFacilityMission()
+{
+	return MissionUIType == eMissionUI_AlienFacility;
+}
+
+simulated function bool IsGoldenPathMission()
+{
+	return MissionUIType == eMissionUI_GoldenPath;
+}
+
+simulated function bool IsGuerrillaOpMission()
+{
+	return MissionUIType == eMissionUI_GuerrillaOps;
+}
+
+simulated function bool IsSupplyRaidMission()
+{
+	return MissionUIType == eMissionUI_SupplyRaid;
+}
+
+simulated function bool IsLandedUFOMission()
+{
+	return MissionUIType == eMissionUI_LandedUFO;
+}
+
+simulated function String GetMissionTitle()
+{
+	return GetMission().GetMissionDescription();
 }
 
 simulated function bool CanBackOut()
@@ -377,11 +996,41 @@ simulated function bool CanBackOut()
 	return (super.CanBackOut() && class'XComGameState_HeadquartersXCom'.static.IsObjectiveCompleted('T0_M7_WelcomeToGeoscape'));
 }
 
-// ----------------------------------------------------------------------
-// -------- UTILITY CLASSSES FOR VARIOUS MISSION TYPES ------------------
-// ----------------------------------------------------------------------
+simulated function OnRemoved()
+{
+	super.OnRemoved();
 
-//--=- GAME DATA HOOKUP ----
+	// KDM : Removed LW code found here since it already exists within UIMission.OnRemoved.
+	// I am leaving this function here as a reminder of the change.
+}
+
+simulated function AddIgnoreButton()
+{
+	// XCom : Flash shows IgnoreButton by default; therefore, it needs to be hidden manually if desired.
+	IgnoreButton = Spawn(class'UIButton', LibraryPanel);
+	
+	if (CanBackOut())
+	{
+		if (!`ISCONTROLLERACTIVE)
+		{
+			IgnoreButton.InitButton('IgnoreButton', "", OnCancelClicked);
+			IgnoreButton.SetResizeToText(false);
+		}
+		else
+		{
+			IgnoreButton.InitButton('IgnoreButton', "", OnCancelClicked, eUIButtonStyle_HOTLINK_BUTTON);
+			IgnoreButton.SetResizeToText(true);
+			IgnoreButton.SetGamepadIcon(class'UIUtilities_Input'.static.GetBackButtonIcon());
+			IgnoreButton.SetX(1450.0);
+			IgnoreButton.SetY(644.0);
+		}
+	}
+	else
+	{
+		IgnoreButton.InitButton('IgnoreButton').Hide();
+	}
+}
+
 simulated function String GetRegionLocalizedDesc(string strDesc)
 {
 	local XGParamTag ParamTag;
@@ -405,8 +1054,10 @@ simulated function String GetMissionImage()
 	MissionSite = GetMission();
 
 	AlienActivity = GetAlienActivity();
-	if(AlienActivity != none)
+	if (AlienActivity != none)
+	{
 		return AlienActivity.GetMissionImage(MissionSite);
+	}
 
 	return "img:///UILibrary_StrategyImages.X2StrategyMap.Alert_Guerrilla_Ops";
 }
@@ -432,9 +1083,7 @@ simulated function String GetObjectiveString()
 	{
 		ActivityObjective = "";
 	}
-	//if(ActivityObjective == "")
-		//ActivityObjective = "Missing ActivityObjectives[" $ AlienActivity.CurrentMissionLevel $ "] for AlienActivity " $ ActivityTemplate.DataName;
-
+	
 	ObjectiveString $= ActivityObjective;
 
 	return ObjectiveString;
@@ -454,9 +1103,8 @@ simulated function string GetModifiedRewardString()
 	RewardString = GetRewardString();
 	if (MissionState.GeneratedMission.Mission.MissionFamily == "Neutralize_LW")
 	{
-		RewardString = "$$$" $ RewardString;	// Intended to handle any repeats
+		RewardString = "$$$" $ RewardString;	// LW2 : This is intended to handle any repeats.
 		OldCaptureRewardString = Mid(RewardString, 0, Instr(RewardString, ","));
-		//`log ("MODIFYING REWARD STRING" @ OldCaptureRewardString);
 		NewCaptureRewardString = OldCaptureRewardString @ class'UIUtilities_LW'.default.m_strVIPCaptureReward;
 		RewardString = Repl (RewardString, OldCaptureRewardString, NewCaptureRewardString);
 		RewardString -= "$$$";
@@ -464,529 +1112,78 @@ simulated function string GetModifiedRewardString()
 	return RewardString;
 }
 
-
-// ----------------------------------------------------------------------
-// ----------------- START FLASH INTERFACES -----------------------------
-// ----------------------------------------------------------------------
-
-// ---- GUERRILLA OPS ----
-
-simulated function BuildGuerrillaOpsMissionPanel()
-{
-	local string strDarkEventLabel, strDarkEventValue, strDarkEventTime;
-	local XComGameState_LWAlienActivity AlienActivity;
-	local bool bHasDarkEvent;
-	local XComGameState_MissionSite MissionState;
-
-	MissionState = GetMission();
-	bHasDarkEvent = MissionState.HasDarkEvent();
-
-	if(bHasDarkEvent)
-	{
-		strDarkEventLabel = class'UIMission_GOps'.default.m_strDarkEventLabel;
-		strDarkEventValue = MissionState.GetDarkEvent().GetDisplayName();
-		strDarkEventTime = MissionState.GetDarkEvent().GetPreMissionText();
-	}
-	else
-	{
-		strDarkEventLabel = "";
-		strDarkEventValue = "";
-		strDarkEventTime = "";
-	}
-
-	// Send over to flash ---------------------------------------------------
-
-	LibraryPanel.MC.BeginFunctionOp("UpdateGuerrillaOpsInfoBlade");
-	LibraryPanel.MC.QueueString(GetRegion().GetMyTemplate().DisplayName);
-	LibraryPanel.MC.QueueString(class'UIMission_GOps'.default.m_strGOpsTitle);
-	LibraryPanel.MC.QueueString(GetMissionImage());			// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strMissionLabel);			// defined in UIMission
-	LibraryPanel.MC.QueueString(GetOpName());				// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strMissionObjective);		// defined in UIMission
-	LibraryPanel.MC.QueueString(GetObjectiveString());		// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strMissionDifficulty_start);	// defined locally
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text_LW'.static.GetDifficultyString(GetMission()));		// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strReward);				// defined in UIX2SimpleScreen
-	LibraryPanel.MC.QueueString(GetModifiedRewardString());			// defined in UIMission
-	LibraryPanel.MC.QueueString(strDarkEventLabel);			// defined locally
-	LibraryPanel.MC.QueueString(strDarkEventValue);			// defined locally
-	LibraryPanel.MC.QueueString(strDarkEventTime);			// defined locally
-	LibraryPanel.MC.QueueString(GetRewardIcon());			// defined in UIMission
-	LibraryPanel.MC.EndOp();
-
-	if (MissionInfoText == none)
-	{
-		MissionInfoText = Spawn(class'UITextContainer', LibraryPanel);
-		MissionInfoText.bAnimateOnInit = false;
-		MissionInfoText.MCName = 'MissionInfoText_LW';
-		if (bHasDarkEvent)
-			MissionInfoText.InitTextContainer('MissionInfoText_LW', , 212, 822+15, 320, 87);
-		else // use a larger area to display more text if there's no dark event
-			MissionInfoText.InitTextContainer('MissionInfoText_LW', , 212, 822-80, 320, 87+80);
-	}
-
-	MissionInfoText.Show();
-
-	AlienActivity = `LWACTIVITYMGR.FindAlienActivityByMission(MissionState);
-	if(AlienActivity != none)
-		MissionInfoText.SetHTMLText(class'UIUtilities_Text'.static.GetColoredText(AlienActivity.GetMissionDescriptionForActivity(), eUIState_Normal));
-	else
-		MissionInfoText.Hide();
-}
-
-simulated function UpdateGOpButtons()
-{
-	// GOps have no button2/3 for extra missions
-	Button2.MC.FunctionVoid("Hide");
-	Button3.MC.FunctionVoid("Hide");
-	RefreshNavigation();
-}
-
-simulated function BuildGuerrillaOpsOptionsPanel()
-{
-	// only allowing one mission option here
-	// Mission 1
-	Button1.SetText(GetRegionName());
-	Button1.Show();
-	Button2.DisableNavigation();
-	Button2.Hide();
-	Button2.Remove();
-	Button3.DisableNavigation();
-	Button3.Hide();
-	Button3.Remove();
-
-	// Send over to flash ---------------------------------------------------
-
-	LibraryPanel.MC.BeginFunctionOp("UpdateGuerrillaOpsButtonBlade");
-	LibraryPanel.MC.QueueString(class'UIMission_GOps'.default.m_strGOpsSite);
-	LibraryPanel.MC.QueueString("") ; //GetUnlockHelpString());
-	LibraryPanel.MC.QueueString(GetRegionName()); //GetGOpsMissionLocString(0));
-	LibraryPanel.MC.QueueString(""); //GetGOpsMissionLocString(1));
-	LibraryPanel.MC.QueueString(""); //GetGOpsMissionLocString(2));
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericConfirm);
-	LibraryPanel.MC.QueueString(CanBackOut() ? m_strIgnore : ""); // defined in UIX2SimpleScreen
-	LibraryPanel.MC.EndOp();
-
-	// ----------------------------------------------------------------------
-
-	// WOTC TODO Other mission types may be missing these
-	// BuildConfirmPanel does nothing, but left in for comparison with UIMission_GOps.
-	// BuildConfirmPanel();
-	AddIgnoreButton();
-	SetTimer(0.3, false, 'UpdateGOpButtons');
-}
-
-// ---- COUNCIL ----
-
-simulated function BuildCouncilMissionPanel()
-{
-	LibraryPanel.MC.BeginFunctionOp("UpdateCouncilInfoBlade");
-	LibraryPanel.MC.QueueString(GetMissionImage());					// defined in UIMission
-	LibraryPanel.MC.QueueString("../AssetLibraries/ProtoImages/Proto_HeadFirebrand.tga");
-	LibraryPanel.MC.QueueString("../AssetLibraries/TacticalIcons/Objective_VIPGood.tga");
-	LibraryPanel.MC.QueueString(class'UIMission_Council'.default.m_strImageGreeble);
-	LibraryPanel.MC.QueueString(GetRegion().GetMyTemplate().DisplayName);
-	LibraryPanel.MC.QueueString(GetOpName());						// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strMissionObjective);				// defined in UIMission
-	LibraryPanel.MC.QueueString(GetObjectiveString());				// defined in UIMission
-	LibraryPanel.MC.QueueString(GetRewardIcon());					// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strReward);						// defined in UIX2SimpleScreen
-	LibraryPanel.MC.QueueString(GetModifiedRewardString());					// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strLaunchMission);				// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strIgnore);						// defined in UIX2SimpleScreen
-	LibraryPanel.MC.EndOp();
-
-	Button1.OnClickedDelegate = OnLaunchClicked;
-	Button2.OnClickedDelegate = OnCancelClicked;
-	Button3.Hide();
-	ConfirmButton.Hide();
-}
-
-simulated function BuildCouncilOptionsPanel()
-{
-	LibraryPanel.MC.BeginFunctionOp("UpdateCouncilButtonBlade");
-	LibraryPanel.MC.QueueString(class'UIMission_Council'.default.m_strCouncilMission);
-	LibraryPanel.MC.QueueString(m_strLaunchMission);				// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strIgnore);						// defined in UIX2SimpleScreen
-	LibraryPanel.MC.EndOp();
-}
-
-// ---- SUPPLY RAID ----
-
-simulated function BuildSupplyRaidMissionPanel()
-{
-	LibraryPanel.MC.BeginFunctionOp("UpdateSupplyRaidButtonBlade");
-	LibraryPanel.MC.QueueString(class'UIMission_SupplyRaid'.default.m_strSupplyRaidTitleGreeble);
-	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(class'UIMission_SupplyRaid'.default.m_strRaidDesc));
-	LibraryPanel.MC.QueueString(m_strLaunchMission);				// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strIgnore);						// defined in UIX2SimpleScreen
-	LibraryPanel.MC.EndOp();
-
-	Button1.OnClickedDelegate = OnLaunchClicked;
-	Button2.OnClickedDelegate = OnCancelClicked;
-
-	Button3.Hide();
-	ConfirmButton.Hide();
-}
-
-simulated function BuildSupplyRaidOptionsPanel()
-{
-	LibraryPanel.MC.BeginFunctionOp("UpdateSupplyRaidInfoBlade");
-	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
-	LibraryPanel.MC.QueueString(class'UIMission_SupplyRaid'.default.m_strSupplyMission);
-	LibraryPanel.MC.QueueString(GetRegion().GetMyTemplate().DisplayName);
-	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
-	LibraryPanel.MC.QueueString(GetObjectiveString());			// defined in UIMission
-	LibraryPanel.MC.QueueString(class'UIMission_SupplyRaid'.default.m_strSupplyRaidGreeble);
-
-	// Launch/Help Panel
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-
-	LibraryPanel.MC.EndOp();
-}
-
-// ---- LANDED UFO ----
-
-simulated function BuildLandedUFOMissionPanel()
-{
-	LibraryPanel.MC.BeginFunctionOp("UpdateSupplyRaidButtonBlade");
-	LibraryPanel.MC.QueueString(class'UIMission_LandedUFO'.default.m_strLandedUFOTitleGreeble);
-	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(class'UIMission_LandedUFO'.default.m_strMissionDesc));
-	LibraryPanel.MC.QueueString(m_strLaunchMission);				// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strIgnore);						// defined in UIX2SimpleScreen
-	LibraryPanel.MC.EndOp();
-
-	Button1.OnClickedDelegate = OnLaunchClicked;
-	Button2.OnClickedDelegate = OnCancelClicked;
-
-	Button3.Hide();
-	ConfirmButton.Hide();
-}
-
-simulated function BuildLandedUFOOptionsPanel()
-{
-	LibraryPanel.MC.BeginFunctionOp("UpdateSupplyRaidInfoBlade");
-	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
-	LibraryPanel.MC.QueueString(class'UIMission_LandedUFO'.default.m_strLandedUFOMission);
-	LibraryPanel.MC.QueueString(GetRegion().GetMyTemplate().DisplayName);
-	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
-	LibraryPanel.MC.QueueString(GetObjectiveString());			// defined in UIMission
-	LibraryPanel.MC.QueueString(class'UIMission_LandedUFO'.default.m_strLandedUFOGreeble);
-
-	// Launch/Help Panel
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-
-	LibraryPanel.MC.EndOp();
-}
-
-// ---- RETALIATION ----
-
-simulated function BuildRetaliationMissionPanel()
-{
-	// Send over to flash ---------------------------------------------------
-
-	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationInfoBlade");
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.static.CapsCheckForGermanScharfesS( GetRegion().GetMyTemplate().DisplayName ));
-	LibraryPanel.MC.QueueString(class'UIMission_Retaliation'.default.m_strRetaliationMission);
-	LibraryPanel.MC.QueueString(class'UIMission_Retaliation'.default.m_strRetaliationWarning);
-	LibraryPanel.MC.QueueString(GetMissionImage());					// defined in UIMission
-	LibraryPanel.MC.QueueString(GetOpName());						// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strMissionObjective);				// defined in UIMission
-	LibraryPanel.MC.QueueString(GetObjectiveString());				// defined in UIMission
-	LibraryPanel.MC.EndOp();
-}
-
-simulated function BuildRetaliationOptionsPanel()
-{
-	// Send over to flash ---------------------------------------------------
-
-	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationButtonBlade");
-	LibraryPanel.MC.QueueString(class'UIMission_Retaliation'.default.m_strRetaliationWarning);
-	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(class'UIMission_Retaliation'.default.m_strRetaliationDesc));
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericConfirm);
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
-	LibraryPanel.MC.QueueString("" /*LockedTitle*/);
-	LibraryPanel.MC.QueueString("" /*LockedDesc*/);
-	LibraryPanel.MC.QueueString("" /*LockedOKButton*/);
-	LibraryPanel.MC.EndOp();
-
-	Button1.SetText(class'UIUtilities_Text'.default.m_strGenericConfirm);
-	Button1.SetBad(true);
-	Button1.OnClickedDelegate = OnLaunchClicked;
-
-	Button2.SetText(class'UIUtilities_Text'.default.m_strGenericCancel);
-	Button2.SetBad(true);
-	Button2.OnClickedDelegate = OnCancelClicked;
-
-	Button3.Hide();
-	ConfirmButton.Hide();
-}
-
-// ---- RENDEZVOUS ----
-
-simulated function BuildRendezvousMissionPanel()
-{
-	// Send over to flash ---------------------------------------------------
-
-	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationInfoBlade");
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.static.CapsCheckForGermanScharfesS( GetRegion().GetMyTemplate().DisplayName ));
-	LibraryPanel.MC.QueueString(m_strRendezvousMission);
-	LibraryPanel.MC.QueueString(m_strUrgent);
-	LibraryPanel.MC.QueueString(GetMissionImage());					// defined in UIMission
-	LibraryPanel.MC.QueueString(GetOpName());						// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strMissionObjective);				// defined in UIMission
-	LibraryPanel.MC.QueueString(GetObjectiveString());				// defined in UIMission
-	LibraryPanel.MC.EndOp();
-}
-
-simulated function BuildRendezvousOptionsPanel()
-{
-	// Send over to flash ---------------------------------------------------
-
-	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationButtonBlade");
-	LibraryPanel.MC.QueueString(m_strUrgent);
-	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(m_strRendezvousDesc));
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericConfirm);
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
-	LibraryPanel.MC.QueueString("" /*LockedTitle*/);
-	LibraryPanel.MC.QueueString("" /*LockedDesc*/);
-	LibraryPanel.MC.QueueString("" /*LockedOKButton*/);
-	LibraryPanel.MC.EndOp();
-
-	Button1.SetText(class'UIUtilities_Text'.default.m_strGenericConfirm);
-	Button1.SetBad(true);
-	Button1.OnClickedDelegate = OnLaunchClicked;
-
-	Button2.SetText(class'UIUtilities_Text'.default.m_strGenericCancel);
-	Button2.SetBad(true);
-	Button2.OnClickedDelegate = OnCancelClicked;
-
-	Button3.Hide();
-	ConfirmButton.Hide();
-}
-
-
-// ---- INVASION ----
-
-simulated function BuildInvasionMissionPanel()
-{
-	// Send over to flash ---------------------------------------------------
-
-	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationInfoBlade");
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.static.CapsCheckForGermanScharfesS( GetRegion().GetMyTemplate().DisplayName ));
-	LibraryPanel.MC.QueueString(m_strInvasionMission);
-	LibraryPanel.MC.QueueString(m_strInvasionWarning);
-	LibraryPanel.MC.QueueString(GetMissionImage());					// defined in UIMission
-	LibraryPanel.MC.QueueString(GetOpName());						// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strMissionObjective);				// defined in UIMission
-	LibraryPanel.MC.QueueString(GetObjectiveString());				// defined in UIMission
-	LibraryPanel.MC.EndOp();
-}
-
-simulated function BuildInvasionOptionsPanel()
-{
-	// Send over to flash ---------------------------------------------------
-
-	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationButtonBlade");
-	LibraryPanel.MC.QueueString(m_strInvasionWarning);
-	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(m_strInvasionDesc));
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericConfirm);
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
-	LibraryPanel.MC.QueueString("" /*LockedTitle*/);
-	LibraryPanel.MC.QueueString("" /*LockedDesc*/);
-	LibraryPanel.MC.QueueString("" /*LockedOKButton*/);
-	LibraryPanel.MC.EndOp();
-
-	Button1.SetText(class'UIUtilities_Text'.default.m_strGenericConfirm);
-	Button1.SetBad(true);
-	Button1.OnClickedDelegate = OnLaunchClicked;
-
-	Button2.SetText(class'UIUtilities_Text'.default.m_strGenericCancel);
-	Button2.SetBad(true);
-	Button2.OnClickedDelegate = OnCancelClicked;
-
-	Button3.Hide();
-	ConfirmButton.Hide();
-}
-
-
-
-// ---- ALIEN FACILITY ----
-
-simulated function BuildAlienFacilityMissionPanel()
-{
-	local XComGameState_LWAlienActivity Activity;
-
-	Activity = GetAlienActivity();
-
-	// Send over to flash ---------------------------------------------------
-
-	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathInfoBlade");
-	LibraryPanel.MC.QueueString(GetMissionTitle());
-	LibraryPanel.MC.QueueString(GetRegionName());				// defined in UIMission
-	LibraryPanel.MC.QueueString(GetMissionImage());				// defined in UIMission
-	LibraryPanel.MC.QueueString(GetOpName());					// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strMissionObjective);			// defined in UIMission
-	LibraryPanel.MC.QueueString(super.GetObjectiveString());			// defined in UIMission -- don't pull the activity subobjective string
-	if (Activity == none)
-		LibraryPanel.MC.QueueString(class'UIMission_AlienFacility'.default.m_strFlavorText);
-	else
-		LibraryPanel.MC.QueueString(Activity.GetMissionDescriptionForActivity());
-	if( GetMission().GetRewardAmountString() != "" )
-	{
-		LibraryPanel.MC.QueueString(m_strReward $":");
-		LibraryPanel.MC.QueueString(GetMission().GetRewardAmountString());
-	}
-	LibraryPanel.MC.EndOp();
-}
-
 simulated function bool CanTakeAlienFacilityMission()
 {
 	return GetRegion().HaveMadeContact();
 }
 
-
-simulated function BuildAlienFacilityOptionsPanel()
+// KDM : The navigation system, set up in UIMission.RefreshNavigation, is a mess; override it here and 
+// clean it up.
+simulated function RefreshNavigation()
 {
-	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathIntel");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.EndOp();
+	local bool SelectionSet;
+	local UIPanel DefaultPanel;
 
-	// ---------------------
+	SelectionSet = false;
 
-	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathButtonBlade");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString(class'UIMission_AlienFacility'.default.m_strLaunchMission);
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
-
-	if( !CanTakeAlienFacilityMission() )
+	// KDM : Enable focus cascading so Navigator.Clear kills 'all' UI focus.
+	LibraryPanel.bCascadeFocus = true;
+	ButtonGroup.bCascadeFocus = true;
+	DefaultPanel = LibraryPanel.GetChildByName('DefaultPanel', false);
+	if (DefaultPanel != none)
 	{
-		LibraryPanel.MC.QueueString(m_strLocked);
-		LibraryPanel.MC.QueueString(class'UIMission_AlienFacility'.default.m_strLockedHelp);
-		LibraryPanel.MC.QueueString(m_strOK); //OnCancelClicked
-	}
-	LibraryPanel.MC.EndOp();
-
-	// ---------------------
-
-	if( !CanTakeAlienFacilityMission() )
-	{
-		// Hook up to the flash assets for locked info.
-		LockedPanel = Spawn(class'UIPanel', LibraryPanel);
-		LockedPanel.InitPanel('lockedMC', '');
-
-		LockedButton = Spawn(class'UIButton', LockedPanel);
-		LockedButton.SetResizeToText(false);
-		LockedButton.InitButton('ConfirmButton', "");
-		LockedButton.SetText(m_strOK);
-		LockedButton.OnClickedDelegate = OnCancelClicked;
-		LockedButton.Show();
-	}
-	else
-	{
-		Button1.OnClickedDelegate = OnLaunchClicked;
-		Button2.OnClickedDelegate = OnCancelClicked;
+		DefaultPanel.bCascadeFocus = true;
 	}
 
-	Button1.SetBad(true);
-	Button2.SetBad(true);
+	// KDM : Empty the navigation system.
+	Navigator.Clear();
+	Navigator.LoopSelection = true;
 
-	Button3.Hide();
-	ConfirmButton.Hide();
+	// KDM : The navigation system need not be setup for controller users, since they use hotlinks.
+	if (!`ISCONTROLLERACTIVE)
+	{
+		// KDM : If a button exists, and is visible, then add it to the Navigator.
+		SelectionSet = class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(self, LockedButton, SelectionSet);
+		SelectionSet = class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(self, ConfirmButton, SelectionSet);
+		SelectionSet = class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(self, IgnoreButton, SelectionSet);
+		
+		// The 'Guerrilla Ops' option panel is distinct since Button1 is used to display a region name rather 
+		// than act as a 'clickable' button.
+		if (!IsGuerrillaOpMission())
+		{
+			SelectionSet = class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(self, Button1, SelectionSet);
+			SelectionSet = class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(self, Button2, SelectionSet);
+			SelectionSet = class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(self, Button3, SelectionSet);
+		}
+	}
 }
 
-// ---- GOLDEN PATH ----
-
-simulated function BuildGoldenPathMissionPanel()
+simulated function bool OnUnrealCommand(int cmd, int arg)
 {
-	// Send over to flash ---------------------------------------------------
+	local UIButton SelectedButton;
 
-	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathInfoBlade");
-	LibraryPanel.MC.QueueString(GetMissionTitle());								// defined in UIMission
-	LibraryPanel.MC.QueueString(class'UIMission_GoldenPath'.default.m_strGPMissionSubtitle);
-	LibraryPanel.MC.QueueString(GetMissionImage());								// defined in UIMission
-	LibraryPanel.MC.QueueString(GetOpName());									// defined in UIMission
-	LibraryPanel.MC.QueueString(m_strMissionObjective);							// defined in UIMission
-	LibraryPanel.MC.QueueString(GetObjectiveString());							// defined in UIMission ***
-	LibraryPanel.MC.QueueString(GetMission().GetMissionSource().MissionFlavorText);						// defined in UIMission
-	if( GetMission().GetRewardAmountString() != "" )							// defined in UIMission
+	if (!CheckInputIsReleaseOrDirectionRepeat(cmd, arg))
 	{
-		LibraryPanel.MC.QueueString(m_strReward $":");							// defined in UIMission
-		LibraryPanel.MC.QueueString(GetMission().GetRewardAmountString());		// defined in UIMission
+		return false;
 	}
-	LibraryPanel.MC.EndOp();
+
+	switch(cmd)
+	{
+	// KDM : The spacebar and enter key 'click' on the selected button. Previously, the spacebar and
+	// enter key would only attempt to 'click' ConfirmButton or Button1.
+	case class'UIUtilities_Input'.const.FXS_KEY_ENTER:
+	case class'UIUtilities_Input'.const.FXS_KEY_SPACEBAR:
+		SelectedButton = UIButton(Navigator.GetSelected());
+		if (SelectedButton != none && SelectedButton.OnClickedDelegate != none)
+		{
+			SelectedButton.Click();
+			return true;
+		}
+		break;
+	}
+
+	return super.OnUnrealCommand(cmd, arg);
 }
-
-simulated function BuildGoldenPathOptionsPanel()
-{
-	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathIntel");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.EndOp();
-
-	// ---------------------
-
-	LibraryPanel.MC.BeginFunctionOp("UpdateGoldenPathButtonBlade");
-	LibraryPanel.MC.QueueString("");
-	LibraryPanel.MC.QueueString(m_strLaunchMission);							// defined in UIMission
-	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
-
-	if( !CanTakeMission() )
-	{
-		LibraryPanel.MC.QueueString(m_strLocked);
-		LibraryPanel.MC.QueueString(class'UIMission_GoldenPath'.default.m_strLockedHelp);
-
-		LibraryPanel.MC.QueueString(m_strOK); //OnCancelClicked
-	}
-	LibraryPanel.MC.EndOp();
-
-	// ---------------------
-
-	Button1.SetBad(true);
-	Button2.SetBad(true);
-
-	if( !CanTakeMission() )
-	{
-		// Hook up to the flash assets for locked info.
-		LockedPanel = Spawn(class'UIPanel', LibraryPanel);
-		LockedPanel.InitPanel('lockedMC', '');
-
-		LockedButton = Spawn(class'UIButton', LockedPanel);
-		LockedButton.SetResizeToText(false);
-		LockedButton.InitButton('ConfirmButton', "");
-		LockedButton.SetText(m_strOK);
-		LockedButton.OnClickedDelegate = OnCancelClicked;
-		LockedButton.Show();
-
-		Button1.SetDisabled(true);
-		Button2.SetDisabled(true);
-	}
-
-
-	if( CanTakeMission() )
-	{
-		Button1.OnClickedDelegate = OnLaunchClicked;
-		Button2.OnClickedDelegate = OnCancelClicked;
-	}
-	Button3.Hide();
-	ConfirmButton.Hide();
-}
-
 
 defaultproperties
 {

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_Mission_ChosenAvengerAssault.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_Mission_ChosenAvengerAssault.uc
@@ -1,0 +1,94 @@
+//---------------------------------------------------------------------------------------
+//	FILE :		UIScreenListener_Mission_ChosenAvengerAssault.uc
+//	AUTHOR :	KDM
+//	PURPOSE :	Set up the UIMission_ChosenAvengerAssault screen such that :
+//				- For controller users, the 'launch mission' button appears as a parent-panel centered hotlink.
+//				- For mouse and keyboard users, the 'launch mission' button appears as a parent-panel centered 
+//				conventional button.
+//---------------------------------------------------------------------------------------
+
+class UIScreenListener_Mission_ChosenAvengerAssault extends UIScreenListener;
+
+var UIMission_ChosenAvengerAssault ChosenAvengerAssaultScreen;
+var UIButton Button1;
+
+event OnInit(UIScreen Screen)
+{
+	ChosenAvengerAssaultScreen = UIMission_ChosenAvengerAssault(Screen);
+	Button1 = ChosenAvengerAssaultScreen.Button1;
+	
+	// KDM : Display parent-panel centered hotlinks for controller users, and parent-panel centered buttons
+	// for mouse and keyboard users.
+	if (`ISCONTROLLERACTIVE)
+	{
+		Button1.OnSizeRealized = OnButtonSizeRealized;
+		// KDM : Allow the hotlink to be shorter than 150 pixels, its flash-based default.
+		Button1.MC.SetNum("MIN_WIDTH", 50);
+		// KDM : Enable hotlink resizing.
+		Button1.SetResizeToText(true);
+		// KDM : Actually 'make' it a hotlink with a gamepad icon.
+		Button1.SetStyle(eUIButtonStyle_HOTLINK_BUTTON);
+		Button1.SetGamepadIcon(class 'UIUtilities_Input'.static.GetAdvanceButtonIcon());
+		// KDM : Set the hotlink's text so OnSizeRealized is called; this is where we center it within its
+		// parent panel.
+		Button1.SetText(Button1.Text);
+	}
+	else
+	{
+		// KDM : Resizing is already removed from Button1; therefore, simply set its width
+		// and position it manually.
+		Button1.SetWidth(300);
+		Button1.SetPosition(-150, 0);
+	}
+
+	// KDM : The navigation system, set up in UIMission_ChosenAvengerAssault.RefreshNavigation, is a mess; 
+	// clean it up here.
+	RefreshNavigation();
+}
+
+event OnRemoved(UIScreen Screen)
+{
+	if (Button1 != none)
+	{
+		Button1.OnSizeRealized = none;
+	}
+
+	Button1 = none;
+	ChosenAvengerAssaultScreen = none;
+}
+
+simulated function RefreshNavigation()
+{
+	local bool SelectionSet;
+
+	SelectionSet = false;
+
+	// KDM : Enable focus cascading so Navigator.Clear kills 'all' UI focus.
+	ChosenAvengerAssaultScreen.LibraryPanel.bCascadeFocus = true;
+	ChosenAvengerAssaultScreen.ButtonGroup.bCascadeFocus = true;
+	
+	// KDM : Empty the navigation system.
+	ChosenAvengerAssaultScreen.Navigator.Clear();
+	ChosenAvengerAssaultScreen.Navigator.LoopSelection = true;
+
+	// KDM : The navigation system need not be setup for controller users, since they use hotlinks.
+	if (!`ISCONTROLLERACTIVE)
+	{
+		// KDM : Add the 'launch mission' button to the Navigator.
+		class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(ChosenAvengerAssaultScreen, Button1, SelectionSet);
+	}
+}
+
+simulated function OnButtonSizeRealized()
+{
+	if (ChosenAvengerAssaultScreen != none)
+	{
+		Button1.SetX(-Button1.Width / 2.0);
+		Button1.SetY(10.0);
+	}
+}
+
+defaultproperties
+{
+	ScreenClass = UIMission_ChosenAvengerAssault
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_Mission_ChosenStronghold.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_Mission_ChosenStronghold.uc
@@ -1,0 +1,223 @@
+//---------------------------------------------------------------------------------------
+//	FILE :		UIScreenListener_Mission_ChosenStronghold.uc
+//	AUTHOR :	KDM
+//	PURPOSE :	Set up the UIMission_ChosenStronghold screen such that :
+//				- For controller users, the 'launch mission', 'cancel mission', and 'locked mission' buttons appear 
+//				as parent-panel centered hotlinks.
+//				- For mouse and keyboard users, the 'launch mission', 'cancel mission', and 'locked mission' buttons
+//				appear as parent-panel centered conventional buttons.
+//---------------------------------------------------------------------------------------
+
+class UIScreenListener_Mission_ChosenStronghold extends UIScreenListener;
+
+var UIMission_ChosenStronghold ChosenStrongholdScreen;
+var UIButton Button1, Button2, LockedButton;
+
+event OnInit(UIScreen Screen)
+{
+	ChosenStrongholdScreen = UIMission_ChosenStronghold(Screen);
+	// KDM : If CanTakeMission is true then LockedButton will be 'none'; if CanTakeMission is false then Button1 
+	// and Button2 will both be 'none'.
+	Button1 = ChosenStrongholdScreen.Button1;
+	Button2 = ChosenStrongholdScreen.Button2;
+	LockedButton = ChosenStrongholdScreen.LockedButton;
+
+	// KDM : Display parent-panel centered hotlinks for controller users, and parent-panel centered buttons
+	// for mouse and keyboard users.
+	if (`ISCONTROLLERACTIVE)
+	{
+		if (ChosenStrongholdScreen.CanTakeMission())
+		{
+			Button1.OnSizeRealized = OnButtonSizeRealized;
+			// KDM : Allow the hotlink to be shorter than 150 pixels, its flash-based default.
+			Button1.MC.SetNum("MIN_WIDTH", 50);
+			// KDM : Enable hotlink resizing.
+			Button1.SetResizeToText(true);
+			// KDM : Actually 'make' it a hotlink with a gamepad icon.
+			Button1.SetStyle(eUIButtonStyle_HOTLINK_BUTTON);
+			Button1.SetGamepadIcon(class 'UIUtilities_Input'.static.GetAdvanceButtonIcon());
+			// KDM : Set the hotlink's text so OnSizeRealized is called; this is where we center it within its
+			// parent panel.
+			Button1.SetText(Button1.Text);
+
+			Button2.OnSizeRealized = OnButtonSizeRealized;
+			Button2.MC.SetNum("MIN_WIDTH", 50);
+			Button2.SetResizeToText(true);
+			Button2.SetStyle(eUIButtonStyle_HOTLINK_BUTTON);
+			Button2.SetGamepadIcon(class 'UIUtilities_Input'.static.GetBackButtonIcon());
+			Button2.SetText(Button2.Text);
+		}
+		else
+		{
+			// KDM : LockedButton is already set up to be a resizing hotlink; therefore, we need not set
+			// its style nor its text-resizing property.
+			LockedButton.OnSizeRealized = OnLockedButtonSizeRealized;
+			LockedButton.MC.SetNum("MIN_WIDTH", 50);
+			LockedButton.SetText(LockedButton.Text);
+		}
+	}
+	else
+	{
+		if (ChosenStrongholdScreen.CanTakeMission())
+		{
+			// KDM : Resizing is already removed from Button1 and Button2; therefore, simply set their width
+			// and position them manually.
+			Button1.SetWidth(300);
+			Button1.SetPosition(-150, 0);
+
+			Button2.SetWidth(300);
+			Button2.SetPosition(-150, 31);
+		}
+		else
+		{
+			// KDM : We want LockedButton to be nice and wide; therefore, remove its text resizing and set its width
+			// and position manually.
+			LockedButton.SetResizeToText(false);
+			LockedButton.SetWidth(300);
+			LockedButton.SetPosition(50, 120);
+		}
+
+	}
+
+	// KDM : The navigation system, set up in UIMission.RefreshNavigation, is a mess; clean it up here.
+	RefreshNavigation();
+	
+	`HQPRES.ScreenStack.SubscribeToOnInputForScreen(Screen, OnChosenStrongholdMissionCommand);
+}
+
+event OnRemoved(UIScreen Screen)
+{
+	if (Button1 != none)
+	{
+		Button1.OnSizeRealized = none;
+	}
+	if (Button2 != none)
+	{
+		Button2.OnSizeRealized = none;
+	}
+	if (LockedButton != none)
+	{
+		LockedButton.OnSizeRealized = none;
+	}
+
+	Button1 = none;
+	Button2 = none;
+	LockedButton = none;
+	ChosenStrongholdScreen = none;
+
+	`HQPRES.ScreenStack.UnsubscribeFromOnInputForScreen(Screen, OnChosenStrongholdMissionCommand);
+}
+
+simulated function RefreshNavigation()
+{
+	local bool SelectionSet;
+
+	SelectionSet = false;
+
+	// KDM : Enable focus cascading so Navigator.Clear kills 'all' UI focus.
+	ChosenStrongholdScreen.LibraryPanel.bCascadeFocus = true;
+	ChosenStrongholdScreen.ButtonGroup.bCascadeFocus = true;
+
+	// KDM : Empty the navigation system.
+	ChosenStrongholdScreen.Navigator.Clear();
+	ChosenStrongholdScreen.Navigator.LoopSelection = true;
+
+	// KDM : The navigation system need not be setup for controller users, since they use hotlinks.
+	if (!`ISCONTROLLERACTIVE)
+	{
+		if (ChosenStrongholdScreen.CanTakeMission())
+		{
+			// KDM : Add the 'launch mission' and 'cancel mission' buttons to the Navigator.
+			SelectionSet = class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(ChosenStrongholdScreen, Button1, SelectionSet);
+			SelectionSet = class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(ChosenStrongholdScreen, Button2, SelectionSet);
+		}
+		else
+		{
+			// KDM : Add the 'locked mission' button to the Navigator.
+			class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(ChosenStrongholdScreen, LockedButton, SelectionSet);
+		}
+	}
+}
+
+simulated function OnButtonSizeRealized()
+{
+	if (ChosenStrongholdScreen != none)
+	{
+		Button1.SetX(-Button1.Width / 2.0);
+		Button1.SetY(10.0);
+
+		Button2.SetX(-Button2.Width / 2.0);
+		Button2.SetY(40.0);
+	}
+}
+
+simulated function OnLockedButtonSizeRealized()
+{
+	if (ChosenStrongholdScreen != none)
+	{
+		LockedButton.SetX(200 - LockedButton.Width / 2.0);
+		LockedButton.SetY(125.0);
+	}
+}
+
+simulated protected function bool OnChosenStrongholdMissionCommand(UIScreen Screen, int cmd, int arg)
+{
+	local UIButton SelectedButton;
+
+	if (!Screen.CheckInputIsReleaseOrDirectionRepeat(cmd, arg))
+	{
+		return false;
+	}
+
+	// KDM : Exit if the screen doesn't exist yet.
+	if (ChosenStrongholdScreen == none)
+	{
+		return false;
+	}
+
+	switch(cmd)
+	{
+	// KDM : UIMission_ChosenStronghold.OnUnrealCommand would only 'click' on Button1 or Button2 if they were
+	// focused; since controller users use hotlinks remove this requirement.
+	case class'UIUtilities_Input'.const.FXS_BUTTON_A:
+		if (ChosenStrongholdScreen.CanTakeMission() && Button1 != none && Button1.bIsVisible)
+		{
+			Button1.Click();
+		}
+		else if (Button2 != none && Button2.bIsVisible)
+		{
+			Button2.Click();
+		}
+		return true;
+
+	// KDM : UIMission_ChosenStronghold.OnUnrealCommand ignores B button presses unless the mission is locked.
+	// This allows the B button to back out of the screen when the mission is unlocked, assuming certain conditions
+	// are met.
+	case class'UIUtilities_Input'.const.FXS_BUTTON_B:
+		if(ChosenStrongholdScreen.CanBackOut() && Button2 != none && Button2.bIsVisible)
+		{
+			ChosenStrongholdScreen.CloseScreen();
+			return true;
+		}
+		break;
+
+	// KDM : The spacebar and enter key 'click' on the selected button. Previously, the spacebar and
+	// enter key would only attempt to 'click' ConfirmButton or Button1.
+	case class'UIUtilities_Input'.const.FXS_KEY_ENTER:
+	case class'UIUtilities_Input'.const.FXS_KEY_SPACEBAR:
+		SelectedButton = UIButton(ChosenStrongholdScreen.Navigator.GetSelected());
+		if (SelectedButton != none && SelectedButton.OnClickedDelegate != none)
+		{
+			SelectedButton.Click();
+			return true;
+		}
+		break;
+	}
+
+	return false;
+}
+
+defaultproperties
+{
+	ScreenClass = UIMission_ChosenStronghold
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_Mission_GPIntelOptions.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_Mission_GPIntelOptions.uc
@@ -1,0 +1,236 @@
+//---------------------------------------------------------------------------------------
+//	FILE :		UIScreenListener_Mission_GPIntelOptions.uc
+//	AUTHOR :	KDM
+//	PURPOSE :	Set up the UIMission_GPIntelOptions final-mission screen such that :
+//				- For controller users, the 'launch mission', 'cancel mission', and 'locked mission' buttons appear 
+//				as parent-panel centered hotlinks.
+//				- For mouse and keyboard users, the 'launch mission', 'cancel mission', and 'locked mission' buttons
+//				appear as parent-panel centered conventional buttons.
+//---------------------------------------------------------------------------------------
+
+class UIScreenListener_Mission_GPIntelOptions extends UIScreenListener;
+
+var UIMission_GPIntelOptions GPIntelOptionsScreen;
+var UIButton Button1, Button2, LockedButton;
+
+event OnInit(UIScreen Screen)
+{
+	GPIntelOptionsScreen = UIMission_GPIntelOptions(Screen);
+	// KDM : If CanTakeMission is true then LockedButton will be 'none'; if CanTakeMission is false then Button1 
+	// and Button2 will both be 'none'. Buttons which are not 'none' will have the eUIButtonStyle_HOTLINK_BUTTON style
+	// and will resize according to their text.
+	Button1 = GPIntelOptionsScreen.Button1;
+	Button2 = GPIntelOptionsScreen.Button2;
+	LockedButton = GPIntelOptionsScreen.LockedButton;
+
+	// KDM : Display parent-panel centered hotlinks for controller users, and parent-panel centered buttons
+	// for mouse and keyboard users.
+	if (`ISCONTROLLERACTIVE)
+	{
+		if (GPIntelOptionsScreen.CanTakeMission())
+		{
+			Button1.OnSizeRealized = OnButtonSizeRealized;
+			// KDM : Allow the hotlink to be shorter than 150 pixels, its flash-based default.
+			Button1.MC.SetNum("MIN_WIDTH", 50);
+			// KDM : Set the hotlink's text so OnSizeRealized is called; this is where we center it within its
+			// parent panel.
+			Button1.SetText(Button1.Text);
+
+			Button2.OnSizeRealized = OnButtonSizeRealized;
+			Button2.MC.SetNum("MIN_WIDTH", 50);
+			Button2.SetText(Button2.Text);
+		}
+		else
+		{
+			LockedButton.OnSizeRealized = OnLockedButtonSizeRealized;
+			LockedButton.MC.SetNum("MIN_WIDTH", 50);
+			LockedButton.SetText(LockedButton.Text);
+		}
+	}
+	else
+	{
+		if (GPIntelOptionsScreen.CanTakeMission())
+		{
+			// KDM : Within UIMission_GPIntelOptions Button1.OnSizeRealized, Button2.OnSizeRealized, and
+			// LockedButton.OnSizeRealized all point to OnButtonSizeRealized, a function which changes all 3
+			// button's positions. We don't want this, so override OnSizeRealized. 
+			Button1.OnSizeRealized = OnButtonSizeRealized;
+			// KDM : We want the buttons to be nice and wide; therefore, remove their text resizing and set their width
+			// and position manually.
+			Button1.SetResizeToText(false);
+			Button1.SetWidth(300);
+			Button1.SetPosition(-150, 0);
+
+			Button2.OnSizeRealized = OnButtonSizeRealized;
+			Button2.SetResizeToText(false);
+			Button2.SetWidth(300);
+			Button2.SetPosition(-150, 31);
+		}
+		else
+		{
+			LockedButton.OnSizeRealized = OnLockedButtonSizeRealized;
+			LockedButton.SetResizeToText(false);
+			LockedButton.SetWidth(300);
+			LockedButton.SetPosition(50, 90);
+		}
+	}
+
+	// KDM : The navigation system, set up in UIMission.RefreshNavigation, is a mess; clean it up here.
+	RefreshNavigation();
+	
+	`HQPRES.ScreenStack.SubscribeToOnInputForScreen(Screen, OnGPIntelOptionsMissionCommand);	
+}
+
+event OnRemoved(UIScreen Screen)
+{
+	if (Button1 != none)
+	{
+		Button1.OnSizeRealized = none;
+	}
+	if (Button2 != none)
+	{
+		Button2.OnSizeRealized = none;
+	}
+	if (LockedButton != none)
+	{
+		LockedButton.OnSizeRealized = none;
+	}
+
+	Button1 = none;
+	Button2 = none;
+	LockedButton = none;
+	GPIntelOptionsScreen = none;
+
+	`HQPRES.ScreenStack.UnsubscribeFromOnInputForScreen(Screen, OnGPIntelOptionsMissionCommand);
+}
+
+simulated function RefreshNavigation()
+{
+	local bool SelectionSet;
+	local int i;
+	local UIList List;
+	local UIMechaListItem ListItem;
+	local UIPanel IntelPanel;
+
+	SelectionSet = false;
+
+	List = GPIntelOptionsScreen.List;
+
+	// KDM : An unlocked final mission screen makes use of a special navigation system which consists of a list, and 
+	// a variety of buttons. Just leave it 'as is' !
+	if (!GPIntelOptionsScreen.CanTakeMission())
+	{
+		// KDM : Enable focus cascading so Navigator.Clear kills 'all' UI focus.
+		GPIntelOptionsScreen.LibraryPanel.bCascadeFocus = true;
+		IntelPanel = GPIntelOptionsScreen.LibraryPanel.GetChildByName('IntelPanel', false);
+		if (IntelPanel != none)
+		{
+			IntelPanel.bCascadeFocus = true;
+		}
+		GPIntelOptionsScreen.ButtonGroup.bCascadeFocus = true;
+
+		// KDM : Empty the navigation system.
+		GPIntelOptionsScreen.Navigator.Clear();
+		GPIntelOptionsScreen.Navigator.LoopSelection = true;
+
+		// KDM : The navigation system need not be setup for controller users, since they use hotlinks.
+		if (!`ISCONTROLLERACTIVE)
+		{
+			// KDM : Add the 'locked mission' button to the Navigator.
+			class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(GPIntelOptionsScreen, LockedButton, SelectionSet);
+		}
+
+		// KDM : If the mission is locked then disable all of the intel option buttons.
+		for (i = 0; i < List.ItemCount; i++)
+		{
+			ListItem = UIMechaListItem(List.GetItem(i));
+			if (ListItem != none)
+			{
+				ListItem.SetDisabled(true);
+			}
+		}
+	}
+}
+
+simulated function OnButtonSizeRealized()
+{
+	// KDM : When using a mouse and keyboard, this function acts as an override for 
+	// UIMission_GPIntelOptions.OnButtonSizeRealized; therefore, we can simply exit.
+	if (!`ISCONTROLLERACTIVE)
+	{
+		return;
+	}
+
+	if (GPIntelOptionsScreen != none)
+	{
+		Button1.SetX(-Button1.Width / 2.0);
+		Button1.SetY(10.0);
+
+		Button2.SetX(-Button2.Width / 2.0);
+		Button2.SetY(40.0);
+	}
+}
+
+simulated function OnLockedButtonSizeRealized()
+{
+	if (!`ISCONTROLLERACTIVE)
+	{
+		return;
+	}
+
+	if (GPIntelOptionsScreen != none)
+	{
+		LockedButton.SetX(225 - LockedButton.Width / 2.0);
+		LockedButton.SetY(85.0);
+	}
+}
+
+simulated protected function bool OnGPIntelOptionsMissionCommand(UIScreen Screen, int cmd, int arg)
+{
+	local UIButton SelectedButton;
+
+	if (!Screen.CheckInputIsReleaseOrDirectionRepeat(cmd, arg))
+	{
+		return false;
+	}
+
+	// KDM : Exit if the screen doesn't exist yet.
+	if (GPIntelOptionsScreen == none)
+	{
+		return false;
+	}
+
+	if (!GPIntelOptionsScreen.CanTakeMission())
+	{
+		switch(cmd)
+		{
+		// KDM : UIMission_GPIntelOptions.OnUnrealCommand automatically pipes commands through the intel options
+		// list; however, when the mission is locked, we don't want to allow list navigation. Consequently, grab
+		// ahold of any up/down commands and ignore them.
+		case class'UIUtilities_Input'.const.FXS_DPAD_UP:
+		case class'UIUtilities_Input'.const.FXS_DPAD_DOWN:
+		case class'UIUtilities_Input'.const.FXS_ARROW_UP:
+		case class'UIUtilities_Input'.const.FXS_ARROW_DOWN:
+			return true;
+
+		// KDM : The spacebar and enter key 'click' on the selected button. Previously, the spacebar and
+		// enter key would only attempt to 'click' ConfirmButton or Button1.
+		case class'UIUtilities_Input'.const.FXS_KEY_ENTER:
+		case class'UIUtilities_Input'.const.FXS_KEY_SPACEBAR:
+			SelectedButton = UIButton(GPIntelOptionsScreen.Navigator.GetSelected());
+			if (SelectedButton != none && SelectedButton.OnClickedDelegate != none)
+			{
+				SelectedButton.Click();
+				return true;
+			}
+			break;
+		}
+	}
+
+	return false;
+}
+
+defaultproperties
+{
+	ScreenClass = UIMission_GPIntelOptions
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_Mission_GoldenPath.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_Mission_GoldenPath.uc
@@ -1,0 +1,196 @@
+//---------------------------------------------------------------------------------------
+//	FILE :		UIScreenListener_Mission_GoldenPath.uc
+//	AUTHOR :	KDM
+//	PURPOSE :	Set up the UIMission_GoldenPath screen such that :
+//				- For controller users, the 'launch mission', 'cancel mission', and 'locked mission' buttons appear 
+//				as parent-panel centered hotlinks.
+//				- For mouse and keyboard users, the 'launch mission', 'cancel mission', and 'locked mission' buttons
+//				appear as parent-panel centered conventional buttons.
+//---------------------------------------------------------------------------------------
+
+class UIScreenListener_Mission_GoldenPath extends UIScreenListener;
+
+var UIMission_GoldenPath GoldenPathScreen;
+var UIButton Button1, Button2, LockedButton;
+
+event OnInit(UIScreen Screen)
+{
+	GoldenPathScreen = UIMission_GoldenPath(Screen);
+	// KDM : If CanTakeMission is true then LockedButton will be 'none'; if CanTakeMission is false then Button1 
+	// and Button2 will both be 'none'. Buttons which are not 'none' will have the eUIButtonStyle_HOTLINK_BUTTON style
+	// and will resize according to their text.
+	Button1 = GoldenPathScreen.Button1;
+	Button2 = GoldenPathScreen.Button2;
+	LockedButton = GoldenPathScreen.LockedButton;
+
+	// KDM : Display parent-panel centered hotlinks for controller users, and parent-panel centered buttons
+	// for mouse and keyboard users.
+	if (`ISCONTROLLERACTIVE)
+	{
+		if (GoldenPathScreen.CanTakeMission())
+		{
+			Button1.OnSizeRealized = OnButtonSizeRealized;
+			// KDM : Allow the hotlink to be shorter than 150 pixels, its flash-based default.
+			Button1.MC.SetNum("MIN_WIDTH", 50);
+			// KDM : Set the hotlink's text so OnSizeRealized is called; this is where we center it within its
+			// parent panel.
+			Button1.SetText(Button1.Text);
+
+			Button2.OnSizeRealized = OnButtonSizeRealized;
+			Button2.MC.SetNum("MIN_WIDTH", 50);
+			Button2.SetText(Button2.Text);
+		}
+		else
+		{
+			LockedButton.OnSizeRealized = OnLockedButtonSizeRealized;
+			LockedButton.MC.SetNum("MIN_WIDTH", 50);
+			LockedButton.SetText(LockedButton.Text);
+		}
+	}
+	else
+	{
+		if (GoldenPathScreen.CanTakeMission())
+		{
+			// KDM : We want the buttons to be nice and wide; therefore, remove their text resizing and set their width
+			// and position manually.
+			Button1.SetResizeToText(false);
+			Button1.SetWidth(300);
+			Button1.SetPosition(-150, 0);
+
+			Button2.SetResizeToText(false);
+			Button2.SetWidth(300);
+			Button2.SetPosition(-150, 31);
+		}
+		else
+		{
+			LockedButton.SetResizeToText(false);
+			LockedButton.SetWidth(300);
+			LockedButton.SetPosition(50, 120);
+		}
+
+	}
+
+	// KDM : The navigation system, set up in UIMission.RefreshNavigation, is a mess; clean it up here.
+	RefreshNavigation();
+	
+	`HQPRES.ScreenStack.SubscribeToOnInputForScreen(Screen, OnGoldenPathMissionCommand);
+}
+
+event OnRemoved(UIScreen Screen)
+{
+	if (Button1 != none)
+	{
+		Button1.OnSizeRealized = none;
+	}
+	if (Button2 != none)
+	{
+		Button2.OnSizeRealized = none;
+	}
+	if (LockedButton != none)
+	{
+		LockedButton.OnSizeRealized = none;
+	}
+
+	Button1 = none;
+	Button2 = none;
+	LockedButton = none;
+	GoldenPathScreen = none;
+
+	`HQPRES.ScreenStack.UnsubscribeFromOnInputForScreen(Screen, OnGoldenPathMissionCommand);
+}
+
+simulated function RefreshNavigation()
+{
+	local bool SelectionSet;
+	local UIPanel DefaultPanel;
+
+	SelectionSet = false;
+
+	// KDM : Enable focus cascading so Navigator.Clear kills 'all' UI focus.
+	GoldenPathScreen.LibraryPanel.bCascadeFocus = true;
+	GoldenPathScreen.ButtonGroup.bCascadeFocus = true;
+	DefaultPanel = GoldenPathScreen.LibraryPanel.GetChildByName('DefaultPanel', false);
+	if (DefaultPanel != none)
+	{
+		DefaultPanel.bCascadeFocus = true;
+	}
+
+	// KDM : Empty the navigation system.
+	GoldenPathScreen.Navigator.Clear();
+	GoldenPathScreen.Navigator.LoopSelection = true;
+
+	// KDM : The navigation system need not be setup for controller users, since they use hotlinks.
+	if (!`ISCONTROLLERACTIVE)
+	{
+		if (GoldenPathScreen.CanTakeMission())
+		{
+			// KDM : Add the 'launch mission' and 'cancel mission' buttons to the Navigator.
+			SelectionSet = class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(GoldenPathScreen, Button1, SelectionSet);
+			SelectionSet = class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(GoldenPathScreen, Button2, SelectionSet);
+		}
+		else
+		{
+			// KDM : Add the 'locked mission' button to the Navigator.
+			class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(GoldenPathScreen, LockedButton, SelectionSet);
+		}
+	}
+}
+
+simulated function OnButtonSizeRealized()
+{
+	if (GoldenPathScreen != none)
+	{
+		Button1.SetX(-Button1.Width / 2.0);
+		Button1.SetY(10.0);
+
+		Button2.SetX(-Button2.Width / 2.0);
+		Button2.SetY(40.0);
+	}
+}
+
+simulated function OnLockedButtonSizeRealized()
+{
+	if (GoldenPathScreen != none)
+	{
+		LockedButton.SetX(200 - LockedButton.Width / 2.0);
+		LockedButton.SetY(125.0);
+	}
+}
+
+simulated protected function bool OnGoldenPathMissionCommand(UIScreen Screen, int cmd, int arg)
+{
+	local UIButton SelectedButton;
+
+	if (!Screen.CheckInputIsReleaseOrDirectionRepeat(cmd, arg))
+	{
+		return false;
+	}
+
+	// KDM : Exit if the screen doesn't exist yet.
+	if (GoldenPathScreen == none)
+	{
+		return false;
+	}
+
+	switch(cmd)
+	{
+	// KDM : The spacebar and enter key 'click' on the selected button. Previously, the spacebar and
+	// enter key would only attempt to 'click' ConfirmButton or Button1.
+	case class'UIUtilities_Input'.const.FXS_KEY_ENTER:
+	case class'UIUtilities_Input'.const.FXS_KEY_SPACEBAR:
+		SelectedButton = UIButton(GoldenPathScreen.Navigator.GetSelected());
+		if (SelectedButton != none && SelectedButton.OnClickedDelegate != none)
+		{
+			SelectedButton.Click();
+			return true;
+		}
+		break;
+	}
+
+	return false;
+}
+
+defaultproperties
+{
+	ScreenClass = UIMission_GoldenPath
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_UFOAttack.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_UFOAttack.uc
@@ -1,0 +1,146 @@
+//---------------------------------------------------------------------------------------
+//	FILE :		UIScreenListener_UFOAttack.uc
+//	AUTHOR :	KDM
+//	PURPOSE :	Set up the UIUFOAttack screen such that :
+//				- For controller users, the 'launch mission' button appears as a parent-panel centered hotlink.
+//				- For mouse and keyboard users, the 'launch mission' button appears as a parent-panel centered 
+//				conventional button.
+//---------------------------------------------------------------------------------------
+
+class UIScreenListener_UFOAttack extends UIScreenListener;
+
+var UIUFOAttack UFOAttackScreen;
+var UIButton Button1;
+
+event OnInit(UIScreen Screen)
+{
+	UFOAttackScreen = UIUFOAttack(Screen);
+	Button1 = UFOAttackScreen.Button1;
+	
+	// KDM : Display parent-panel centered hotlinks for controller users, and parent-panel centered buttons
+	// for mouse and keyboard users.
+	if (`ISCONTROLLERACTIVE)
+	{
+		Button1.OnSizeRealized = OnButtonSizeRealized;
+		// KDM : Allow the hotlink to be shorter than 150 pixels, its flash-based default.
+		Button1.MC.SetNum("MIN_WIDTH", 50);
+		// KDM : Enable hotlink resizing.
+		Button1.SetResizeToText(true);
+		// KDM : Actually 'make' it a hotlink with a gamepad icon.
+		Button1.SetStyle(eUIButtonStyle_HOTLINK_BUTTON);
+		Button1.SetGamepadIcon(class 'UIUtilities_Input'.static.GetAdvanceButtonIcon());
+		// KDM : Set the hotlink's text so OnSizeRealized is called; this is where we center it within its
+		// parent panel.
+		Button1.SetText(Button1.Text);
+	}
+	else
+	{
+		// KDM : Resizing is already removed from Button1; therefore, simply set its width and position it manually.
+		Button1.SetWidth(300);
+		Button1.SetPosition(-150, 0);
+	}
+
+	// KDM : The navigation system, set up in UIUFOAttack.RefreshNavigation, is a mess; clean it up here.
+	RefreshNavigation();
+
+	`HQPRES.ScreenStack.SubscribeToOnInputForScreen(Screen, OnUFOAttackCommand);
+}
+
+event OnRemoved(UIScreen Screen)
+{
+	if (Button1 != none)
+	{
+		Button1.OnSizeRealized = none;
+	}
+
+	Button1 = none;
+	UFOAttackScreen = none;
+
+	`HQPRES.ScreenStack.UnsubscribeFromOnInputForScreen(Screen, OnUFOAttackCommand);
+}
+
+simulated function RefreshNavigation()
+{
+	local bool SelectionSet;
+	local UIPanel DefaultPanel;
+
+	SelectionSet = false;
+
+	// KDM : Enable focus cascading so Navigator.Clear kills 'all' UI focus.
+	UFOAttackScreen.LibraryPanel.bCascadeFocus = true;
+	DefaultPanel = UFOAttackScreen.LibraryPanel.GetChildByName('DefaultPanel', false);
+	if (DefaultPanel != none)
+	{
+		DefaultPanel.bCascadeFocus = true;
+	}
+	UFOAttackScreen.ButtonGroup.bCascadeFocus = true;
+
+	// KDM : Empty the navigation system.
+	UFOAttackScreen.Navigator.Clear();
+	UFOAttackScreen.Navigator.LoopSelection = true;
+
+	// KDM : The navigation system need not be setup for controller users, since they use hotlinks.
+	if (!`ISCONTROLLERACTIVE)
+	{
+		// KDM : Add the 'launch mission' button to the Navigator.
+		class'UIUtilities_LW'.static.AddBtnToNavigatorAndSelect(UFOAttackScreen, Button1, SelectionSet);
+	}
+}
+
+simulated function OnButtonSizeRealized()
+{
+	if (UFOAttackScreen != none)
+	{
+		Button1.SetX(-Button1.Width / 2.0);
+		Button1.SetY(10.0);
+	}
+}
+
+simulated protected function bool OnUFOAttackCommand(UIScreen Screen, int cmd, int arg)
+{
+	local UIButton SelectedButton;
+
+	if (!Screen.CheckInputIsReleaseOrDirectionRepeat(cmd, arg))
+	{
+		return false;
+	}
+
+	// KDM : Exit if the screen doesn't exist yet.
+	if (UFOAttackScreen == none)
+	{
+		return false;
+	}
+
+	switch(cmd)
+	{
+
+	// KDM : UIUFOAttack.OnUnrealCommand would only 'click' on a button if it was selected; since controller users 
+	// use hotlinks remove this requirement.
+	case class'UIUtilities_Input'.const.FXS_BUTTON_A:
+		if (Button1 != none && Button1.bIsVisible)
+		{
+			Button1.Click();
+			return true;
+		}
+		break;
+
+	// KDM : The spacebar and enter key 'click' on the selected button. Previously, the spacebar and
+	// enter key would only attempt to 'click' a button if it was selected, and was a child of ButtonGroup.
+	case class'UIUtilities_Input'.const.FXS_KEY_ENTER:
+	case class'UIUtilities_Input'.const.FXS_KEY_SPACEBAR:
+		SelectedButton = UIButton(UFOAttackScreen.Navigator.GetSelected());
+		if (SelectedButton != none && SelectedButton.OnClickedDelegate != none)
+		{
+			SelectedButton.Click();
+			return true;
+		}
+		break;
+	}
+
+	return false;
+}
+
+defaultproperties
+{
+	ScreenClass = UIUFOAttack
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIUtilities_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIUtilities_LW.uc
@@ -546,3 +546,20 @@ static function bool ShouldShowPsiOffense(XComGameState_Unit UnitState)
 	return UnitState.IsPsiOperative() ||
 		(UnitState.GetRank() == 0 && !UnitState.CanRankUpSoldier() && `XCOMHQ.IsTechResearched('AutopsySectoid'));
 }
+
+// KDM : Adds a UIButton, if it exists and is visible, to a UIScreen's Navigator; furthermore, it selects this button
+// if SelectionSet was false.
+simulated static function bool AddBtnToNavigatorAndSelect(UIScreen TheScreen, UIButton TheButton, bool SelectionSet)
+{
+	if (TheButton != none && TheButton.bIsVisible)
+	{
+		TheScreen.Navigator.AddControl(TheButton);
+		if (!SelectionSet)
+		{
+			TheScreen.Navigator.SetSelected(TheButton);
+			return true;
+		}
+	}
+
+	return SelectionSet;
+}


### PR DESCRIPTION
…compatible for M&K users.

**Modifies : `UIMission_LWCustomMission.uc`**

The file has been re-structured so that functions appear, generally speaking, in the order in which they are called; this makes 'following the code' much easier.

------------------------------

Converts `MissionInfoText` from a `UITextContainer` to a `UIVerticalScrollingText2`

`MissionInfoText` is used to display LW specific mission information on the bottom of the mission panel, located on the left side of the screen. The problem with `UITextContainer`s is that they don't display scrolled text; this appears to be an inherent bug which was fixed by LW2 coders via the creation of `UIVerticalScrollingText2`.

------------------------------

Mission screens display hotlinks for controller users and nice, wide conventional buttons for mouse and keyboard users.

`BindLibraryItem` was modified such that, when using a controller :

1. Buttons are given the style `eUIButtonStyle_HOTLINK_BUTTON`; this way they appear as hotlinks.
2. Buttons are given a gamepad icon so the hotlink appears properly.
3. Buttons are set to resize to their text size; this helps center them within their parent panel.

`BindLibraryItem` was modified such that, when using a mouse and keyboard :

1. Buttons don't resize to their text size; this way their position and size can be set manually.

** Similar changes were also made in `BuildAlienFacilityOptionsPanel` and `BuildGoldenPathOptionsPanel` for `LockedButton`; this is a button which appears when a mission is 'locked'.

** In order to center hotlinks within their parent panel, they call `OnUnlockedButtonSizeRealized` once realized; this is necessary since their text width is not initially known. `LockedButton`, rather than calling `OnUnlockedButtonSizeRealized`, calls `OnLockedButtonSizeRealized`.

------------------------------

The code within `BuildSupplyRaidMissionPanel` and` BuildSupplyRaidOptionsPanel` has been swapped since each had 'the others' code; the same was done for `BuildLandedUFOMissionPanel` and `BuildLandedUFOOptionsPanel`.

------------------------------

Since `UIMission.RefreshNavigation` is a mess; `RefreshNavigation` was overridden. It performs the following steps :

1. It kills the navigation system and current focus.
2. If using a mouse and keyboard, it adds visible buttons to the `Navigator` and selects the 1st appropriate one. If using a controller it does nothing, since you shouldn't be able to 'navigate' hotlinks.

Ultimately, this removes navigation for controller users who use hotlinks instead, and allows mouse and keyboard users to make use of the arrow keys to navigate visible buttons.

------------------------------

`OnUnrealCommand` was overridden so that mouse and keyboard users can use the spacebar or enter key to 'activate' the selected button.

------------------------------

Miscellaneous unnecessary code was removed; this is described within the code's comments.

******************************

**Modifies : `UIUtilities_LW.uc`**

Added the function `AddBtnToNavigatorAndSelect` which adds a `UIButton`, if it exists and is visible, to a `UIScreen`'s `Navigator`; furthermore, it selects the `UIButton` if `SelectionSet` was false beforehand.

******************************

**Adds : `UIScreenListener_Mission_GoldenPath.uc`**

A screen listener which enables Golden path mission screens to follow the precedent set in custom LW mission screens (`UIMission_LWCustomMission`).
- Controller users see parent-panel centered hotlinks.
- Mouse and keyboard users see parent-panel centered conventional buttons which are navigable via the arrow keys.

******************************

**Adds : `UIScreenListener_Mission_ChosenStronghold.uc`**

A screen listener which enables the Chosen Stronghold mission screen to follow the precedent set in custom LW mission screens.
- Controller users see parent-panel centered hotlinks.
- Mouse and keyboard users see parent-panel centered conventional buttons which are navigable via the arrow keys.

******************************

**Adds : `UIScreenListener_Mission_ChosenAvengerAssault.uc`**

A screen listener which enables the Chosen Avenger Assault mission screen to follow the precedent set in custom LW mission screens.
- Controller users see parent-panel centered hotlinks.
- Mouse and keyboard users see parent-panel centered conventional buttons which are navigable via the arrow keys.

******************************

**Adds : `UIScreenListener_UFOAttack.uc`**

A screen listener which enables the UFO Attack mission screen to follow the precedent set in custom LW mission screens.
- Controller users see parent-panel centered hotlinks.
- Mouse and keyboard users see parent-panel centered conventional buttons which are navigable via the arrow keys.

******************************

**Adds : `UIScreenListener_Mission_GPIntelOptions.uc`**

A screen listener which enables the final mission screens to follow the precedent set in custom LW mission screens.

In this case, the navigation system was not modified when the mission is 'unlocked' since the UI is more complex; it consists of a list of intel-related `UIButton`s as well as normal 'accept' and 'cancel' `UIButton`s.