### PR TITLE
Allow AI to consider overwatch counters for suppression targeting

### DIFF
--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -73,6 +73,21 @@
 +BehaviorRemovals="ConsiderTakingOverwatch"
 +NewBehaviors=(BehaviorName=ConsiderTakingOverwatch, NodeType=Selector, Child[0]=TryTwoTurnAttackSupport, Child[1]=ConsiderTakingOverwatchAllUnits)
 
+; "EvaluateSuppressionTargetByAim", "EvaluatePotentialSuppressionTarget", "EvaluateSuppressionTarget"
+; add TargetHasOverwatchCounter check to prevent suppression use on targets that have overwatch defense
++BehaviorRemovals="EvaluateSuppressionTargetByAim"
++NewBehaviors=(BehaviorName=EvaluateSuppressionTargetByAim, NodeType=Sequence, Child[0]=SetNextTarget, Child[1]=SSScoreUnsuppressedByHitChanceValue, Child[2]=TargetScoreInvalidateCivilians, Child[3]=TargetScoreInvalidateOverwatchCounter, Child[4]=UpdateBestTarget)
++BehaviorRemovals="EvaluatePotentialSuppressionTarget"
++NewBehaviors=(BehaviorName=EvaluatePotentialSuppressionTarget, NodeType=Sequence, Child[0]=SetNextTarget, Child[1]=TargetScoreUnsuppressedByClosestDistance, Child[2]=AvoidBoundAndPanickedTargets, Child[3]=TargetScoreInvalidateCivilians, Child[4]=TargetScoreInvalidateOverwatchCounter, Child[5]=UpdateBestTarget)
++BehaviorRemovals="EvaluateSuppressionTarget"
++NewBehaviors=(BehaviorName=EvaluateSuppressionTarget, NodeType=Sequence, Child[0]=SetNextTarget, Child[1]=TargetScoreUnsuppressedByClosestDistance, Child[2]=TargetScoreInvalidateCivilians, Child[3]=TargetScoreInvalidateOverwatchCounter, Child[4]=UpdateBestTarget)
+
++NewBehaviors=(BehaviorName=TargetScoreInvalidateOverwatchCounter, NodeType=Selector, Child[0]=ScoreTargetOutIfOverwatchCounter, Child[1]=AddToTargetScore_0)
++NewBehaviors=(BehaviorName=ScoreTargetOutIfOverwatchCounter, NodeType=Sequence, Child[0]=TargetHasOverwatchCounter, Child[1]=AddToTargetScore_-1000)
++NewBehaviors=(BehaviorName=TargetHasOverwatchCounter, NodeType=Selector, Child[0]=TargetAffectedByEffect-Shadowstep, Child[1]=TargetAffectedByEffect-LightningReflexes_LW)
++NewBehaviors=(BehaviorName=TargetAffectedByEffect-Shadowstep, NodeType=Condition)
++NewBehaviors=(BehaviorName=TargetAffectedByEffect-LightningReflexes_LW, NodeType=Condition)
+
 ; "GenericAIRoot" - Allow a chance to hunker (DoCower). Only used as a last resort before skipping a move.
 +BehaviorRemovals="GenericAIRoot"
 +NewBehaviors=(BehaviorName=GenericAIRoot, NodeType=Selector, Child[0]=TryNonAggressiveBehavior, Child[1]=TryMindControlledRoot, Child[2]="::CharacterRoot", Child[3]=RandOverwatch50, Child[4]=DoCower, Child[5]=SkipMove)


### PR DESCRIPTION
Saw MEC choose to suppress unit with lightning reflex, immediately tracked down the behaviours responsible for suppression targeting and added overwatch counter skill check.
TargetHasOverwatchCounter is modification of pre-existing HasOverwatchCounter behaviour.