### PR TITLE
Add a button on the Geoscape to access Resistance Management screen

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_StrategyMap_HavenManagementButton.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_StrategyMap_HavenManagementButton.uc
@@ -20,21 +20,23 @@ event OnInit(UIScreen Screen)
 	StrategyMap = UIStrategyMap(Screen);
 	if (StrategyMap == none) return;
 
-	HavenManagementButton = Screen.Spawn(class 'UIStrategyMap_HavenManagementButton', StrategyMap.StrategyMapHUD);
-	HavenManagementButton.InitHMButton();
+	if (!`ISCONTROLLERACTIVE)
+	{
+		HavenManagementButton = Screen.Spawn(class 'UIStrategyMap_HavenManagementButton', StrategyMap.StrategyMapHUD);
+		HavenManagementButton.InitHMButton();
+	}
 
-	HandleInput(true);
 }
 
 public function OnHavenManagementNewButton(UIButton HavenManagementNewButton)
 {
-	class'XComGameState_LWOutpostManager'.static.ResistanceManagementScreen();
+	class'XComGameState_LWOutpostManager'.static.OpenResistanceManagementScreen();
 }
 
 ///////////////////////////////////////////
 /// Handling input (controller support) ///
 ///////////////////////////////////////////
-
+/*
 event OnReceiveFocus(UIScreen screen)
 {
 	if (UIStrategyMap(Screen) == none) return;
@@ -86,3 +88,4 @@ static protected function bool OnUnrealCommand(int cmd, int arg)
 
 	return false;
 }
+*/

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_StrategyMap_HavenManagementButton.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_StrategyMap_HavenManagementButton.uc
@@ -1,0 +1,88 @@
+//---------------------------------------------------------------------------------------
+//  AUTHOR:  Rai 
+//  PURPOSE: This class adds the corresponding screen listener to access the haven management 
+//           screen from the geoscape directly
+//---------------------------------------------------------------------------------------
+//  Credits: Adapted from WOTCStrategyOverhaul Team's code for CI
+//---------------------------------------------------------------------------------------
+
+class UIScreenListener_StrategyMap_HavenManagementButton extends UIScreenListener;
+
+/////////////////////
+/// Adding button ///
+/////////////////////
+
+event OnInit(UIScreen Screen)
+{
+	local UIStrategyMap_HavenManagementButton HavenManagementButton;
+	local UIStrategyMap StrategyMap;
+
+	StrategyMap = UIStrategyMap(Screen);
+	if (StrategyMap == none) return;
+
+	HavenManagementButton = Screen.Spawn(class 'UIStrategyMap_HavenManagementButton', StrategyMap.StrategyMapHUD);
+	HavenManagementButton.InitHMButton();
+
+	HandleInput(true);
+}
+
+public function OnHavenManagementNewButton(UIButton HavenManagementNewButton)
+{
+	class'XComGameState_LWOutpostManager'.static.ResistanceManagementScreen();
+}
+
+///////////////////////////////////////////
+/// Handling input (controller support) ///
+///////////////////////////////////////////
+
+event OnReceiveFocus(UIScreen screen)
+{
+	if (UIStrategyMap(Screen) == none) return;
+
+	HandleInput(true);
+}
+
+event OnLoseFocus(UIScreen screen)
+{
+	if (UIStrategyMap(Screen) == none) return;
+
+	HandleInput(false);
+}
+
+event OnRemoved(UIScreen screen)
+{
+	if (UIStrategyMap(Screen) == none) return;
+
+	HandleInput(false);
+}
+
+function HandleInput(bool isSubscribing)
+{
+	local delegate<UIScreenStack.CHOnInputDelegate> inputDelegate;
+	inputDelegate = OnUnrealCommand;
+
+	if(isSubscribing)
+	{
+		`SCREENSTACK.SubscribeToOnInput(inputDelegate);
+	}
+	else
+	{
+		`SCREENSTACK.UnsubscribeFromOnInput(inputDelegate);
+	}
+}
+
+static protected function bool OnUnrealCommand(int cmd, int arg)
+{
+	if (cmd == class'UIUtilities_Input'.const.FXS_BUTTON_X && arg == class'UIUtilities_Input'.const.FXS_ACTION_RELEASE)
+	{
+		if (class'XComEngine'.static.GetHQPres().StrategyMap2D.m_eUIState != eSMS_Flight)
+		{
+			// Cannot open screen during flight
+			class'XComGameState_LWOutpostManager'.static.ResistanceManagementScreen();
+		}
+
+		return true;
+	}
+
+	return false;
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMap_HavenManagementButton.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMap_HavenManagementButton.uc
@@ -1,0 +1,173 @@
+//---------------------------------------------------------------------------------------
+//  AUTHOR:  Rai 
+//  PURPOSE: New Geoscape button, positioned above the factions "triangle" at the bottom
+//           to access the resistance outpost screen quickly from the geoscape
+//---------------------------------------------------------------------------------------
+//  Credit: Adapted from WOTCStrategyOverhaul Team's code for CI
+//---------------------------------------------------------------------------------------
+
+class UIStrategyMap_HavenManagementButton extends UIPanel;
+
+var UIStrategyMap StrategyMap;
+
+var UIPanel BG;
+var UIText Label;
+var UIImage ControllerIcon;
+var UIImage ResistanceOutpost;
+
+var protected float TimeSinceLastColourSwitch;
+var protected bool bCurrentlyAttention;
+var protected bool bFlashing;
+
+const NEW_ACTION_FLASH_DURATION = 1;
+
+var localized string strLabel;
+
+simulated function InitHMButton()
+{
+	InitPanel('HavenManagementButton');
+
+	StrategyMap = UIStrategyMap(GetParent(class'UIStrategyMap', true));
+
+	BG = Spawn(class'UIPanel', self);
+	BG.InitPanel('BG', 'X2MenuBG');
+	BG.AnchorBottomCenter();
+	BG.SetWidth(140);
+	BG.SetX(-(BG.Width / 2));
+	BG.SetAlpha(80);
+
+	// Rai - Add resistance outpost icon
+	strLabel = class'UIUtilities_Text'.static.InjectImage("img:///UILibrary_StrategyImages.X2StrategyMap.MissionIcon_ResHQ", 26, 26, ) @ strLabel;
+
+	Label = Spawn(class'UIText', self);
+	Label.InitText('Label');
+	Label.AnchorBottomCenter();
+	Label.SetX(BG.X + 5);
+	Label.SetWidth(BG.Width - 10);
+	Label.OnTextSizeRealized = OnLabelSizeRealized;
+
+	if (`ISCONTROLLERACTIVE)
+	{
+		ControllerIcon = Spawn(class'UIImage', self);
+		ControllerIcon.InitImage('ControllerIcon', "img:///gfxGamepadIcons." $ class'UIUtilities_Input'.static.GetGamepadIconPrefix() $ class'UIUtilities_Input'.const.ICON_X_SQUARE);
+		ControllerIcon.AnchorBottomCenter();
+		ControllerIcon.SetSize(40, 40);
+		ControllerIcon.SetX(BG.X + 10);
+
+		Label.SetX(ControllerIcon.X + ControllerIcon.Width + 10);
+		Label.SetWidth(BG.Width - ControllerIcon.Width - 20);
+	}
+
+	UpdateLabel();
+	SubscribeToEvents();
+}
+
+simulated protected function RealizeLayout()
+{
+	BG.SetHeight(Max(50, Label.Height + 10));
+	BG.SetY(-(133 + BG.Height));
+
+	if (ControllerIcon != none)
+	{
+		ControllerIcon.SetY(BG.Y + (BG.Height - ControllerIcon.Height) / 2);
+	}
+
+	Label.SetY(BG.Y + 5);
+}
+
+simulated protected function UpdateLabel()
+{
+	local EUIState Colour;
+	local int FontSize;
+
+	Colour = bIsFocused ? eUIState_Header : eUIState_Normal;
+	FontSize = bIsFocused ? 18 : 20;
+
+	Label.SetCenteredText(class'UIUtilities_Text'.static.GetColoredText(
+			class'UIUtilities_Text'.static.AddFontInfo(strLabel, Screen.bIsIn3D,,, FontSize),
+			Colour));
+}
+
+simulated protected function OnLabelSizeRealized()
+{
+	RealizeLayout();
+}
+
+simulated function OnReceiveFocus()
+{
+	super.OnReceiveFocus();
+
+	UpdateLabel();
+}
+
+simulated function OnLoseFocus()
+{
+	super.OnLoseFocus();
+
+	UpdateLabel();
+}
+
+simulated function OnMouseEvent(int cmd, array<string> args)
+{
+	super.OnMouseEvent(cmd, args);
+
+	switch (cmd)
+	{
+	case class'UIUtilities_Input'.const.FXS_L_MOUSE_UP:
+	case class'UIUtilities_Input'.const.FXS_L_MOUSE_DOUBLE_UP:
+		OnClicked();
+		break;
+	}
+}
+
+simulated protected function OnClicked()
+{
+	if (Movie.Pres.ScreenStack.GetCurrentScreen() != StrategyMap) return;
+	if (StrategyMap.IsInFlightMode()) return;
+
+	class'XComGameState_LWOutpostManager'.static.ResistanceManagementScreen();
+	OnLoseFocus();
+}
+
+simulated event Removed()
+{
+	super.Removed();
+
+	UnsubscribeFromAllEvents();
+}
+
+/////////////////////////////
+/// Geoscape flight event ///
+/////////////////////////////
+
+simulated protected function SubscribeToEvents()
+{
+	local X2EventManager EventManager;
+	local Object ThisObj;
+
+	EventManager = `XEVENTMGR;
+    ThisObj = self;
+
+	EventManager.RegisterForEvent(ThisObj, 'GeoscapeFlightModeUpdate', OnGeoscapeFlightModeUpdate,, 99);
+}
+
+simulated protected function UnsubscribeFromAllEvents()
+{
+    local Object ThisObj;
+
+    ThisObj = self;
+    `XEVENTMGR.UnRegisterFromAllEvents(ThisObj);
+}
+
+simulated protected function EventListenerReturn OnGeoscapeFlightModeUpdate(Object EventData, Object EventSource, XComGameState GameState, Name EventID, Object CallbackData)
+{
+	SetVisible(!StrategyMap.IsInFlightMode());
+
+	return ELR_NoInterrupt;
+}
+
+defaultproperties
+{
+	bIsNavigable = false;
+	bProcessesMouseEvents = true;
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMap_HavenManagementButton.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMap_HavenManagementButton.uc
@@ -38,6 +38,7 @@ simulated function InitHMButton()
 
 	// Rai - Add resistance outpost icon
 	strLabel = class'UIUtilities_Text'.static.InjectImage("img:///UILibrary_StrategyImages.X2StrategyMap.MissionIcon_ResHQ", 26, 26, ) @ strLabel;
+	strLabel $= "Resistance Management";
 
 	Label = Spawn(class'UIText', self);
 	Label.InitText('Label');
@@ -46,6 +47,8 @@ simulated function InitHMButton()
 	Label.SetWidth(BG.Width - 10);
 	Label.OnTextSizeRealized = OnLabelSizeRealized;
 
+	// Rai - Removed as per suggestion
+	/*
 	if (`ISCONTROLLERACTIVE)
 	{
 		ControllerIcon = Spawn(class'UIImage', self);
@@ -56,7 +59,7 @@ simulated function InitHMButton()
 
 		Label.SetX(ControllerIcon.X + ControllerIcon.Width + 10);
 		Label.SetWidth(BG.Width - ControllerIcon.Width - 20);
-	}
+	}*/
 
 	UpdateLabel();
 	SubscribeToEvents();
@@ -125,7 +128,7 @@ simulated protected function OnClicked()
 	if (Movie.Pres.ScreenStack.GetCurrentScreen() != StrategyMap) return;
 	if (StrategyMap.IsInFlightMode()) return;
 
-	class'XComGameState_LWOutpostManager'.static.ResistanceManagementScreen();
+	class'XComGameState_LWOutpostManager'.static.OpenResistanceManagementScreen();
 	OnLoseFocus();
 }
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpostManager.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpostManager.uc
@@ -232,6 +232,21 @@ simulated function GoToResistanceManagement(optional StateObjectReference Facili
 	}
 }
 
