### PR TITLE
Warlock Teleport AI Improvement

### DIFF
--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -1272,11 +1272,11 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 +Behaviors=(BehaviorName=ChosenWarlockLastAction, NodeType=Sequence, Child[0]=IsLastActionPoint, Child[1]=ChosenWarlockLastActionSelector)
 
 +Behaviors=(BehaviorName="ChosenWarlockFirstActionSelector", NodeType=Selector, \\
-			Child[0]=TryAmmoDump, \\
-			Child[1]=TryShieldAlly, \\
-			Child[2]=DoIfFlankedMove,\\
-			Child[3]=TryTeleportAlly, \\
-			Child[4]=TryChosenSummon, \\
+			Child[0]=TryChosenSummon, \\
+			Child[1]=TryAmmoDump, \\
+			Child[2]=TryShieldAlly, \\
+			Child[3]=DoIfFlankedMove, \\
+			Child[4]=TryTeleportAlly, \\
 			Child[5]=TakePriorityshotsChosen, \\
 			Child[6]=TryMindScorch, \\
 			Child[7]=TryPsiMindControl, \\
@@ -1285,14 +1285,15 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 
 +Behaviors=(BehaviorName="ChosenWarlockLastActionSelector", NodeType=Selector, \\
 			Child[0]=TryChosenSummon, \\
-			Child[1]=TryAmmoDump,\\
+			Child[1]=TryAmmoDump, \\
 			Child[2]=TryShieldAlly, \\
 			Child[3]=TakePriorityshotsChosen, \\
 			Child[4]=TryMindScorch, \\
 			Child[5]=TryPsiMindControl, \\
-			Child[6]=DoIfFlankedMove,\\
-			Child[7]=TryShootOrReloadOrOverwatch, \\
-			Child[8]=HuntEnemyWithCover)
+			Child[6]=TryTeleportAlly, \\
+			Child[7]=DoIfFlankedMove, \\
+			Child[8]=TryShootOrReloadOrOverwatch, \\
+			Child[9]=HuntEnemyWithCover)
 
 +Behaviors=(BehaviorName=WarlockReaction, NodeType=Selector, Child[0]=DoIfFlankedPrimeFallback, Child[1]=NeedsReload, Child[2]=TryCombatReadiness)
 
@@ -1345,7 +1346,8 @@ MAX_SURPRISED_SCAMPER_PATH_LENGTH=7		; Scamper paths longer than this number of 
 +Behaviors=(BehaviorName=TargetTemplateNameIs-AdvPriestM3, NodeType=Condition)
 
 -Behaviors=(BehaviorName=EvaluateForTeleportAlly, NodeType=Sequence, Child[0]=TargetHasRevealed, Child[1]=TargetNotFlanking, Child[2]=TargetNotSpectral, Child[3]=GenericScoreTargetRandomlySequence)
-+Behaviors=(BehaviorName=EvaluateForTeleportAlly, NodeType=Sequence, Child[0]=TargetHasRevealed, Child[1]=TargetNotFlanking, Child[2]=TargetNotSpectral, Child[3]=TargetIsNotMelee, Child[4]=TargetIsNotCocoon, Child[5]=GenericScoreTargetRandomlySequence)
++Behaviors=(BehaviorName=EvaluateForTeleportAlly, NodeType=Sequence, Child[0]=TargetHasRevealed, Child[1]=TargetNotFlanking, Child[2]=TargetNotSpectral, Child[3]=TargetIsNotMelee, Child[4]=TargetIsNotCocoon, Child[5]=TargetIsNotInFirstCombatTurn, Child[6]=GenericScoreTargetRandomlySequence)
++Behaviors=(BehaviorName=TargetIsNotInFirstCombatTurn, NodeType=TargetStatCondition, Param[0]=TurnsEngaged, Param[1]=">=", Param[2]="2")
 
 +Behaviors=(BehaviorName=TargetIsNotCocoon, NodeType=Inverter, Child[0]=TargetTemplateNameIs-ChryssalidCocoon)
 +Behaviors=(BehaviorName=TargetTemplateNameIs-ChryssalidCocoon, NodeType=Condition)


### PR DESCRIPTION
Adds a check that makes Warlock only teleport units that have been engaged with XCOM for more than one turn. 
This prevents Warlock from wasting Teleport AP on units that were just summoned or dropped as reinforcement (and therefore cannot act after teleport).
Moved back TryChosenSummon to Child[0] since the issue that made it move to Child[4] was fixed.