### PR TITLE
Add Strategy Map NavHelp items when using a controller.

### DIFF
--- a/LongWarOfTheChosen/Localization/LW_Overhaul.int
+++ b/LongWarOfTheChosen/Localization/LW_Overhaul.int
@@ -286,6 +286,8 @@ strTimeRemainingDaysAndHours="<XGParam:IntValue1>D, <XGParam:IntValue0>H"
 ; LWOTC Needs Translation
 strDarkEventExpiredTitle="Dark Event Expired"
 strDarkEventExpiredText="has expired"
+OpenResistanceManagementStr="OPEN RESISTANCE MANAGEMENT"
+OpenHavenManagementStr="OPEN HAVEN MANAGEMENT"
 ; End Translation
 
 [X2EventListener_Soldiers]


### PR DESCRIPTION
Add Strategy Map 'Open Haven Management' and 'Open Resistance Management' `NavHelp` items when using a controller.

When on the strategy map, and using a controller either :

1. Display an 'Open Haven Management' `NavHelp` item if a haven is currently selected.
2. Display an 'Open Resistance Management' `NavHelp` item if a haven is not currently selected.

Adds : `X2EventListener_StrategyMap.DisplayResistanceAndHavenManagementNavHelp`

Whenever `UIStrategyMap.UpdateButtonHelp` is called to update the strategy map's button help bar, the event `StrategyMap_NavHelpUpdated` is triggered and, ultimately, `DisplayResistanceAndHavenManagementNavHelp` is called. `DisplayResistanceAndHavenManagementNavHelp` determines if the currently selected map item is a contacted haven or not, and adds the appropriate `NavHelp` item to the button help bar.

==============================

Modifies : `LW_Overhaul.int`

Adds `OpenResistanceManagementStr` and `OpenHavenManagementStr` under the `X2EventListener_StrategyMap` section. These localized strings are used within` X2EventListener_StrategyMap.DisplayResistanceAndHavenManagementNavHelp` to display the appropriate `NavHelp` text.