### PR TITLE
Fixing multiplying Plasma Grenades and Nanomedikits

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -637,6 +637,10 @@ BLUESCREEN_DISORIENT_CHANCE=50
 ; Not technically a schematic, but needed here so it's removed as a
 ; `CreatorTemplateName` for Mk2 grenades
 +SchematicsToDisable=AdvancedGrenades
+; Not technically schematics either, but needed here so frag grenades
+; and medikits won't upgrade by CheckToUpgradeItems Covert Action function
++SchematicsToDisable=PlasmaGrenade
++SchematicsToDisable=BattlefieldMedicine
 
 ; LWOTC: DEPRECATED - moving to a whitelist for schematics so that
 ; LWOTC works better with mods that add new schematics. Those mods


### PR DESCRIPTION
This fixes #887 / #1037 issues of multiplying plasma grenase and nanomedikits.

For reference, upgrading occurs in X2StrategyElement_XpackStaffSlots.CheckToUpgradeItems.

There are different ways to fix this. The selected way of adding techs to SchematicsToDisable is roundabout one, and was chosen only because there is precedence of using it for AdvancedGrenades case already. But if it works it works I guess.
The alternative would be to clear BaseItem field for Nanomedikit and AlienGrenade templates, which makes somewhat more sense overall, since these items have different infinite/buildable status already. But I am not 100% sure what consequences clearing BaseItem would have, and there is comment at https://github.com/long-war-2/lwotc/blob/27ba49a62f93dfe96c8b5a17d584359cd6bd3d6d/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc#L2900 which asks not to do so.

Even better way, imho, to fix this would be to have check for equality of bInfiniteItem flag between non-upgraded and upgraded item versions about here:
https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/blob/090c0863a0e023ba48ec1772cc44949764073871/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2StrategyElement_XpackStaffSlots.uc#L739
But, changing CHL is beyond my ability and I will leave it as it is.