### PR TITLE
Make Alien Facilities controller compatible

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_AlienNetworkComponent_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_AlienNetworkComponent_LW.uc
@@ -6,10 +6,13 @@
 //           up when you sent a squad to infiltrate an alien facility with the base implentation of
 //           the parent class.
 // 
-//           This class' code is a literal copy paste of the UIStrategyMapItem_Mission_LW classs so
+//           This class' code is a literal copy paste of the UIStrategyMapItem_Mission_LW class so
 //           that the alien facility strategy item has the same infiltration mechanics as other missions
 //           do. All of the code in this class is unique to this class and does not override any of the
 //           parent class behavior.
+//
+//	KDM : The same controller code found in UIStrategyMapItem_Mission_LW has been implemented here so
+//	that alien facilities are 'clickable'. 
 //--------------------------------------------------------------------------------------- 
 
 class UIStrategyMapItem_AlienNetworkComponent_LW extends UIStrategyMapItem_AlienNetworkComponent;
@@ -40,7 +43,7 @@ simulated function UIStrategyMapItem InitMapItem(out XComGameState_GeoscapeEntit
 	InitPanel(Name(Entity.GetUIWidgetName()), 'MI_alienFacility');
 
 	PinImage = Entity.GetUIPinImagePath();
-	if( PinImage != "" )
+	if (PinImage != "")
 	{
 		SetImage(PinImage);
 	}
@@ -69,6 +72,13 @@ simulated function UIStrategyMapItem InitMapItem(out XComGameState_GeoscapeEntit
 	bScanButtonResized = false;
 
 	InstanceMapItem3DMaterial();
+
+	// KDM : The mission map item's help icon gets in the way of the infiltrating squad icon; the best way to deal with it is to null it.
+	// For more information on a similar topic please see the comments in UIStrategyMapItem_Region_LW --> InitMapItem().
+	if (`ISCONTROLLERACTIVE)
+	{
+		ScanButton.mc.SetNull("consoleHint");
+	}
 
 	return self;
 }
@@ -108,28 +118,45 @@ function InstanceMapItem3DMaterial()
 
 function UpdateFromGeoscapeEntity(const out XComGameState_GeoscapeEntity GeoscapeEntity)
 {
-	local XComGameState_MissionSite MissionState;
-	local string MissionTitle;
-	local string InfiltrationPctValue;
-	local string MissionInfo;
-	local int InfiltrationPct;
-	local XComGameState_LWPersistentSquad InfiltratingSquad;
-	local X2MissionTemplate MissionTemplate;
+	local int InfiltrationPct, InfiltrationTextColour;
 	local float ScanWidth;
+	local string InfiltrationPctValue, MissionInfo, MissionTitle;
+	local X2MissionTemplate MissionTemplate;
+	local XComGameState_LWPersistentSquad InfiltratingSquad;
+	local XComGameState_MissionSite MissionState;
 
-	if( !bIsInited ) return; 
+	if (!bIsInited)
+	{
+		return; 
+	}
 
 	super(UIStrategyMapItem).UpdateFromGeoscapeEntity(GeoscapeEntity);
 
 	InfiltratingSquad = GetInfiltratingSquad();
 	 
 	MissionState = GetMission();
-	if(InfiltratingSquad != none)
+	if (InfiltratingSquad != none)
 	{
+		InfiltrationTextColour = (bIsFocused) ? -1 : eUIState_Normal;
+
 		InfiltrationPct = int(InfiltratingSquad.CurrentInfiltration * 100.0);
 		InfiltrationPctValue = string(InfiltrationPct) $ "%";
-		InfilPct.SetHTMLText(CenterText(class'UIUtilities_Text'.static.AddFontInfo(InfiltrationPctValue, false, true,, 20)));
-
+		
+		// KDM : When using a controller, there are 2 general colour states :
+		// 1.] This mission map item is selected, so its background is highlighted, and its text should be black.
+		// 2.] This mission map item is not selected, so its background is not highlighted, and its text should be normal blue.
+		if (`ISCONTROLLERACTIVE)
+		{
+			// KDM : When using a controller, the infiltration label needs to be continually refreshed according to the map item's selection status.
+			// When using a mouse & keyboard, the infiltration label doesn't need to change, so it can be called a single time down below.
+			InfilLabel.SetHTMLText(CenterText(class'UIUtilities_Text_LW'.static.AddFontInfoWithColor(strRecon, false, false, , 16, InfiltrationTextColour)));
+			InfilPct.SetHTMLText(CenterText(class'UIUtilities_Text_LW'.static.AddFontInfoWithColor(InfiltrationPctValue, false, true, , 20, InfiltrationTextColour)));
+		}
+		else
+		{
+			InfilPct.SetHTMLText(CenterText(class'UIUtilities_Text'.static.AddFontInfo(InfiltrationPctValue, false, true, , 20)));
+		}
+		
 		if (!bScanButtonResized)
 		{
 			MissionTitle = class'UIUtilities_Text'.static.CapsCheckForGermanScharfesS(InfiltratingSquad.sSquadName);
@@ -139,7 +166,12 @@ function UpdateFromGeoscapeEntity(const out XComGameState_GeoscapeEntity Geoscap
 			ScanButton.SetText(MissionTitle, MissionInfo, " ", " "); // have to leave blank spaces so that Flash will size BG big enough 
 			SetLevel(0); // show 0 doom pips
 
-			InfilLabel.SetHTMLText(CenterText(class'UIUtilities_Text'.static.GetSizedText(strRecon, 16)));
+			// KDM : Infiltration label handling for controllers is dealt with up above.
+			if (!`ISCONTROLLERACTIVE)
+			{
+				InfilLabel.SetHTMLText(CenterText(class'UIUtilities_Text'.static.GetSizedText(strRecon, 16)));
+			}
+			
 			bScanButtonResized = true;
 
 			CachedImageName = InfiltratingSquad.GetSquadImagePath();
@@ -187,6 +219,19 @@ function UpdateFromGeoscapeEntity(const out XComGameState_GeoscapeEntity Geoscap
 		SquadImage.Hide();
 		bScanButtonResized = false;
 	}
+
+	// KDM : Our custom, mission map item, tooltip contains information, like mission expiration and infiltration percentage, which changes over 
+	// time; therefore, we need to continously update it. However, there are a few caveats :
+	//
+	// 1.] Tooltips are not created under normal circumstances for mission map items; therefore, we only need to worry about updating when
+	// a controller is being used, and SHOW_MISSION_TOOLTIPS_CTRL is true.
+	// 2.] UIStrategyMap stores a single active tooltip, ActiveTooltip, which it associates with the currently selected map item; unfortunately, 
+	// UpdateFromGeoscapeEntity() is called regardless of whether this map item is selected or not. Consequently, we don't want this mission
+	// map item polluting the tool tip when it is not selected.
+	if (GetStrategyMap().SelectedMapItem == self && `ISCONTROLLERACTIVE && class'UIStrategyMapItem_Mission_LW'.default.SHOW_MISSION_TOOLTIPS_CTRL)
+	{
+		UpdateTooltip();
+	}
 }
 
 simulated function string CenterText(string Text)
@@ -218,36 +263,45 @@ function OpenInfiltrationMissionScreen()
 
 simulated function OnMouseEvent(int cmd, array<string> args)
 {
-	local XComGameStateHistory History;
-	local XComGameState_GeoscapeEntity GeoscapeEntity;
-	local XComGameState_LWPersistentSquad InfiltratingSquad;
-
-	if(GetStrategyMap().m_eUIState == eSMS_Flight)
+	if (GetStrategyMap().m_eUIState == eSMS_Flight)
 	{
 		return;
 	}
 
 	switch(cmd) 
 	{ 
-	case class'UIUtilities_Input'.const.FXS_L_MOUSE_IN:
-		OnMouseIn();
-		break;
-	case class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT:
-		OnMouseOut();
-		break;
-	case class'UIUtilities_Input'.const.FXS_L_MOUSE_UP:
-		History = `XCOMHISTORY;
-		InfiltratingSquad = GetInfiltratingSquad();
-		if(InfiltratingSquad == none)
-		{
-			GeoscapeEntity = XComGameState_GeoscapeEntity(History.GetGameStateForObjectID(GeoscapeEntityRef.ObjectID));
-			GeoscapeEntity.AttemptSelectionCheckInterruption();
-		}
-		else
-		{
-			OpenInfiltrationMissionScreen();
-		}
-		break;
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_IN:
+			OnMouseIn();
+			break;
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT:
+			OnMouseOut();
+			break;
+		// KDM : A mouse click opens a mission's infiltration screen if it is currently being infiltrated.
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_UP:
+			MapItemMissionClicked();
+			break;
+	}
+}
+
+// KDM : This code was stripped out of OnMouseEvent() --> FXS_L_MOUSE_UP and placed within a function so that it could be called from both
+// 1.] OnMouseEvent() for mouse & keyboard users 2.] OnUnrealCommand() for controller users.
+simulated function MapItemMissionClicked()
+{
+	local XComGameState_GeoscapeEntity GeoscapeEntity;
+	local XComGameState_LWPersistentSquad InfiltratingSquad;
+	local XComGameStateHistory History;
+	
+	History = `XCOMHISTORY;
+	InfiltratingSquad = GetInfiltratingSquad();
+	
+	if (InfiltratingSquad == none)
+	{
+		GeoscapeEntity = XComGameState_GeoscapeEntity(History.GetGameStateForObjectID(GeoscapeEntityRef.ObjectID));
+		GeoscapeEntity.AttemptSelectionCheckInterruption();
+	}
+	else
+	{
+		OpenInfiltrationMissionScreen();
 	}
 }
 
@@ -337,6 +391,123 @@ simulated function Show()
 simulated function OnLoseFocus()
 {
 	super.OnLoseFocus();
+}
+
+function string GetToolTipText()
+{
+	local int InfiltrationPct;
+	local string BodyStr, TitleStr, InfiltrationPctStr, TooltipHTML;
+	local XComGameState_LWPersistentSquad InfiltratingSquad;
+	local XComGameState_MissionSite Mission;
+
+	InfiltratingSquad = GetInfiltratingSquad();
+	Mission = GetMission();
+
+	TooltipHTML = "";
+
+	if (Mission != none)
+	{	
+		class'X2EventListener_StrategyMap'.static.GetMissionSiteUIButtonToolTip(TitleStr, BodyStr, none, Mission);
+		TitleStr = class'UIUtilities_Text'.static.GetColoredText(TitleStr, eUIState_Header);
+			
+		// KDM : The title includes the amount of time left before the mission expires; this is very useful information. 
+		TooltipHTML $= TitleStr;
+		TooltipHTML $= "\n";
+		TooltipHTML $= "--------------------------------";
+		// KDM : If a squad is infiltrating, show the infiltration percentage.
+		if (InfiltratingSquad != none)
+		{
+			TooltipHTML $= "\n";
+			TooltipHTML $= class'UIStrategyMapItem_Mission_LW'.default.InfiltrationTooltipString $ " : ";
+
+			InfiltrationPct = int(InfiltratingSquad.CurrentInfiltration * 100.0);
+			InfiltrationPctStr = class'UIUtilities_Text'.static.GetColoredText(string(InfiltrationPct), eUIState_Good);
+				
+			TooltipHTML $= InfiltrationPctStr @ "%";
+			TooltipHTML $= "\n";
+			TooltipHTML $= "--------------------------------";
+		}
+		TooltipHTML $= "\n";
+		TooltipHTML $= BodyStr;
+	}
+	return TooltipHTML;
+}
+
+function UpdateTooltip()
+{
+	local string TooltipHTML;
+	local UIStrategyMap StrategyMap;
+
+	StrategyMap = GetStrategyMap();
+
+	// KDM : If the strategy map has no active tooltip, then there is nothing to update.
+	if (StrategyMap.ActiveTooltip != none)
+	{
+		// KDM : Get the new tooltip text and update the active tooltip.
+		TooltipHTML = GetToolTipText();
+		StrategyMap.ActiveTooltip.SetText(TooltipHTML);
+		StrategyMap.ActiveTooltip.UpdateData();
+
+		// KDM : The tooltip data has been updated; however, this information is not pushed to the flash UI element, so we don't see
+		// any changes. There are 2 ways around this :
+		//
+		// 1.] The flash element, TooltipBox, has a function, Show(), which updates the tooltip's : Style, Text, Size, BG, and Location.
+		// Furthermore, it animates the tooltip in. This is a nice 'complete' method, but it involves us having to constantly hide and show the
+		// tooltip within UnrealScript. Additionally, it requires us to kill the tooltip's animation since we can't have it contantly fading in
+		// and fading out.
+		// 2.] Update the flash element's : Style, Text, Size, and BG, via Actionscript calls. This is a better solution because it updates
+		// the tooltip text and size, without having to resort to hiding and showing the tooltip; furthermore, it doesn't mess with any 
+		// tooltip animations.
+		StrategyMap.ActiveTooltip.MC.FunctionVoid("RealizeStyle");
+		StrategyMap.ActiveTooltip.MC.FunctionVoid("RealizeText");	
+		StrategyMap.ActiveTooltip.MC.FunctionVoid("RealizeSize");
+		StrategyMap.ActiveTooltip.MC.FunctionVoid("RealizeBG");
+	}
+}
+
+// KDM : Long War provides useful mission tooltips; however, they only appear over the mission icons on the bottom icon bar, and are only
+// accessible to mouse & keyboard users. Consequently, we want to give controller users the opportunity to display this information as a normal tooltip
+// next to the mission map item.
+function GenerateTooltip(string tooltipHTML)
+{	
+	// KDM : Normally, for mission map items, tooltipHTML will be an empty string; consequently, no tooltip will be created. 
+	// Only show mission tooltips if the controller is active, and SHOW_MISSION_TOOLTIPS_CTRL is true.
+	if (`ISCONTROLLERACTIVE && class'UIStrategyMapItem_Mission_LW'.default.SHOW_MISSION_TOOLTIPS_CTRL)
+	{
+		tooltipHTML = GetToolTipText();
+	}
+	
+	super.GenerateTooltip(tooltipHTML);
+}
+
+simulated function bool OnUnrealCommand(int cmd, int arg)
+{
+	local bool bHandled;
+
+	if (!CheckInputIsReleaseOrDirectionRepeat(cmd, arg))
+	{
+		return true;
+	}
+
+	bHandled = true;
+
+	switch(cmd)
+	{
+		// KDM : The A button opens a mission's infiltration screen if it is currently being infiltrated.
+		// OnMouseEvent() checks if the Avenger is in flight before executing any of its code; consequently, the same is done here for consistency.
+		case class'UIUtilities_Input'.static.GetAdvanceButtonInputCode():
+			if (GetStrategyMap().m_eUIState != eSMS_Flight)
+			{
+				MapItemMissionClicked();
+			}
+			break;
+
+		default :
+			bHandled = false;
+			break;
+	}
+
+	return bHandled || super.OnUnrealCommand(cmd, arg);
 }
 
 DefaultProperties

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_AlienNetworkComponent_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIStrategyMapItem_AlienNetworkComponent_LW.uc
@@ -77,7 +77,7 @@ simulated function UIStrategyMapItem InitMapItem(out XComGameState_GeoscapeEntit
 	// For more information on a similar topic please see the comments in UIStrategyMapItem_Region_LW --> InitMapItem().
 	if (`ISCONTROLLERACTIVE)
 	{
-		ScanButton.mc.SetNull("consoleHint");
+		ScanButton.MC.SetNull("consoleHint");
 	}
 
 	return self;


### PR DESCRIPTION
Modify `UIStrategyMapItem_AlienNetworkComponent_LW` so that Alien Facilities are clickable with a controller.

**Description** : A while back, `UIStrategyMapItem_Mission_LW `was modified so that strategy map items could be 'clicked' and would interact appropriately with a controller. Unfortunately, I didn't realize that the alien facility had its own special strategy map item class, `UIStrategyMapItem_AlienNetworkComponent_LW`.

Consequently, I have transferred all of the changes I made to `UIStrategyMapItem_Mission_LW` into `UIStrategyMapItem_AlienNetworkComponent_LW`.

Here is a general discussion of the changes made from my commits for `UIStrategyMapItem_Mission_LW`

=========================

Modifies `UIStrategyMapItem_AlienNetworkComponent_LW `--> `InitMapItem()`

When using a controller, an infiltrating mission displays a help icon, `StrategyScanButton `--> `consoleHint`, to the left of the haven information button. The problem is that it overlaps the icon representing the infiltrating squad. Consequently, the best way to deal with it, is to null it.

=========================

Modifies : `UIStrategyMapItem_AlienNetworkComponent_LW `--> `UpdateFromGeoscapeEntity()`

If an infiltrating mission map item is selected, make sure the infiltration percentage string is black. If an infiltrating mission map item is not selected, make sure the infiltration percentage string is its normal blue. If this is not done, the text will 'disappear' into the background colour.

Additionally, within this function, update the map item tooltip information when appropriate.

=========================

Modifies `UIStrategyMapItem_AlienNetworkComponent_LW `--> `OnMouseEvent()` and `OnUnrealCommand()`.

Originally, when a controller user clicked on the A button while a map item mission was highlighted, it would open a normal mission screen even if the mission was currently undergoing infiltration. As a result, `OnUnrealCommand()` had to be extended so as to call the same code as found in `OnMouseEvent()` --> `FXS_L_MOUSE_UP`. This code calls `OpenInfiltrationMissionScreen()`, which pushes an infiltration screen onto the screen stack if infiltration is occurring.

=========================

Added : `UIStrategyMapItem_AlienNetworkComponent_LW `--> `GetToolTipText`, `UpdateTooltip`, and `GenerateTooltip`

Provides the opportunity for controller users to display mission tooltips next to the mission map item. Formerly, they would only be accessible to mouse and keyboard users via the mission icons on the bottom icon bar.