### PR TITLE
Update effects for CHL damage modifier hooks

### DIFF
--- a/LongWarOfTheChosen/Config/XComGameData_SoldierSkills.ini
+++ b/LongWarOfTheChosen/Config/XComGameData_SoldierSkills.ini
@@ -252,8 +252,6 @@ HOLYWARRIOR_M3_HP=9
 +SUSTAINTRIGGERUNITCHECK_LW_ARRAY=(UnitType="AdvPriestM2", PercentChance=17)
 +SUSTAINTRIGGERUNITCHECK_LW_ARRAY=(UnitType="AdvPriestM3", PercentChance=10)
 
-[LWPerkPack_Integrated.X2Effect_DeadeyeDamage]
-DamageMultiplier=0.5f
 [XComGame.X2Ability_PsiWitch]
 MIND_CONTROL_LOCAL_COOLDOWN_PLAYER=5
 MIND_CONTROL_LOCAL_COOLDOWN_AI=3

--- a/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
+++ b/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
@@ -816,6 +816,7 @@
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Effect_Cutthroat.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Effect_DamageControl.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Effect_DamnGoodGround.uc" />
+    <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Effect_DeadeyeDamage_LW.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Effect_DeadeyeDamage_SnapShot.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Effect_DenseSmokeGrenade.uc" />
     <Content Include="Src\LW_PerkPack_Integrated\Classes\X2Effect_DepthPerception.uc" />

--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_Amplify_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_Amplify_LW.uc
@@ -5,13 +5,15 @@
 //---------------------------------------------------------------------------------------
 class X2Effect_Amplify_LW extends X2Effect_Amplify;
 
-function float GetPostDefaultDefendingDamageModifier_CH
-(XComGameState_Effect EffectState,
- XComGameState_Unit SourceUnit,
-  XComGameState_Unit TargetUnit,
-   XComGameState_Ability AbilityState,
-    const out EffectAppliedData ApplyEffectParameters,
-	 float WeaponDamage, XComGameState NewGameState)
+function float GetPostDefaultDefendingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit SourceUnit,
+	XComGameState_Unit TargetUnit,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData ApplyEffectParameters,
+	float WeaponDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
 	local XComGameState_Effect_Amplify_LW AmplifyState;
 	local float DamageMod;

--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_Apotheosis.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_Apotheosis.uc
@@ -39,7 +39,9 @@ function float GetPostDefaultAttackingDamageModifier_CH(
 	Damageable Target,
 	XComGameState_Ability AbilityState,
 	const out EffectAppliedData ApplyEffectParameters,
-	float WeaponDamage, XComGameState NewGameState)
+	float WeaponDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
 	local XComGameState_Effect_FocusLevel FocusEffectState;
 	local XComGameState_Unit TargetUnit;

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_GeneralDamageModifier.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_GeneralDamageModifier.uc
@@ -3,7 +3,15 @@ class X2Effect_GeneralDamageModifier extends X2Effect_Persistent;
 var float DamageModifier;
 var name AbilityTemplate;
 
-function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState)
+function float GetPostDefaultAttackingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit Attacker,
+	Damageable TargetDamageable,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData AppliedData,
+	float CurrentDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
 	local float ExtraDamage;
 
@@ -15,7 +23,7 @@ function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGa
 			ExtraDamage = CurrentDamage * DamageModifier;
 		}
 	}
-	return int(ExtraDamage);
+	return ExtraDamage;
 }
 
 defaultproperties

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_RoustDamage.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_RoustDamage.uc
@@ -8,26 +8,29 @@ class X2Effect_RoustDamage extends X2Effect_Persistent;
 
 var float Roust_Damage_Modifier;
 
-function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState)
+function float GetPostDefaultAttackingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit Attacker,
+	Damageable TargetDamageable,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData AppliedData,
+	float CurrentDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
-    local float ExtraDamage;
-	local X2Effect_ApplyWeaponDamage		WeaponDamageEffect;
+	local float ExtraDamage;
 
