### PR TITLE
Added aliens to Rendezvous spawns

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1999,10 +1999,6 @@ TIERED_RESPEC_TIMES=true
 +EXCLUDE_FROM_PISTOL_SLOT_CLASSES=Templar
 ; +EXCLUDE_FROM_PISTOL_SLOT_CLASSES=Skirmisher
 +EXCLUDE_FROM_PISTOL_SLOT_CLASSES=Spark
-;Allowed Weapon Categories in Pistol Slots (by default, pistol only). Items still need to be in the inventory slot eInvSlot_Pistol as with default LWOTC. 
-;Mostly for compatibility with e.g. Iridar Autopistol Overhaul or other mods adding different item categories intended for the Pistol Slot. 
-
-+PISTOL_SLOT_WEAPON_CLASSES=pistol
 
 [LW_Overhaul.Utilities_LW]
 ; Controls how frequently a scampering alien will receive an extra action point when they activate on their own turn while in yellow alert. This uses the yellow action table.

--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1999,6 +1999,10 @@ TIERED_RESPEC_TIMES=true
 +EXCLUDE_FROM_PISTOL_SLOT_CLASSES=Templar
 ; +EXCLUDE_FROM_PISTOL_SLOT_CLASSES=Skirmisher
 +EXCLUDE_FROM_PISTOL_SLOT_CLASSES=Spark
+;Allowed Weapon Categories in Pistol Slots (by default, pistol only). Items still need to be in the inventory slot eInvSlot_Pistol as with default LWOTC. 
+;Mostly for compatibility with e.g. Iridar Autopistol Overhaul or other mods adding different item categories intended for the Pistol Slot. 
+
++PISTOL_SLOT_WEAPON_CLASSES=pistol
 
 [LW_Overhaul.Utilities_LW]
 ; Controls how frequently a scampering alien will receive an extra action point when they activate on their own turn while in yellow alert. This uses the yellow action table.

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
@@ -60,9 +60,9 @@ static function bool CanAddItemToPistolSlot(
     WeaponTemplate = X2WeaponTemplate(Template);
     if (WeaponTemplate != none)
     {
-        return default.PISTOL_SLOT_WEAPON_CLASSES.Find(WeaponTemplate.WeaponCat()) == INDEX_NONE;
+        return WeaponTemplate.WeaponCat == 'pistol';
     }
-    return true;
+    return false;
 }
 
 static function bool HasPistolSlot(

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
@@ -8,7 +8,6 @@
 class CHItemSlot_PistolSlot_LW extends CHItemSlotSet config(LW_Overhaul);
 
 var config array<name> EXCLUDE_FROM_PISTOL_SLOT_CLASSES;
-var config array<name> PISTOL_SLOT_WEAPON_CLASSES;
 
 static function array<X2DataTemplate> CreateTemplates()
 {

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
@@ -8,6 +8,7 @@
 class CHItemSlot_PistolSlot_LW extends CHItemSlotSet config(LW_Overhaul);
 
 var config array<name> EXCLUDE_FROM_PISTOL_SLOT_CLASSES;
+var config array<name> PISTOL_SLOT_WEAPON_CLASSES;
 
 static function array<X2DataTemplate> CreateTemplates()
 {
@@ -59,9 +60,9 @@ static function bool CanAddItemToPistolSlot(
     WeaponTemplate = X2WeaponTemplate(Template);
     if (WeaponTemplate != none)
     {
-        return WeaponTemplate.WeaponCat == 'pistol';
+        return default.PISTOL_SLOT_WEAPON_CLASSES.Find(WeaponTemplate.WeaponCat()) == INDEX_NONE;
     }
-    return false;
+    return true;
 }
 
 static function bool HasPistolSlot(


### PR DESCRIPTION
1. Split the encounter lists for Leader and Follower (previously both drew from the same Encounter List)
2. Spectres, Archons and Sectoids can now spawn as Leaders and Followers
3. Vipers and Faceless can spawn as Followers
4. Muton Elites, Centurions, and Sectoid Commanders can spawn as Leaders
5. Officers and Priests now only spawn as Leaders
6. Trooper variants and Stun Lancers now only spawn as Followers (Sergeant included)