### PR TITLE
More Psi abilities for Faceless chance reduction

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Outposts.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Outposts.ini
@@ -13,6 +13,11 @@ INITIAL_REBEL_COUNT=4			; Base number of rebels in other new outposts
 RANDOM_REBEL_COUNT=3			; Random number of rebels between 0 and this value are added to INITIAL_REBEL_COUNT
 FACELESS_SUPPLY_DRAIN=20f       ; Percent of supplies drained from the monthly supply in this haven per faceless, factoring number of days active.
 
+; These are Psi abilities which provide a bonus to detecting Faceless if a soldier liason in a Haven has at least one of them.
+; Multiple eligible Psi abilities don't stack with each other, but can stack with other things like Scanning Protocol or a Battle Scanner.
+
++FacelessReductionPsiAbilities = "MindMerge"
+
 ; This is the chance ADVENT detects a rebel doing a non-hiding job each day (by difficulty level). If successful, the buckets for retaliations get a little more full.
 JOB_DETECTION_CHANCE[0]=40
 JOB_DETECTION_CHANCE[1]=50

--- a/LongWarOfTheChosen/Config/XComLW_Outposts.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Outposts.ini
@@ -13,10 +13,13 @@ INITIAL_REBEL_COUNT=4			; Base number of rebels in other new outposts
 RANDOM_REBEL_COUNT=3			; Random number of rebels between 0 and this value are added to INITIAL_REBEL_COUNT
 FACELESS_SUPPLY_DRAIN=20f       ; Percent of supplies drained from the monthly supply in this haven per faceless, factoring number of days active.
 
-; These are Psi abilities which provide a bonus to detecting Faceless if a soldier liason in a Haven has at least one of them.
-; Multiple eligible Psi abilities don't stack with each other, but can stack with other things like Scanning Protocol or a Battle Scanner.
+; These are abilities which provide a bonus to detecting Faceless if a soldier liason in a Haven has at least one of them.
++FacelessReductionAbilities=ScanningProtocol
++FacelessReductionAbilities=MindMerge
++FacelessReductionAbilities=Battlescanner
 
