### PR TITLE
Update Shadow Chamber information window after boosting infiltration

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
@@ -567,6 +567,7 @@ simulated function ConfirmBoostInfiltrationCallback(Name Action)
 		// rebuild the panels to display the updated status
 		BuildMissionPanel();
 		BuildOptionsPanel();
+		UpdateShadowChamber();
 		UpdateSitreps();
 		class'UIUtilities_LW'.static.BuildMissionInfoPanel(self, MissionRef, true);
 


### PR DESCRIPTION
Simply updates Shadow Chamber information window after boosting infiltration, so you don't have to manually do this by going to the avenger and returning back.