-	WeaponDamageEffect = X2Effect_ApplyWeaponDamage(class'X2Effect'.static.GetX2Effect(AppliedData.EffectRef));
-	if (WeaponDamageEffect != none)
-	{			
-		if (WeaponDamageEffect.bIgnoreBaseDamage)
-		{	
-			return 0;		
-		}
+	if (WeaponDamageEffect.bIgnoreBaseDamage)
+	{	
+		return 0;		
 	}
 
-    if(AbilityState.GetMyTemplateName() == 'Roust')
-    {
+	if (AbilityState.GetMyTemplateName() == 'Roust')
+	{
 		if (class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult))
 		{
-			ExtraDamage = -1 * (float(CurrentDamage) * Roust_Damage_Modifier);
+			ExtraDamage = -CurrentDamage * Roust_Damage_Modifier;
 		}
-    }
-    return int(ExtraDamage);
+	}
+	return ExtraDamage;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2LWAbilitiesModTemplate.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2LWAbilitiesModTemplate.uc
@@ -109,6 +109,9 @@ static function UpdateAbilities(X2AbilityTemplate Template, int Difficulty)
 		case 'RevivalProtocol':
 			AllowRevivalProtocolToRemoveStunned(Template);
 			break;
+		case 'DeadeyeDamage':
+			UseNewDeadeyeEffect(Template);
+			break;
 		case 'RestorativeMist':
 			AllowRestorativeMistToRemoveStunned(Template);
 			break;
@@ -733,6 +736,20 @@ static function UpdateSustainEffect(X2AbilityTemplate Template)
 	SustainEffect.EffectName='Sustain';
 	SustainEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true,, Template.AbilitySourceName);
 	Template.AddTargetEffect(SustainEffect);
+}
+
+static function UseNewDeadeyeEffect(X2AbilityTemplate Template)
+{
+	local X2Effect_DeadeyeDamage_LW DeadeyeEffect;
+
+	// Remove old effect before adding the new one.
+	class'Helpers_LW'.static.RemoveAbilityTargetEffects(Template, 'X2Effect_DeadeyeDamage');
+
+	DeadeyeEffect = new class'X2Effect_DeadeyeDamage_LW';
+	DeadeyeEffect.BuildPersistentEffect(1, true, false, false);
+	DeadeyeEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false,,Template.AbilitySourceName);
+	DeadeyeEffect.DamageMultiplier = class'X2Effect_DeadeyeDamage'.default.DamageMultiplier;
+	Template.AddTargetEffect(DeadeyeEffect);
 }
 
 static function AllowRevivalProtocolToRemoveStunned(X2AbilityTemplate Template)

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_AbilityDamageMult.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_AbilityDamageMult.uc
@@ -21,12 +21,12 @@ function float GetPostDefaultAttackingDamageModifier_CH(
 	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
 	XComGameState NewGameState)
 {
-    local float ExtraDamage;
+	local float ExtraDamage;
 
 	//`LOG ("X2EFFECT_ADM");
 	ExtraDamage = 0.0;
-    if (Mult && AbilityState.GetMyTemplateName() == ActiveAbility)
-    {
+	if (Mult && AbilityState.GetMyTemplateName() == ActiveAbility)
+	{
 		if (class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult))
 		{
 			if (Penalty)
@@ -40,19 +40,19 @@ function float GetPostDefaultAttackingDamageModifier_CH(
 				ExtraDamage = CurrentDamage * DamageMod;
 			}
 		}
-    }
+	}
 
-    return ExtraDamage;
+	return ExtraDamage;
 }
 
 function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState)
 {
-    local int ExtraDamage;
+	local int ExtraDamage;
 
 	//`LOG ("X2EFFECT_ADM");
 	ExtraDamage = 0;
-    if (!Mult && AbilityState.GetMyTemplateName() == ActiveAbility)
-    {
+	if (!Mult && AbilityState.GetMyTemplateName() == ActiveAbility)
+	{
 		if (class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult))
 		{
 			if (Penalty)
@@ -66,5 +66,5 @@ function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGa
 		}
     }
 
-    return ExtraDamage;
+	return ExtraDamage;
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_AbilityDamageMult.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_AbilityDamageMult.uc
@@ -11,42 +11,60 @@ var bool Penalty;
 var float DamageMod;
 var name ActiveAbility;
 
-function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState)
+function float GetPostDefaultAttackingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit Attacker,
+	Damageable TargetDamageable,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData AppliedData,
+	float CurrentDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
     local float ExtraDamage;
 
 	//`LOG ("X2EFFECT_ADM");
 	ExtraDamage = 0.0;
