### PR TITLE
Add a Covert Action to obtain a Resistance MEC

### DIFF
--- a/LongWarOfTheChosen/Config/XComGameBoard.ini
+++ b/LongWarOfTheChosen/Config/XComGameBoard.ini
@@ -620,6 +620,17 @@ MaxActionHours[0]=144
 MaxActionHours[1]=144
 MaxActionHours[2]=192
 MaxActionHours[3]=192
+
+[CovertAction_ResistanceMec X2CovertActionTemplate]
+MinActionHours[0]=120
+MinActionHours[1]=120
+MinActionHours[2]=144
+MinActionHours[3]=144
+
+MaxActionHours[0]=144
+MaxActionHours[1]=144
+MaxActionHours[2]=192
+MaxActionHours[3]=192
 ; End of easy failure risk CAs
 
 ; Currently disabled

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -2168,8 +2168,9 @@ strCharacterName="Resistance MEC"
 [Reward_Rebel X2RewardTemplate]
 DisplayName="Resistance Personnel"
 
-[Reward_ResistanceMEC X2RewardTemplate]
+[Reward_ResistanceMec X2RewardTemplate]
 DisplayName="Resistance MEC"
+RewardDetails="You'll get a Resistance MEC to guard one of your Havens."
 
 [Reward_NewResources X2RewardTemplate]
 DisplayName="New Resources"
@@ -2205,10 +2206,6 @@ RewardDetails="You'll get a selection of random enemy corpses."
 
 [Reward_Dummy_StatBoost X2RewardTemplate]
 DisplayName="Stat Boosts"
-
-[Reward_ResistanceMec X2RewardTemplate]
-DisplayName="Resistance MEC"
-RewardDetails="You'll get a Resistance MEC to guard one of your Havens."
 ; End Translation
 
 ; POI Templates

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -2168,7 +2168,7 @@ strCharacterName="Resistance MEC"
 [Reward_Rebel X2RewardTemplate]
 DisplayName="Resistance Personnel"
 
-[Reward_ResistanceMec X2RewardTemplate]
+[Reward_ResistanceMEC X2RewardTemplate]
 DisplayName="Resistance MEC"
 RewardDetails="You'll get a Resistance MEC to guard one of your Havens."
 

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -2205,6 +2205,10 @@ RewardDetails="You'll get a selection of random enemy corpses."
 
 [Reward_Dummy_StatBoost X2RewardTemplate]
 DisplayName="Stat Boosts"
+
+[Reward_ResistanceMec X2RewardTemplate]
+DisplayName="Resistance MEC"
+RewardDetails="You'll get a Resistance MEC to guard one of your Havens."
 ; End Translation
 
 ; POI Templates
@@ -5727,6 +5731,9 @@ ActionObjective="Steal Corpses"
 [CovertAction_IntenseTraining X2CovertActionTemplate]
 ActionObjective="Intense Training"
 
+[CovertAction_ResistanceMec X2CovertActionTemplate]
+ActionObjective="Obtain Resistance MEC"
+
 [CovertActionNarrative_EnemyCorpses_Skirmishers X2CovertActionNarrativeTemplate]
 ActionName="Raid an Enemy Morgue"
 ActionPreNarrative="We've discovered where they've been dumping the corpses from all the fighting you've been doing. Could be an opportunity to accelerate your tech development."
@@ -5756,6 +5763,21 @@ ActionPostNarrative="Your soldier is better now."
 ActionName="Undertake Hard Training (Cost: 5 AP)"
 ActionPreNarrative="Time to put in some effort and improve yourself. Get training, soldier!"
 ActionPostNarrative="Your soldier is better now."
