### PR TITLE
Add the option to configure Pistol Slot weapons

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1999,7 +1999,8 @@ TIERED_RESPEC_TIMES=true
 +EXCLUDE_FROM_PISTOL_SLOT_CLASSES=Templar
 ; +EXCLUDE_FROM_PISTOL_SLOT_CLASSES=Skirmisher
 +EXCLUDE_FROM_PISTOL_SLOT_CLASSES=Spark
-
+;Add categories to the pistol slot. Currently only pistols supported, as LWOTC default. Items need to be assigned to eInvSlot_Pistol.
++LWOTC_PISTOL_SLOT_WEAPON_CAT=Pistol
 [LW_Overhaul.Utilities_LW]
 ; Controls how frequently a scampering alien will receive an extra action point when they activate on their own turn while in yellow alert. This uses the yellow action table.
 REFLEX_ACTION_CHANCE_YELLOW[0]=0.0

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
@@ -8,6 +8,7 @@
 class CHItemSlot_PistolSlot_LW extends CHItemSlotSet config(LW_Overhaul);
 
 var config array<name> EXCLUDE_FROM_PISTOL_SLOT_CLASSES;
+var config array<name> PISTOL_SLOT_WEAPON_CAT;
 
 static function array<X2DataTemplate> CreateTemplates()
 {
@@ -55,11 +56,11 @@ static function bool CanAddItemToPistolSlot(
     optional XComGameState_Item ItemState)
 {    
     local X2WeaponTemplate WeaponTemplate;
-
+//in theory: if not found in the PISTOL_SLOT_WEAPON_CAT, it´s not added. Not sure if I put this correctly. If it´s not a weapon, it won´t do anything. 
     WeaponTemplate = X2WeaponTemplate(Template);
     if (WeaponTemplate != none)
     {
-        return WeaponTemplate.WeaponCat == 'pistol';
+         return default.PISTOL_SLOT_WEAPON_CAT.Find(WeaponTemplate.WeaponCat()) == INDEX_NONE;
     }
     return false;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
@@ -8,7 +8,7 @@
 class CHItemSlot_PistolSlot_LW extends CHItemSlotSet config(LW_Overhaul);
 
 var config array<name> EXCLUDE_FROM_PISTOL_SLOT_CLASSES;
-var config array<name> PISTOL_SLOT_WEAPON_CAT;
+var config array<name> LWOTC_PISTOL_SLOT_WEAPON_CAT;
 
 static function array<X2DataTemplate> CreateTemplates()
 {
@@ -56,11 +56,11 @@ static function bool CanAddItemToPistolSlot(
     optional XComGameState_Item ItemState)
 {    
     local X2WeaponTemplate WeaponTemplate;
-//in theory: if not found in the PISTOL_SLOT_WEAPON_CAT, it´s not added. Not sure if I put this correctly. If it´s not a weapon, it won´t do anything. 
+//in theory: if not found in the LWOTC_PISTOL_SLOT_WEAPON_CAT, it´s not added to the slot. Not sure if I put this correctly.
     WeaponTemplate = X2WeaponTemplate(Template);
     if (WeaponTemplate != none)
     {
-         return default.PISTOL_SLOT_WEAPON_CAT.Find(WeaponTemplate.WeaponCat()) == INDEX_NONE;
+         return default.LWOTC_PISTOL_SLOT_WEAPON_CAT.Find(WeaponTemplate.WeaponCat()) != INDEX_NONE;
     }
     return false;
 }


### PR DESCRIPTION
Adds a LWOTC_PISTOL_SLOT_WEAPON_CAT variable to add weapon categories assigned to eInvSlot_Pistol