### PR TITLE
Shieldbearer AI modification

### DIFF
--- a/LongWarOfTheChosen/Config/XComAI.ini
+++ b/LongWarOfTheChosen/Config/XComAI.ini
@@ -173,6 +173,28 @@
 +NewBehaviors=(BehaviorName=AdvCaptain_RedLastActionSelector, NodeType=Selector, Child[0]=AdvCaptainTryGrenade, Child[1]=TryHighPriorityShot, Child[2]=TryMarkTargetOption, Child[3]=TryShootOrReloadOrOverwatch, Child[4]=HuntEnemyWithCover, Child[5]=SelectMove_JobOrDefensive)
 
 ; ----------------------------------------------------------------------------------------------------------
+; --------------------------- ADVENT SHIELDBEARER --------------------------------------------------
+; ---------------------------------------------------------------------------------------------------------- 
++BehaviorRemovals="ShieldBearerFirstActionSelector"
++NewBehaviors=(BehaviorName=ShieldBearerFirstActionSelector, NodeType=Selector, \\
+	Child[0]=TryMoveForEnergyShield, \\
+	Child[1]=DoIfFlankedMove, \\
+	Child[2]=TryEnergyShieldOnMultipleTargets, \\
+	Child[3]=TryHighPriorityShot, \\
+	Child[4]=SelectMove_JobOrDefensive, \\
+	Child[5]=HuntEnemyWithCover, \\
+	Child[6]=TryShootOrReloadOrOverwatch)
+
++BehaviorRemovals="ShieldBearerLastActionSelector"
++NewBehaviors=(BehaviorName=ShieldBearerLastActionSelector, NodeType=Selector, \\
+	Child[0]=TryEnergyShieldOnMultipleTargets, \\
+	Child[1]=TryHighPriorityShot, \\
+	Child[2]=TryEnergyShieldOnAnyTarget, \\
+	Child[3]=TryShootOrReloadOrOverwatch,  \\
+	Child[4]=HuntEnemyWithCover, \\
+	Child[5]=SelectMove_JobOrDefensive)
+
+; ----------------------------------------------------------------------------------------------------------
 ; --------------------------- ADVENT SECTOPOD --------------------------------------------------
 ; ----------------------------------------------------------------------------------------------------------
 +BehaviorRemovals="SectopodFirstActionSelector"


### PR DESCRIPTION
Fixes the problem of Shieldbearer AI always using shield on its first turn no matter what, while keeping its defensive behaviour intact; shielding 3+ units are still prioritized highest, but high priority shots are checked before TryEnergyShieldOnAnyTarget