### PR TITLE
Add Chosen icons to the regions

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_Region_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_Region_LW.uc
@@ -164,6 +164,7 @@ function UpdateFlyoverText()
 {
 	local XComGameStateHistory History;
 	local XComGameState_WorldRegion RegionState;
+	local XComGameState_AdventChosen ControllingChosen;
 	local String RegionLabel;
 	local String HavenLabel;
 	local String StateLabel;
@@ -180,6 +181,12 @@ function UpdateFlyoverText()
 
 	HavenLabel = GetHavenLabel(RegionState, OutpostState);
 	RegionLabel = GetRegionLabel(RegionState, OutpostState);
+
+	ControllingChosen = RegionState.GetControllingChosen();
+	if( ControllingChosen != none && ControllingChosen.bMetXCom && !ControllingChosen.bDefeated && RegionState.HaveMadeContact() )
+	{
+		AS_SetChosenIcon(ControllingChosen.GetChosenIcon());
+	}
 	
 	HoverInfo = "";
 	if (ShowContactButton())


### PR DESCRIPTION
Adds part of the WOTC code related to displaying Chosen icons in UIStrategyMapItem_Region objects. As far as I can tell UpdateFlyoverText function of UIStrategyMapItem_Region_LW was copied from vanilla UIStrategyMapItem_Region pre-WOTC, and simply haven't been updated since.