-+FacelessReductionPsiAbilities = "MindMerge"
+; This is how many of the above abilities on a single liason can stack for a greater bonus to Faceless detection.
+MaxFacelessReductions = 2
 
 ; This is the chance ADVENT detects a rebel doing a non-hiding job each day (by difficulty level). If successful, the buckets for retaliations get a little more full.
 JOB_DETECTION_CHANCE[0]=40

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
@@ -269,10 +269,14 @@ function StateObjectReference CreateRebel(XComGameState NewGameState, XComGameSt
 			{
 				FacelessChance *= 0.6;
 			}
-			if (Unit.HasAbilityFromAnySource.Find(PsionAbilityName))
-			{
-				FacelessChance *= 0.6;
-			}
+       			foreach default.FacelessReductionPsiAbilities(PsionAbilityName)
+            		{
+                		if (Unit.HasAbilityFromAnySource(PsionAbilityName))
+                		{
+                    			FacelessChance *= 0.6;
+					break;
+                		}
+            		}
 			if (Unit.HasItemOfTemplateType('Battlescanner'))
 			{
 				FacelessChance *= 0.6;

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
@@ -263,23 +263,24 @@ function StateObjectReference CreateRebel(XComGameState NewGameState, XComGameSt
 	{
 		FacelessChance *= 2;
 	}
-    if (HasLiaison())
-    {
-        Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(GetLiaison().ObjectID));
-        if (Unit.IsSoldier())
-        {
-            CurrentFacelessReductions = 0;
+	
+	if (HasLiaison())
+	{
+		Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(GetLiaison().ObjectID));
+		if (Unit.IsSoldier())
+		{
+			CurrentFacelessReductions = 0;
 
-            foreach default.FacelessReductionAbilities(FacelessReductionAbilityName)
-            {
-                if (Unit.HasAbilityFromAnySource(FacelessReductionAbilityName) && CurrentFacelessReductions < default.MaxFacelessReductions)
-                {
-                    CurrentFacelessReductions++;
-                    FacelessChance *= 0.6;
-                }
-            }
-        }
-    }
+			foreach default.FacelessReductionAbilities(FacelessReductionAbilityName)
+			{
+				if (Unit.HasAbilityFromAnySource(FacelessReductionAbilityName) && CurrentFacelessReductions < default.MaxFacelessReductions)
+				{
+					CurrentFacelessReductions++;
+					FacelessChance *= 0.6;
+				}
+			}
+		}
+	}
 
 	if (forceFaceless || (allowFaceless && `SYNC_FRAND() < FacelessChance && GetNumFaceless() / GetRebelCount() < default.MAX_FACELESS_PROPORTION))
 	{

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
@@ -265,7 +265,7 @@ function StateObjectReference CreateRebel(XComGameState NewGameState, XComGameSt
 			{
 				FacelessChance *= 0.6;
 			}
-			if (Unit.HasSoldierAbility('MindMerge'))
+			if (Unit.HasSoldierAbility('MindMerge') || Unit.HasSoldierAbility('Soulfire') || Unit.HasSoldierAbility('Insanity'))
 			{
 				FacelessChance *= 0.6;
 			}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
@@ -269,12 +269,9 @@ function StateObjectReference CreateRebel(XComGameState NewGameState, XComGameSt
 			{
 				FacelessChance *= 0.6;
 			}
-			foreach default.FacelessReductionPsiAbilities(PsionAbilityName)
+			if (Unit.HasAbilityFromAnySource.Find(PsionAbilityName))
 			{
-				if (Unit.HasAbilityFromAnySource(PsionAbilityName))
-				{
-					FacelessChance *= 0.6;
-				}
+				FacelessChance *= 0.6;
 			}
 			if (Unit.HasItemOfTemplateType('Battlescanner'))
 			{

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
@@ -75,7 +75,10 @@ var const config int DEFAULT_OUTPOST_MAX_SIZE;
 var const config float DEFAULT_FACELESS_CHANCE;
 
 // Faceless won't generate if they will take the proportion in the Haven past this value
-var config float MAX_FACELESS_PROPORTION;		
+var config float MAX_FACELESS_PROPORTION;
+
+// Psi abilities which reduce the chance of recruiting Faceless if the liason has at least one of them (they don't stack)
+var config array<name> FacelessReductionPsiAbilities;
 
 // Outpost will begin with INITIAL_REBEL_COUNT + Rand(0, RANDOM_REBEL_COUNT)
 // rebels.
@@ -245,6 +248,7 @@ function StateObjectReference CreateRebel(XComGameState NewGameState, XComGameSt
 	local array<X2StrategyElementTemplate> PersonalityTemplates;
 	local StateObjectReference NewUnitRef;
 	local float FacelessChance;
+	local name PsionAbilityName;
 
 	CharacterGenerator = `XCOMGRI.Spawn(class'XGCharacterGenerator');
 	nmCountry = RegionState.GetMyTemplate().GetRandomCountryInRegion();
@@ -265,9 +269,12 @@ function StateObjectReference CreateRebel(XComGameState NewGameState, XComGameSt
 			{
 				FacelessChance *= 0.6;
 			}
-			if (Unit.HasSoldierAbility('MindMerge') || Unit.HasSoldierAbility('Soulfire') || Unit.HasSoldierAbility('Insanity'))
+			foreach default.FacelessReductionPsiAbilities(PsionAbilityName)
 			{
-				FacelessChance *= 0.6;
+				if (Unit.HasAbilityFromAnySource(PsionAbilityName))
+				{
+					FacelessChance *= 0.6;
+				}
 			}
 			if (Unit.HasItemOfTemplateType('Battlescanner'))
 			{


### PR DESCRIPTION
The edited line now checks for one of the following abilities: Mind Merge, Soulfire, or Insanity for Faceless chance reduction, rather than just Mind Merge. This is for better compatibility with alternate Psi setups such as Psionics Overhaul V3 with Mod Jam.