### PR TITLE
Move some abilities assignments from characters to weapons

### DIFF
--- a/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Character_AlienPack.uc
+++ b/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Character_AlienPack.uc
@@ -1639,7 +1639,6 @@ static function X2CharacterTemplate CreateTemplate_AdvGeneric(name TemplateName)
 			LootTimed.LootTableName='AdvTrooperM3_TimedLoot';
 			LootVulture.LootTableName='AdvTrooperM3_VultureLoot';
 			CharTemplate.Abilities.AddItem('TacticalSense');
-			CharTemplate.Abilities.AddItem('LockedOn');				// Weapon?
 			break;
 
 		case 'AdvGeneralM1_LW':
@@ -1688,8 +1687,6 @@ static function X2CharacterTemplate CreateTemplate_AdvGeneric(name TemplateName)
 			LootBase.LootTableName='AdvTrooperM2_BaseLoot';
 			LootTimed.LootTableName='AdvTrooperM2_TimedLoot';
 			LootVulture.LootTableName='AdvTrooperM2_VultureLoot';
-			CharTemplate.Abilities.AddItem('CloseCombatSpecialist');	// weapon?
-			CharTemplate.Abilities.AddItem('CloseAndPersonal');			// weapon?
 			CharTemplate.Abilities.AddItem('WillToSurvive');
 			// Run and Gun, SUppression
 			break;
@@ -1712,8 +1709,6 @@ static function X2CharacterTemplate CreateTemplate_AdvGeneric(name TemplateName)
 			LootTimed.LootTableName='AdvTrooperM2_TimedLoot';
 			LootVulture.LootTableName='AdvTrooperM2_VultureLoot';
 			CharTemplate.Abilities.AddItem('Aggression');
-			CharTemplate.Abilities.AddItem('BringEmOn');
-			CharTemplate.Abilities.AddItem('Executioner_LW');
 			break;
 
 		default:

--- a/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Item_LWAlienWeapons.uc
+++ b/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Item_LWAlienWeapons.uc
@@ -1108,6 +1108,23 @@ static function X2DataTemplate CreateTemplate_AdvElite_WPN(name TemplateName)
 	Template.Abilities.AddItem('Reload');
 	Template.Abilities.AddItem('HotLoadAmmo');
 
+	if (TemplateName == 'AdvSergeantM2_WPN')
+	{
+		Template.Abilities.AddItem('LockedOn');		//Weapon perk
+	}
+
+	if (TemplateName == 'AdvVanguard_WPN')
+	{
+		Template.Abilities.AddItem('CloseCombatSpecialist');	//Weapon perk
+		Template.Abilities.AddItem('CloseAndPersonal');			//Weapon perk
+	}
+
+	if (TemplateName == 'AdvShockTroop_WPN')
+	{
+		Template.Abilities.AddItem('BringEmOn');		//Weapon perk
+		Template.Abilities.AddItem('Executioner_LW');	//Weapon perk
+	}
+
 	Template.GameArchetype = "WP_AssaultRifle_MG.WP_AssaultRifle_MG_Advent";
 	Template.iPhysicsImpulse = 5;
 	Template.CanBeBuilt = false;

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -2113,11 +2113,9 @@ function GeneralCharacterMod(X2CharacterTemplate Template, int Difficulty)
 			break;
 		case 'AdvStunLancerM2':
 			Template.Abilities.AddItem('HunkerDown');
-			Template.Abilities.AddItem('CoupdeGrace2');
 			break;
 		case 'AdvStunLancerM3':
 			Template.Abilities.AddItem('HunkerDown');
-			Template.Abilities.AddItem('CoupdeGrace2');
 			Template.Abilities.AddItem('Whirlwind2');
 			break;
 		case 'AdvPurifierM3':
@@ -2482,6 +2480,10 @@ function ReconfigGear(X2ItemTemplate Template, int Difficulty)
 					WeaponTemplate.UIStatMarkups.RemoveItem(Markup);
 				}
 			}
+			break;
+		case 'AdvStunLancerM2_StunLance':
+		case 'AdvStunLancerM3_StunLance':
+			WeaponTemplate.Abilities.AddItem('CoupdeGrace2');
 			break;
 		default:
 			break;


### PR DESCRIPTION
Changed "LockedOn", "CloseCombatSpecialist", "CloseAndPersonal", "BringEmOn", "Executioner_LW" and  "CoupdeGrace2" from being assigned character templates to being assigned to weapon templates.

For "CloseCombatSpecialist", "CoupdeGrace2" and "BringEmOn" it is required for Ability:BOUND_WEAPON_NAME tag in the descriptions to work correctly. Additionally, as far as I can tell BringEmOn didn't even work properly the way it was set up.

For "LockedOn" and "Executioner_LW" reassignment doesn't strictly matter, but given that these abilities were assigned to weapons for other units (Gunners and Najas respectively) already, it seemed proper to move these as well.

"CloseAndPersonal" being assigned to weapon does not seem to change anything and was changed only because similar "// weapon?" comment which implied it was the intent at some point. Plus it makes more sense this way.