### PR TITLE
Sectopod Lightning Field AI Fix & Priority Changes

### DIFF
--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -173,6 +173,62 @@
 +NewBehaviors=(BehaviorName=AdvCaptain_RedLastActionSelector, NodeType=Selector, Child[0]=AdvCaptainTryGrenade, Child[1]=TryHighPriorityShot, Child[2]=TryMarkTargetOption, Child[3]=TryShootOrReloadOrOverwatch, Child[4]=HuntEnemyWithCover, Child[5]=SelectMove_JobOrDefensive)
 
 ; ----------------------------------------------------------------------------------------------------------
+; --------------------------- ADVENT SECTOPOD --------------------------------------------------
+; ----------------------------------------------------------------------------------------------------------
++BehaviorRemovals="SectopodFirstActionSelector"
++NewBehaviors=(BehaviorName=SectopodFirstActionSelector, NodeType=Selector,\\
+	Child[0]=SectopodCannonCharging, \\
+	Child[1]=TryStandUp,\\
+	Child[2]=ShootWhenFlanking, \\
+	Child[3]=NeedsReload, \\
+	Child[4]=TryMoveForLightningField, \\
+	Child[5]=TakePriorityShotsChosen, \\
+	Child[6]=MoveNoCover, \\
+	Child[7]=TryShootOrReload, \\
+	Child[8]=HuntEnemy)
+
++BehaviorRemovals="SectopodSecondActionSelector"
++NewBehaviors=(BehaviorName=SectopodSecondActionSelector, NodeType=Selector,\\
+	Child[0]=SectopodCannonCharging, \\
+	Child[1]=TryStandUp,\\
+	Child[2]=TryLightningField, \\
+	Child[3]=ShootWhenFlanking, \\
+	Child[4]=NeedsReload, \\
+	Child[5]=TryMoveForLightningField, \\
+	Child[6]=MoveNoCoverIfNotMoved, \\
+	Child[7]=TryShootOrReload, \\
+	Child[8]=HuntEnemy)
+
++BehaviorRemovals="SectopodRedLastActionSelector"
++NewBehaviors=(BehaviorName=SectopodRedLastActionSelector, NodeType=Selector, \\
+	Child[0]=SectopodCannonCharging, \\
+	Child[1]=TryLightningField, \\
+	Child[2]=ShootWhenFlanking, \\
+	Child[3]=TryWrathCannonS1, \\
+	Child[4]=TryShootOrReloadOrOverwatch, \\
+	Child[5]=HuntEnemy)
+
+; variable to check lightning field is used only after TryMoveForLightningField targeting
++NewBehaviors=(BehaviorName=SetLightningFieldOff, NodeType=Action, Param[0]=SetUnitValue, Param[1]="LightningFieldSwitch", Param[2]="1")	
++NewBehaviors=(BehaviorName=SetLightningFieldOn, NodeType=Action, Param[0]=SetUnitValue, Param[1]="LightningFieldSwitch", Param[2]="2")
++NewBehaviors=(BehaviorName=IsLightningFieldOn, NodeType=StatCondition, Param[0]=UnitValue-LightningFieldSwitch, Param[1]="==", Param[2]="2")
++NewBehaviors=(BehaviorName=IsTargetInMovementRange-SectopodLightningField, NodeType=Condition)
+
++BehaviorRemovals="TryMoveForLightningField"
++NewBehaviors=(BehaviorName=TryMoveForLightningField, NodeType=Sequence, Child[0]=DidntJustMove, Child[1]=SafeToMove, Child[2]=IsAbilityReady-SectopodLightningField, Child[3]=MoveStandardIfFirstAbility-LightningField, Child[4]=SetLightningFieldOn)
+; bunch of movement profile changes so FindRestrictedDestination doesn't fail due to negative scoring
++BehaviorRemovals="FindLightningFieldDestination"
++NewBehaviors=(BehaviorName=FindLightningFieldDestination, NodeType=Sequence, Child[0]=SelectTargetForLightningField_LW, Child[1]=ResetDestinationSearch, Child[2]=RestrictToAbilityRange-SectopodLightningField, Child[3]=RestrictToEnemyLoS, Child[4]=OverrideIdealRange-3, Child[5]=FindRestrictedDestination-MWP_Fanatic)
++NewBehaviors=(BehaviorName=SelectTargetForLightningField_LW, NodeType=Sequence, Child[0]=SetPotentialTargetStack, Child[1]=SelectBestPotentialTargetForLightningField, Child[2]=HasValidTarget-Potential)
++NewBehaviors=(BehaviorName=SelectBestPotentialTargetForLightningField, NodeType=RepeatUntilFail, Child[0]=EvaluatePotentialLightningFieldTarget)
++NewBehaviors=(BehaviorName=EvaluatePotentialLightningFieldTarget, NodeType=Sequence, Child[0]=SetNextTarget, Child[1]=TargetScoreClosestLF, Child[2]=TargetScoreCivilian, Child[3]=SSCustomMeleeTargetScore, Child[4]=UpdateBestTarget)
++NewBehaviors=(BehaviorName=TargetScoreClosestLF, NodeType=Successor, Child[0]=ScoreClosestLF)
++NewBehaviors=(BehaviorName=ScoreClosestLF, NodeType=Sequence, Child[0]=TargetIsClosestValidTarget, Child[1]=IsTargetInMovementRange-SectopodLightningField, Child[2]=AddToTargetScore_500)
+
++BehaviorRemovals="TryLightningField"
++NewBehaviors=(BehaviorName=TryLightningField, NodeType=Sequence, Child[0]=IsAbilityAvailable-SectopodLightningField, Child[1]=HasAnyLightningFieldTargets, Child[2]=IsLightningFieldOn, Child[3]=SelectAbility-SectopodLightningField, Child[4]=SetLightningFieldOff)
+
+; ----------------------------------------------------------------------------------------------------------
 ; --------------------------- ADVENT PURIFIER --------------------------------------------------
 ; ----------------------------------------------------------------------------------------------------------
 