+
+[CovertActionNarrative_ResistanceMec_Skirmishers X2CovertActionNarrativeTemplate]
+ActionName="Raid a Robotics Factory"
+ActionPreNarrative="We've discovered a factory that ADVENT uses to build and maintain their mechanized forces. You shouldn't have any trouble finding an inactive but intact MEC to \"recruit\" while our forces distract the security."
+ActionPostNarrative="Your team managed to secure an intact MEC unit. It has been reprogrammed, given a new paint job and sent to a nearby Resistance Haven."
+
+[CovertActionNarrative_ResistanceMec_Reapers X2CovertActionNarrativeTemplate]
+ActionName="Raid a Robotics Factory"
+ActionPreNarrative="We've discovered a factory that ADVENT uses to build and maintain their mechanized forces. You shouldn't have any trouble finding an inactive but intact MEC to \"recruit\" while our forces distract the security."
+ActionPostNarrative="Your team managed to secure an intact MEC unit. It has been reprogrammed, given a new paint job and sent to a nearby Resistance Haven."
+
+[CovertActionNarrative_ResistanceMec_Templars X2CovertActionNarrativeTemplate]
+ActionName="Raid a Robotics Factory"
+ActionPreNarrative="We've discovered a factory that ADVENT uses to build and maintain their mechanized forces. You shouldn't have any trouble finding an inactive but intact MEC to \"recruit\" while our forces distract the security."
+ActionPostNarrative="Your team managed to secure an intact MEC unit. It has been reprogrammed, given a new paint job and sent to a nearby Resistance Haven."
 
 [AbilityPoints X2ItemTemplate]
 FriendlyName="Ability Points"

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2LWCovertActionsModTemplate.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2LWCovertActionsModTemplate.uc
@@ -36,6 +36,7 @@ static function UpdateCovertActions(X2StrategyElementTemplate Template, int Diff
 		case 'CovertAction_GatherIntel':
 		case 'CovertAction_FormSoldierBond':
 		case 'CovertAction_AlienLoot':
+		case 'CovertAction_ResistanceMec':
 			ConfigureEasyCovertAction(CATemplate);
 			break;
 		case 'CovertAction_RecruitScientist':

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultCovertActions_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultCovertActions_LW.uc
@@ -87,7 +87,6 @@ static function X2DataTemplate CreateResistanceMecTemplate()
     // also adds the Failure risk.
 
 	Template.Risks.AddItem('CovertActionRisk_Ambush');
-	Template.Risks.AddItem('CovertActionRisk_SoldierCaptured');
 
 	Template.Rewards.AddItem(class'X2StrategyElement_DefaultRewards_LW'.const.RESISTANCE_MEC_REWARD_NAME);
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultCovertActions_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultCovertActions_LW.uc
@@ -12,6 +12,7 @@ static function array<X2DataTemplate> CreateTemplates()
 
 	CovertActions.AddItem(CreateEnemyCorpsesTemplate());
 	CovertActions.AddItem(CreateIntenseTrainingTemplate());
+	CovertActions.AddItem(CreateResistanceMecTemplate());
 
 	return CovertActions;
 }
@@ -64,6 +65,31 @@ static function X2DataTemplate CreateIntenseTrainingTemplate()
 	Template.Cost.ResourceCosts.AddItem(Resources);
 
 	Template.Rewards.AddItem('Reward_Dummy_StatBoost');
+
+	return Template;
+}
+
+static function X2DataTemplate CreateResistanceMecTemplate()
+{
+	local X2CovertActionTemplate Template;
+
+	`CREATE_X2TEMPLATE(class'X2CovertActionTemplate', Template, 'CovertAction_ResistanceMec');
+
+	Template.ChooseLocationFn = ChooseRandomRegion;
+	Template.OverworldMeshPath = "UI_3D.Overwold_Final.CovertAction";
+
+	Template.Narratives.AddItem('CovertActionNarrative_ResistanceMec_Skirmishers');
+	Template.Narratives.AddItem('CovertActionNarrative_ResistanceMec_Reapers');
+	Template.Narratives.AddItem('CovertActionNarrative_ResistanceMec_Templars');
+
+    // NOTE: Soldier slots configured in `X2LWCovertActionsModTemplate` for consistency and
+    // because some Firaxis developer keeps making functions private..... The template mod
+    // also adds the Failure risk.
+
+	Template.Risks.AddItem('CovertActionRisk_Ambush');
+	Template.Risks.AddItem('CovertActionRisk_SoldierCaptured');
+
+	Template.Rewards.AddItem(class'X2StrategyElement_DefaultRewards_LW'.const.RESISTANCE_MEC_REWARD_NAME);
 
 	return Template;
 }


### PR DESCRIPTION
I felt like we needed some more early covert actions to populate the pool, and Resistance MECs are neat, so why not?