### PR TITLE
Fix Fire and Steel not applying to burn tick damage

### DIFF
--- a/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
+++ b/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
@@ -613,6 +613,7 @@
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_Bombard.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_BonusGrenadeSlotUse.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_BonusRocketCharges.uc" />
+    <Content Include="Src\LW_Overhaul\Classes\X2Effect_BonusWeaponDOT.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_CancelLongRangePenalty.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_CoupDeGrace.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_CoupDeGrace2.uc" />

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_TechnicalAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_TechnicalAbilitySet.uc
@@ -838,7 +838,7 @@ static function X2DataTemplate CreateNapalmXPanicEffectAbility()
 static function X2AbilityTemplate CreateFireandSteelAbility()
 {
 	local X2AbilityTemplate                 Template;
-	local X2Effect_BonusWeaponDamage		DamageEffect;
+	local X2Effect_BonusWeaponDOT			DamageEffect;
 
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'FireandSteel');
 	Template.IconImage = "img:///UILibrary_LW_Overhaul.LW_AbilityFireandSteel";
@@ -849,8 +849,10 @@ static function X2AbilityTemplate CreateFireandSteelAbility()
 	Template.AbilityTargetStyle = default.SelfTarget;
 	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
 	Template.bIsPassive = true;
-	DamageEffect = new class'X2Effect_BonusWeaponDamage';
+	DamageEffect = new class'X2Effect_BonusWeaponDOT';
 	DamageEffect.BonusDmg = default.FIRE_AND_STEEL_DAMAGE_BONUS;
+	// Apply to burning tick effects like the description says it should
+	DamageEffect.ApplyToNonBaseDamage = true;
 	DamageEffect.BuildPersistentEffect(1, true, false, false);
 	DamageEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true,,Template.AbilitySourceName);
 	Template.AddTargetEffect(DamageEffect);

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_BonusWeaponDOT.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_BonusWeaponDOT.uc
@@ -1,0 +1,42 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Effect_BonusWeaponDOT.uc
+//  PURPOSE: Replacement for X2EffectBonusWeaponDamage modifier, which can optionally
+//           apply to damage sources with bIgnoreBaseDamage set, such as DOT effects.
+//---------------------------------------------------------------------------------------
+
+class X2Effect_BonusWeaponDOT extends X2Effect_Persistent;
+
+var int BonusDmg;
+var bool ApplyToNonBaseDamage;
+
+function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState) 
+{
+	local X2Effect_ApplyWeaponDamage DamageEffect;
+
+	if (!class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult) || CurrentDamage == 0)
+		return 0;
+
+	// only limit this when actually applying damage (not previewing)
+	if( NewGameState != none )
+	{
+		//	only add the bonus damage when the damage effect is applying the weapon's base damage
+		//  or when ApplyToNonBaseDamage is explicitly set 
+		DamageEffect = X2Effect_ApplyWeaponDamage(class'X2Effect'.static.GetX2Effect(AppliedData.EffectRef));
+		if( DamageEffect == none || (DamageEffect.bIgnoreBaseDamage && !ApplyToNonBaseDamage))
+		{
+			return 0;
+		}
+	}
+
+	if( AbilityState.SourceWeapon == EffectState.ApplyEffectParameters.ItemStateObjectRef )
+	{
+		return BonusDmg;
+	}
+
+	return 0; 
+}
+
+defaultproperties
+{
+	bDisplayInSpecialDamageMessageUI = true
+}


### PR DESCRIPTION
Fire and Steel currently do not apply its bonus damage to burn tick damage, despite the description saying it should. The issue and the solution are the same as what was solved in "Make Boosted Cores apply to tick damage".

Since burning effect have bIgnoreBaseDamage flag set, the normal X2Effect_BonusWeaponDamage won't apply to it. X2Effect_BonusWeaponDOT copies the base functionality of X2Effect_BonusWeaponDamage with an option for it to apply to sources with bIgnoreBaseDamage set, such as DOT effects.