--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -208,14 +208,8 @@
 	Child[4]=TryShootOrReloadOrOverwatch, \\
 	Child[5]=HuntEnemy)
 
-; variable to check lightning field is used only after TryMoveForLightningField targeting
-+NewBehaviors=(BehaviorName=SetLightningFieldOff, NodeType=Action, Param[0]=SetUnitValue, Param[1]="LightningFieldSwitch", Param[2]="1")	
-+NewBehaviors=(BehaviorName=SetLightningFieldOn, NodeType=Action, Param[0]=SetUnitValue, Param[1]="LightningFieldSwitch", Param[2]="2")
-+NewBehaviors=(BehaviorName=IsLightningFieldOn, NodeType=StatCondition, Param[0]=UnitValue-LightningFieldSwitch, Param[1]="==", Param[2]="2")
-+NewBehaviors=(BehaviorName=IsTargetInMovementRange-SectopodLightningField, NodeType=Condition)
-
 +BehaviorRemovals="TryMoveForLightningField"
-+NewBehaviors=(BehaviorName=TryMoveForLightningField, NodeType=Sequence, Child[0]=DidntJustMove, Child[1]=SafeToMove, Child[2]=IsAbilityReady-SectopodLightningField, Child[3]=MoveStandardIfFirstAbility-LightningField, Child[4]=SetLightningFieldOn)
++NewBehaviors=(BehaviorName=TryMoveForLightningField, NodeType=Sequence, Child[0]=DidntJustMove, Child[1]=SafeToMove, Child[2]=IsAbilityReady-SectopodLightningField, Child[3]=MoveStandardIfFirstAbility-LightningField)
 ; bunch of movement profile changes so FindRestrictedDestination doesn't fail due to negative scoring
 +BehaviorRemovals="FindLightningFieldDestination"
 +NewBehaviors=(BehaviorName=FindLightningFieldDestination, NodeType=Sequence, Child[0]=SelectTargetForLightningField_LW, Child[1]=ResetDestinationSearch, Child[2]=RestrictToAbilityRange-SectopodLightningField, Child[3]=RestrictToEnemyLoS, Child[4]=OverrideIdealRange-3, Child[5]=FindRestrictedDestination-MWP_Fanatic)
@@ -224,9 +218,7 @@
 +NewBehaviors=(BehaviorName=EvaluatePotentialLightningFieldTarget, NodeType=Sequence, Child[0]=SetNextTarget, Child[1]=TargetScoreClosestLF, Child[2]=TargetScoreCivilian, Child[3]=SSCustomMeleeTargetScore, Child[4]=UpdateBestTarget)
 +NewBehaviors=(BehaviorName=TargetScoreClosestLF, NodeType=Successor, Child[0]=ScoreClosestLF)
 +NewBehaviors=(BehaviorName=ScoreClosestLF, NodeType=Sequence, Child[0]=TargetIsClosestValidTarget, Child[1]=IsTargetInMovementRange-SectopodLightningField, Child[2]=AddToTargetScore_500)
-
-+BehaviorRemovals="TryLightningField"
-+NewBehaviors=(BehaviorName=TryLightningField, NodeType=Sequence, Child[0]=IsAbilityAvailable-SectopodLightningField, Child[1]=HasAnyLightningFieldTargets, Child[2]=IsLightningFieldOn, Child[3]=SelectAbility-SectopodLightningField, Child[4]=SetLightningFieldOff)
++NewBehaviors=(BehaviorName=IsTargetInMovementRange-SectopodLightningField, NodeType=Condition)
 
 ; ----------------------------------------------------------------------------------------------------------
 ; --------------------------- ADVENT PURIFIER --------------------------------------------------

--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -208,8 +208,14 @@
 	Child[4]=TryShootOrReloadOrOverwatch, \\
 	Child[5]=HuntEnemy)
 