-    if(AbilityState.GetMyTemplateName() == ActiveAbility)
+    if (Mult && AbilityState.GetMyTemplateName() == ActiveAbility)
     {
 		if (class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult))
 		{
-			if (Mult)
+			if (Penalty)
 			{
-				if (Penalty)
-				{
-					ExtraDamage = -1 * (float(CurrentDamage) * DamageMod);
-					if (CurrentDamage - ExtraDamage < 1.0f)
-						ExtraDamage = 1.0f - CurrentDamage;
-				}
-				else
-				{
-					ExtraDamage = (float(CurrentDamage) * DamageMod);
-				}
+				ExtraDamage = -CurrentDamage * DamageMod;
+				if (CurrentDamage - ExtraDamage < 1.0f)
+					ExtraDamage = 1.0f - CurrentDamage;
 			}
 			else
 			{
-				if (Penalty)
-				{
-					ExtraDamage = -1 * DamageMod;
-				}
-				else
-				{
-					ExtraDamage = DamageMod;
-				}
+				ExtraDamage = CurrentDamage * DamageMod;
 			}
 		}
     }
-	//`LOG ("Base Damage" @ CurrentDamage @ "Modifier" @ ExtraDamage);
-    return int(ExtraDamage);
+
+    return ExtraDamage;
+}
+
+function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState)
+{
+    local int ExtraDamage;
+
+	//`LOG ("X2EFFECT_ADM");
+	ExtraDamage = 0;
+    if (!Mult && AbilityState.GetMyTemplateName() == ActiveAbility)
+    {
+		if (class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult))
+		{
+			if (Penalty)
+			{
+				ExtraDamage = -1 * int(DamageMod);
+			}
+			else
+			{
+				ExtraDamage = int(DamageMod);
+			}
+		}
+    }
+
+    return ExtraDamage;
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_AbsorptionFields.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_AbsorptionFields.uc
@@ -8,7 +8,15 @@ class X2Effect_AbsorptionFields extends X2Effect_BonusArmor config (LW_SoldierSk
 
 var config float ABSORPTION_FIELDS_DAMAGE_REDUCTION_PCT;
 
-function int GetDefendingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, optional XComGameState NewGameState)
+function float GetPostDefaultDefendingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit Attacker,
+	XComGameState_Unit TargetDamageable,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData AppliedData,
+	float CurrentDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
-	return int(-1.0 * float(CurrentDamage) * default.ABSORPTION_FIELDS_DAMAGE_REDUCTION_PCT / 100.0);    
+	return -CurrentDamage * default.ABSORPTION_FIELDS_DAMAGE_REDUCTION_PCT / 100.0;
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Brawler.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Brawler.uc
@@ -9,15 +9,23 @@ var config float BRAWLER_DR_PCT;
 var config int BRAWLER_MAX_TILES;
 
 
-function int GetDefendingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, optional XComGameState NewGameState)
+function float GetPostDefaultDefendingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit Attacker,
+	XComGameState_Unit Target,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData AppliedData,
+	float CurrentDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
 	local int   Tiles;
 
-	Tiles = Attacker.TileDistanceBetween(XComGameState_Unit(TargetDamageable));       
+	Tiles = Attacker.TileDistanceBetween(Target);
 	if (Tiles < default.BRAWLER_MAX_TILES)
 	{
-        return -CurrentDamage * default.BRAWLER_DR_PCT / 100;
-    }
+		return -CurrentDamage * default.BRAWLER_DR_PCT / 100;
+	}
 	
 	return 0;
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_DeadeyeDamage_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_DeadeyeDamage_LW.uc
@@ -1,11 +1,12 @@
 //---------------------------------------------------------------------------------------
-//  FILE:   X2Effect_DeadeyeDamage_SnapShot.uc
-//  AUTHOR:  Grobobobo
-//  PURPOSE: Effect that does the same think as deadeye, but for its snapshot variant.
+//  FILE:    X2Effect_DeadeyeDamage_LW.uc
+//  AUTHOR:  Peter Ledbrook
+//  PURPOSE: Modified version of the vanilla effect that uses the Community
+//           Highlander hooks for multiplicative damage multipliers.
 //---------------------------------------------------------------------------------------
-class X2Effect_DeadeyeDamage_SnapShot extends X2Effect_Persistent config(LW_SoldierSKills);
+class X2Effect_DeadeyeDamage_LW extends X2Effect_Persistent;
 
-var config float DamageMultiplier;
+var float DamageMultiplier;
 
 function float GetPostDefaultAttackingDamageModifier_CH(
 	XComGameState_Effect EffectState,
@@ -17,14 +18,12 @@ function float GetPostDefaultAttackingDamageModifier_CH(
 	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
 	XComGameState NewGameState)
 {
-	local float ExtraDamage;
-
-	if (AbilityState.GetMyTemplateName() == 'DeadeyeSnapShot' && class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult))
+	if (AbilityState.GetMyTemplateName() == 'Deadeye' && class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult))
 	{
-		ExtraDamage = CurrentDamage * DamageMultiplier;
+		return CurrentDamage * DamageMultiplier;
 	}
 
