### PR TITLE
Possible fix to bugs with captured soldiers

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/XComGameState_LWToolboxOptions.uc
+++ b/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/XComGameState_LWToolboxOptions.uc
@@ -1609,6 +1609,7 @@ static function ReleaseSoldierFromAlienHQ(XComGameState NewGameState, StateObjec
 {
 	local XComGameState_HeadquartersAlien AlienHQ;
 
+	AlienHQ = XComGameState_HeadquartersAlien(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersAlien'));
 	// remove the soldier from the captured unit list so they don't show up again later in the playthrough
 	AlienHQ = XComGameState_HeadquartersAlien(NewGameState.ModifyStateObject(class'XComGameState_HeadquartersAlien', AlienHQ.ObjectID));
 	AlienHQ.CapturedSoldiers.RemoveItem(UnitRef);


### PR DESCRIPTION
Function ReleaseSoldierFromAlienHQ, added in "Attempt to fix issues with rescuing captured soldiers" commit, called ModifyStateObject with undefined AlienHQ, which caused following redscreen message in the log: "Redscreen: ModifyStateObject called with a specified ObjectID of '0' for class 'XComGameState_HeadquartersAlien'- this is an invalid argument!"

As far as I can tell, this caused this function to do nothing, which means soldiers captured status was not cleared. Adding the usual line for initializing AlienHQ fixed the "getting already rescued soldier as a reward" bug when I tested it. It might also be the cause of "getting empty soldier as a reward" bug, but I have not verified it, because unlike the previous bug I couldn't easily reproduce it.

Another thing to mention. I am not clear about the general mechanics of the whole StateObject system, but I do note that this function uses ModifyStateObject for XComGameState_HeadquartersAlien class, which is unlike the rest of the LWOTC code, where CreateStateObject is used in similar cases. I don't know the difference between the two, as vanilla code descriptions for both functions are basically the same. Maybe it does not matter.