+; variable to check lightning field is used only after TryMoveForLightningField targeting
++NewBehaviors=(BehaviorName=SetLightningFieldOff, NodeType=Action, Param[0]=SetUnitValue, Param[1]="LightningFieldSwitch", Param[2]="1")	
++NewBehaviors=(BehaviorName=SetLightningFieldOn, NodeType=Action, Param[0]=SetUnitValue, Param[1]="LightningFieldSwitch", Param[2]="2")
++NewBehaviors=(BehaviorName=IsLightningFieldOn, NodeType=StatCondition, Param[0]=UnitValue-LightningFieldSwitch, Param[1]="==", Param[2]="2")
++NewBehaviors=(BehaviorName=IsTargetInMovementRange-SectopodLightningField, NodeType=Condition)
+
 +BehaviorRemovals="TryMoveForLightningField"
-+NewBehaviors=(BehaviorName=TryMoveForLightningField, NodeType=Sequence, Child[0]=DidntJustMove, Child[1]=SafeToMove, Child[2]=IsAbilityReady-SectopodLightningField, Child[3]=MoveStandardIfFirstAbility-LightningField)
++NewBehaviors=(BehaviorName=TryMoveForLightningField, NodeType=Sequence, Child[0]=DidntJustMove, Child[1]=SafeToMove, Child[2]=IsAbilityReady-SectopodLightningField, Child[3]=MoveStandardIfFirstAbility-LightningField, Child[4]=SetLightningFieldOn)
 ; bunch of movement profile changes so FindRestrictedDestination doesn't fail due to negative scoring
 +BehaviorRemovals="FindLightningFieldDestination"
 +NewBehaviors=(BehaviorName=FindLightningFieldDestination, NodeType=Sequence, Child[0]=SelectTargetForLightningField_LW, Child[1]=ResetDestinationSearch, Child[2]=RestrictToAbilityRange-SectopodLightningField, Child[3]=RestrictToEnemyLoS, Child[4]=OverrideIdealRange-3, Child[5]=FindRestrictedDestination-MWP_Fanatic)
@@ -218,7 +224,9 @@
 +NewBehaviors=(BehaviorName=EvaluatePotentialLightningFieldTarget, NodeType=Sequence, Child[0]=SetNextTarget, Child[1]=TargetScoreClosestLF, Child[2]=TargetScoreCivilian, Child[3]=SSCustomMeleeTargetScore, Child[4]=UpdateBestTarget)
 +NewBehaviors=(BehaviorName=TargetScoreClosestLF, NodeType=Successor, Child[0]=ScoreClosestLF)
 +NewBehaviors=(BehaviorName=ScoreClosestLF, NodeType=Sequence, Child[0]=TargetIsClosestValidTarget, Child[1]=IsTargetInMovementRange-SectopodLightningField, Child[2]=AddToTargetScore_500)
-+NewBehaviors=(BehaviorName=IsTargetInMovementRange-SectopodLightningField, NodeType=Condition)
+
++BehaviorRemovals="TryLightningField"
++NewBehaviors=(BehaviorName=TryLightningField, NodeType=Sequence, Child[0]=IsAbilityAvailable-SectopodLightningField, Child[1]=HasAnyLightningFieldTargets, Child[2]=IsLightningFieldOn, Child[3]=SelectAbility-SectopodLightningField, Child[4]=SetLightningFieldOff)
 
 ; ----------------------------------------------------------------------------------------------------------
 ; --------------------------- ADVENT PURIFIER --------------------------------------------------


### PR DESCRIPTION
- Movement profile used in FindLightningFieldDestination modified because FindRestrictedDestination-MWP_Standard was failing, causing Sectopod to not move for Lightning Field even when it could.
- TryMoveForLightningField given highest priority for movement in first and second AP. TryLightningField given highest priority in second and third AP. UnitValue used to ensure Lightning Field triggers only after successful TryMoveForLightningField check.
- TryMoveTowardVisibleEnemies50 behaviours removed because they called TryMoveForLightningField anyways, meaning they are made redundant by moving TryMoveForLightningField up.

Other changes
- Wrath Cannon checked only on last AP, ensures Sectopod can relocate for better opportunities first instead of being locked to spot.
- ShootIfAvailable replaced with TakePriorityShotsChosen for first AP, makes Sectopod more likely to move first AP for better shots if it isn't available.
- NeedsReload checked ahead of all movement on first & second AP like LW2 did for all other vanilla enemies, to "avoid move-reload turns".
- ShootWhenFlanking checked immediately after Lightning Field check. I think this is bare minimum that makes sense for AI to check before trying to move or wrath cannon, and testing reveals Sectopod still only shoots 1~2 times a turn unless player deliberately leaves unit exposed (LF is favoured ahead of shooting, and action trees are structured in a way that Sectopod has to move with either first AP or second AP without flanked target)