### PR TITLE
Fix Biggest Booms bypassing Fortress/Bastion

### DIFF
--- a/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Character_AlienPack.uc
+++ b/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Character_AlienPack.uc
@@ -1080,7 +1080,7 @@ static function X2CharacterTemplate CreateTemplate_AdvGrenadier(name TemplateNam
 	if (TemplateName == 'AdvGrenadierM3')
 	{
 		CharTemplate.Abilities.AddItem('Salvo');
-		CharTemplate.Abilities.AddItem('BiggestBooms');
+		CharTemplate.Abilities.AddItem('BiggestBooms_LW');
 	}
 
 	CharTemplate.SightedNarrativeMoments.AddItem(XComNarrativeMoment'X2NarrativeMoments.TACTICAL.AlienSitings.T_Central_AlienSightings_AdvTrooperM1');
@@ -1180,7 +1180,7 @@ static function X2CharacterTemplate CreateTemplate_AdvRocketeer(name TemplateNam
 	CharTemplate.Abilities.AddItem('DarkEventAbility_Counterattack');
 
 	if (TemplateName == 'AdvRocketeerM3')
-		CharTemplate.Abilities.AddItem('BiggestBooms');
+		CharTemplate.Abilities.AddItem('BiggestBooms_LW');
 
 	CharTemplate.SightedNarrativeMoments.AddItem(XComNarrativeMoment'X2NarrativeMoments.TACTICAL.AlienSitings.T_Central_AlienSightings_AdvTrooperM1');
 
@@ -1327,7 +1327,7 @@ static function X2CharacterTemplate CreateTemplate_AdvMECArcher(name TemplateNam
 	CharTemplate.Abilities.AddItem('DarkEventAbility_Barrier');
 
 	if (TemplateName == 'AdvMecArcherM2')
-		CharTemplate.Abilities.AddItem('BiggestBooms');
+		CharTemplate.Abilities.AddItem('BiggestBooms_LW');
 
 	CharTemplate.strBehaviorTree = "LWAdventMECArcherRoot"; // new config behavior tree parsing means we could use the group instead
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_BiggestBooms_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_BiggestBooms_LW.uc
@@ -28,7 +28,7 @@ function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGa
 				{			
 					if (WeaponDamageEffect.bIgnoreBaseDamage)
 					{	
-						return 1;
+						return 0;
 					}
 				}
 				return default.CRIT_DAMAGE_BONUS;


### PR DESCRIPTION
X2Effect_BiggestBooms_LW added check to prevent increasing damage for attacks with damage value of 0. However, AdvGrenadierM3, AdvRocketeerM3 and AdvMecArcherM2 were assigned original Biggest Booms ability, which didn't have that check and allowed them to sometimes damage normally immune targets (#999). This fixes it.
It is slight nerf to M3 Grenadiers and M3 Rocketeers, and buff to M2 Archers, since Biggest Booms didn't even work for them in the first place, as original effect checks for damage source to be bIndirectFire and Micro Missiles use standart targeting.

Additionally I have no idea why X2Effect_BiggestBooms_LW would return 1  if bIgnoreBaseDamage is set. Nothing else does this, and it directly contradicts what tooltip for Biggest Booms say (it should not affect Concussion Rocket and Bunker Buster, but right now they are affected with bonus damage of 1).