-	return ExtraDamage;
+	return 0;
 }
 
 defaultproperties

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Formidable.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Formidable.uc
@@ -6,9 +6,17 @@ var int Armor_Mitigation;
 function int GetArmorChance(XComGameState_Effect EffectState, XComGameState_Unit UnitState) { return 100; }
 function int GetArmorMitigation(XComGameState_Effect EffectState, XComGameState_Unit UnitState) { return Armor_Mitigation; }
 
-function int GetDefendingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, optional XComGameState NewGameState)
+function float GetPostDefaultDefendingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit Attacker,
+	XComGameState_Unit Target,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData AppliedData,
+	float CurrentDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
-	local int DamageMod;
+	local float DamageMod;
 	local bool Explosives;
 	local XComGameState_Item SourceWeapon;
 	local X2WeaponTemplate WeaponTemplate;
@@ -34,11 +42,10 @@ function int GetDefendingDamageModifier(XComGameState_Effect EffectState, XComGa
 	if (WeaponTemplate != none && WeaponTemplate.DamageTypeTemplateName == 'BlazingPinions')
 		Explosives = true;
 
-	if(Explosives)
+	if (Explosives)
 	{
-		DamageMod = -int(float(CurrentDamage) * ExplosiveDamageReduction);
+		DamageMod = -CurrentDamage * ExplosiveDamageReduction;
 	}
 
 	return DamageMod;
 }
-

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_IronCurtain.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_IronCurtain.uc
@@ -21,14 +21,13 @@ function float GetPostDefaultAttackingDamageModifier_CH(
     local float ExtraDamage;
 
 	ExtraDamage = 0.0;
-    if (AbilityState.GetMyTemplateName() == 'IronCurtainShot')
-    {
+	if (AbilityState.GetMyTemplateName() == 'IronCurtainShot')
+	{
 		if (class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult))
 		{
 			ExtraDamage = -CurrentDamage * default.IRON_CURTAIN_DAMAGE_MODIFIER;
 		}
-    }
+	}
 
-    return ExtraDamage;
+	return ExtraDamage;
 }
-

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_IronCurtain.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_IronCurtain.uc
@@ -8,18 +8,27 @@ class X2Effect_IronCurtain extends X2Effect_Persistent config(LW_SoldierSkills);
 
 var config float IRON_CURTAIN_DAMAGE_MODIFIER;
 
-function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState)
+function float GetPostDefaultAttackingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit Attacker,
+	Damageable TargetDamageable,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData AppliedData,
+	float CurrentDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
     local float ExtraDamage;
 
 	ExtraDamage = 0.0;
-    if(AbilityState.GetMyTemplateName() == 'IronCurtainShot')
+    if (AbilityState.GetMyTemplateName() == 'IronCurtainShot')
     {
 		if (class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult))
 		{
-			ExtraDamage = -1 * CurrentDamage * default.IRON_CURTAIN_DAMAGE_MODIFIER;
+			ExtraDamage = -CurrentDamage * default.IRON_CURTAIN_DAMAGE_MODIFIER;
 		}
     }
-    return int(ExtraDamage);
+
+    return ExtraDamage;
 }
 

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_KillerInstinct.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_KillerInstinct.uc
@@ -17,18 +17,18 @@ function float GetPostDefaultAttackingDamageModifier_CH(
 	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
 	XComGameState NewGameState)
 {
-    local XComGameState_Item SourceWeapon;
-    local XComGameState_Unit TargetUnit;
+	local XComGameState_Item SourceWeapon;
+	local XComGameState_Unit TargetUnit;
 
 	if (WeaponDamageEffect.bIgnoreBaseDamage)
 	{	
 		return 0;		
 	}
 
-    if (AppliedData.AbilityResultContext.HitResult == eHit_Crit)
-    {
-        SourceWeapon = AbilityState.GetSourceWeapon();
-        if(SourceWeapon != none) 
+	if (AppliedData.AbilityResultContext.HitResult == eHit_Crit)
+	{
+		SourceWeapon = AbilityState.GetSourceWeapon();
+		if(SourceWeapon != none) 
         {
 			TargetUnit = XComGameState_Unit(TargetDamageable);
             if(TargetUnit != none)
@@ -37,9 +37,9 @@ function float GetPostDefaultAttackingDamageModifier_CH(
 				{
 					return CurrentDamage * default.KILLER_INSTINCT_CRIT_DAMAGE_BONUS_PCT / 100;
 				}
-            }
-        }
-    }
+			}
+		}
+	}
 
