### PR TITLE
Move some abilities assignments from characters to weapons (config ve…

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -278,6 +278,8 @@ RULER_POD_SIZE_ALERT_THRESHOLDS[3]=999
 +PrimaryWeaponAbilities=ChosenBleedingRounds
 +PrimaryWeaponAbilities=Fatality_LW
 +PrimaryWeaponAbilities=OverBearingSuperiority_LW
++PrimaryWeaponAbilities=CloseCombatSpecialist
++PrimaryWeaponAbilities=BringEmOn
 
 +SecondaryWeaponAbilities=Bladestorm
 +SecondaryWeaponAbilities=BladestormAttack
@@ -286,6 +288,7 @@ RULER_POD_SIZE_ALERT_THRESHOLDS[3]=999
 +SecondaryWeaponAbilities=FaceOff
 +SecondaryWeaponAbilities=FanFire
 +SecondaryWeaponAbilities=BloodThirst
++SecondaryWeaponAbilities=CoupdeGrace2
 
 ShouldCleanupObsoleteUnits=true
 +CharacterTypesExemptFromCleanup="StrategyCentral"


### PR DESCRIPTION
…rsion)

This does the same thing as the previous PR "Move some abilities assignments from characters to weapons" did but through different method. "LockedOn", "Executioner_LW" and "CloseAndPersonal" were excluded from the change as it was not necessary for the desctiptions of those. Part of previous comment (below) still applies.

Changed "CloseCombatSpecialist", "BringEmOn" and "CoupdeGrace2" from being assigned character templates to being assigned to weapon templates.

For "CloseCombatSpecialist", "CoupdeGrace2" and "BringEmOn" it is required for Ability:BOUND_WEAPON_NAME tag in the descriptions to work correctly. Additionally, as far as I can tell BringEmOn didn't even work properly the way it was set up.