+// Rai - Added function to enable entering the haven management screen from geoscape directly
+static function ResistanceManagementScreen(optional StateObjectReference ActionToFocus)
+{
+	local UIResistanceManagement_LW TempScreen;
+	local XComHQPresentationLayer HQPres;
+
+	HQPres = `HQPRES;
+	if (HQPres.ScreenStack.GetFirstInstanceOf(class'UIResistanceManagement_LW') != none) return;
+
+	TempScreen = HQPres.Spawn(class'UIResistanceManagement_LW', HQPres);
+	//TempScreen.ActionToShowOnInitRef = ActionToFocus;
+	HQPres.ScreenStack.Push(TempScreen);
+
+}
+
 function bool IsUnitAHavenLiaison(StateObjectReference UnitRef)
 {
 	local XComGameState_LWOutpost Outpost;

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpostManager.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpostManager.uc
@@ -233,7 +233,7 @@ simulated function GoToResistanceManagement(optional StateObjectReference Facili
 }
 
 // Rai - Added function to enable entering the haven management screen from geoscape directly
-static function ResistanceManagementScreen(optional StateObjectReference ActionToFocus)
+static function OpenResistanceManagementScreen(optional StateObjectReference ActionToFocus)
 {
 	local UIResistanceManagement_LW TempScreen;
 	local XComHQPresentationLayer HQPres;


### PR DESCRIPTION
This seeks to replicate the LW2 functionality, but the button has to be moved because WOTC added the faction HQ icons in its place. It is done using a screen listener and while I have not tested it with a controller, it might work with one since it has been adapted from StratOverhaul (credit to them for letting me use their code as baseline).