-    return 0;
+	return 0;
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_KillerInstinct.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_KillerInstinct.uc
@@ -29,10 +29,10 @@ function float GetPostDefaultAttackingDamageModifier_CH(
 	{
 		SourceWeapon = AbilityState.GetSourceWeapon();
 		if(SourceWeapon != none) 
-        {
+		{
 			TargetUnit = XComGameState_Unit(TargetDamageable);
-            if(TargetUnit != none)
-            {
+			if(TargetUnit != none)
+			{
 				if (Attacker.HasSoldierAbility('KillerInstinct'))
 				{
 					return CurrentDamage * default.KILLER_INSTINCT_CRIT_DAMAGE_BONUS_PCT / 100;

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_KillerInstinct.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_KillerInstinct.uc
@@ -7,21 +7,25 @@ class X2Effect_KillerInstinct extends X2Effect_BonusWeaponDamage config (LW_Sold
 
 var config float KILLER_INSTINCT_CRIT_DAMAGE_BONUS_PCT;
 
-function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState)
+function float GetPostDefaultAttackingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit Attacker,
+	Damageable TargetDamageable,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData AppliedData,
+	float CurrentDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
     local XComGameState_Item SourceWeapon;
     local XComGameState_Unit TargetUnit;
-	local X2Effect_ApplyWeaponDamage WeaponDamageEffect;
-	
-	WeaponDamageEffect = X2Effect_ApplyWeaponDamage(class'X2Effect'.static.GetX2Effect(AppliedData.EffectRef));
-	if (WeaponDamageEffect != none)
-	{			
-		if (WeaponDamageEffect.bIgnoreBaseDamage)
-		{	
-			return 0;		
-		}
+
+	if (WeaponDamageEffect.bIgnoreBaseDamage)
+	{	
+		return 0;		
 	}
-    if(AppliedData.AbilityResultContext.HitResult == eHit_Crit)
+
+    if (AppliedData.AbilityResultContext.HitResult == eHit_Crit)
     {
         SourceWeapon = AbilityState.GetSourceWeapon();
         if(SourceWeapon != none) 
@@ -31,11 +35,11 @@ function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGa
             {
 				if (Attacker.HasSoldierAbility('KillerInstinct'))
 				{
-					return int (CurrentDamage * (default.KILLER_INSTINCT_CRIT_DAMAGE_BONUS_PCT / 100));
+					return CurrentDamage * default.KILLER_INSTINCT_CRIT_DAMAGE_BONUS_PCT / 100;
 				}
             }
         }
     }
+
     return 0;
 }
-

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Mayhem.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Mayhem.uc
@@ -9,6 +9,7 @@ function float GetPostDefaultAttackingDamageModifier_CH(
 	XComGameState_Ability AbilityState,
 	const out EffectAppliedData AppliedData,
 	float WeaponDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
 	XComGameState NewGameState)
 {
 	local XComGameState_Item SourceWeapon;

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_PCTDamageReduction.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_PCTDamageReduction.uc
@@ -1,18 +1,22 @@
 //---------------------------------------------------------------------------------------
 //  FILE:   X2Effect_PCTDamageReduction.uc
 //  AUTHOR:  Grobobobo
-//  PURPOSE: General Damage Reduction Effect
+//  PURPOSE: General, unconditional, %-based damage reduction effect
 //---------------------------------------------------------------------------------------
 class X2Effect_PCTDamageReduction extends X2Effect_Persistent config(LW_SoldierSkills);
 
 var float PCTDamage_Reduction;
-function int GetDefendingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, optional XComGameState NewGameState)
+function float GetPostDefaultDefendingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit Attacker,
+	XComGameState_Unit TargetDamageable,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData AppliedData,
+	float CurrentDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
-	local int DamageMod;
-
-	DamageMod = -int(float(CurrentDamage) * PCTDamage_Reduction);
-
-	return DamageMod;
+	return -CurrentDamage * PCTDamage_Reduction;
 }
 
 defaultproperties

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_PrecisionShotCritDamage.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_PrecisionShotCritDamage.uc
@@ -2,18 +2,26 @@ class X2Effect_PrecisionShotCritDamage extends X2Effect_Persistent config(LW_Sol
 
 var config float PRECISION_SHOT_CRIT_DAMAGE_MODIFIER;
 
-function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState)
+function float GetPostDefaultAttackingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit Attacker,
+	Damageable TargetDamageable,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData AppliedData,
+	float CurrentDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
     local float ExtraDamage;
 	
-    if(AbilityState.GetMyTemplateName() == 'PrecisionShot')
+    if (AbilityState.GetMyTemplateName() == 'PrecisionShot')
     {
 		//`LOG ("Checking PS");
-		if(AppliedData.AbilityResultContext.HitResult == eHit_Crit)
+		if (AppliedData.AbilityResultContext.HitResult == eHit_Crit)
 		{
-			ExtraDamage = Max (1, (float(CurrentDamage) * default.PRECISION_SHOT_CRIT_DAMAGE_MODIFIER));
-			//`LOG ("Precision Shot Current/Extra Damage" @ CurrentDamage @ ExtraDamage);
+			ExtraDamage = Max(1, CurrentDamage * default.PRECISION_SHOT_CRIT_DAMAGE_MODIFIER);
 		}
     }
+
     return ExtraDamage;
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_PrecisionShotCritDamage.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_PrecisionShotCritDamage.uc
@@ -12,16 +12,16 @@ function float GetPostDefaultAttackingDamageModifier_CH(
 	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
 	XComGameState NewGameState)
 {
-    local float ExtraDamage;
+	local float ExtraDamage;
 	
-    if (AbilityState.GetMyTemplateName() == 'PrecisionShot')
-    {
+	if (AbilityState.GetMyTemplateName() == 'PrecisionShot')
+	{
 		//`LOG ("Checking PS");
 		if (AppliedData.AbilityResultContext.HitResult == eHit_Crit)
 		{
 			ExtraDamage = Max(1, CurrentDamage * default.PRECISION_SHOT_CRIT_DAMAGE_MODIFIER);
 		}
-    }
+	}
 
-    return ExtraDamage;
+	return ExtraDamage;
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_WalkFireDamage.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_WalkFireDamage.uc
@@ -8,16 +8,25 @@ class X2Effect_WalkFireDamage extends X2Effect_Persistent config(LW_SoldierSkill
 
 var config float WALK_FIRE_DAMAGE_MODIFIER;
 
-function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState)
+function float GetPostDefaultAttackingDamageModifier_CH(
+	XComGameState_Effect EffectState,
+	XComGameState_Unit Attacker,
+	Damageable TargetDamageable,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData AppliedData,
+	float CurrentDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
-    local float ExtraDamage;
+	local float ExtraDamage;
 
-    if(AbilityState.GetMyTemplateName() == 'WalkFire')
-    {
+	if (AbilityState.GetMyTemplateName() == 'WalkFire')
+	{
 		if (class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult))
 		{
-			ExtraDamage = -1 * (float(CurrentDamage) * default.WALK_FIRE_DAMAGE_MODIFIER);
+			ExtraDamage = -CurrentDamage * default.WALK_FIRE_DAMAGE_MODIFIER;
 		}
-    }
-    return int(ExtraDamage);
+	}
+
+	return ExtraDamage;
 }

--- a/LongWarOfTheChosen/Src/LW_XModBase/Classes/XMBEffect_ConditionalBonus.uc
+++ b/LongWarOfTheChosen/Src/LW_XModBase/Classes/XMBEffect_ConditionalBonus.uc
@@ -236,7 +236,9 @@ function float GetPostDefaultAttackingDamageModifier_CH(
 	Damageable Target,
 	XComGameState_Ability AbilityState,
 	const out EffectAppliedData ApplyEffectParameters,
-	float WeaponDamage, XComGameState NewGameState)
+	float WeaponDamage,
+	X2Effect_ApplyWeaponDamage WeaponDamageEffect,
+	XComGameState NewGameState)
 {
 	local ExtShotModifierInfo ExtModInfo;
 	local int BonusDamage;


### PR DESCRIPTION
This makes all %-based abilities in LWOTC use the new Community Highlander hooks that ensure they work reliably, applying percentage changes to all flat damage bonuses and penalties as well as being independent of effect order.

I also updated `X2Effect_ApplyAltWeaponDamage` so that it's inline with the latest CHL version of the base class. Ideally we would add an overridable function to the CHL base class that returns the base weapon damage. Then we could remove most of the code, but not ready to make another highlander change at this point.