### PR TITLE
Allow items specified as Pistol Slot to show in Armory UI for soldiers (part 2)

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
@@ -87,11 +87,11 @@ static function bool ShowPistolItemInLockerList(
     XComGameState CheckGameState)
 {
     local X2WeaponTemplate WeaponTemplate;
-
+//UI check to show in armory. 
     WeaponTemplate = X2WeaponTemplate(ItemTemplate);
     if (WeaponTemplate != none)
     {
-        return WeaponTemplate.WeaponCat == 'pistol';
+         return default.LWOTC_PISTOL_SLOT_WEAPON_CAT.Find(WeaponTemplate.WeaponCat) != INDEX_NONE;
     }
     return false;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/CHItemSlot_PistolSlot_LW.uc
@@ -56,9 +56,10 @@ static function bool CanAddItemToPistolSlot(
     optional XComGameState_Item ItemState)
 {    
     local X2WeaponTemplate WeaponTemplate;
-//in theory: if not found in the LWOTC_PISTOL_SLOT_WEAPON_CAT, it´s not added to the slot. Not sure if I put this correctly.
+//in theory: if not found in the LWOTC_PISTOL_SLOT_WEAPON_CAT, it´s not added to the slot.
+//Not sure if I put this correctly. Also added small failsafe to prevent multiple pistols equipped as per issue 1006 (again, I have no idea)
     WeaponTemplate = X2WeaponTemplate(Template);
-    if (WeaponTemplate != none)
+       if (WeaponTemplate != none && UnitState.GetItemInSlot(Slot.InvSlot, CheckGameState) == none)
     {
          return default.LWOTC_PISTOL_SLOT_WEAPON_CAT.Find(WeaponTemplate.WeaponCat) != INDEX_NONE;
     }


### PR DESCRIPTION
I did not edit the check for allowing the item to show on the Inventory UI (so whilst soldiers could equip the specified items, they would not show in the Armory UI). I confirmed this by having a Templar with an Autopistol equipped on the secondary despite those being in eINVSlot_Pistol (Autopistol Overhaul allows sidearms and pistols to go through both slots.