### PR TITLE
Clear job prohibitions after liberation

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
@@ -597,8 +597,7 @@ static function OnProtectRegionActivityComplete(bool bAlienSuccess, XComGameStat
 
 		//Removing prohibitions on jobs
 		Outpost = `LWOUTPOSTMGR.GetOutpostForRegion(PrimaryRegionState);
-		Outpost = XComGameState_LWOutpost(NewGameState.CreateStateObject(class'XComGameState_LWOutpost', Outpost.ObjectID));
-		NewGameState.AddStateObject(Outpost);
+		Outpost = XComGameState_LWOutpost(NewGameState.ModifyStateObject(class'XComGameState_LWOutpost', Outpost.ObjectID));
 		for (k = 0; k < Outpost.ProhibitedJobs.Length; k++)
 		{
 			Outpost.ProhibitedJobs[k].DaysLeft = 0;

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
@@ -606,7 +606,7 @@ static function OnProtectRegionActivityComplete(bool bAlienSuccess, XComGameStat
 
 		for (k = 0; k < Outpost.CurrentRetributions.Length; k++)
 		{
-			OutPost.CurrentRetributions[k].DaysLeft = 0;
+			Outpost.CurrentRetributions[k].DaysLeft = 0;
 		}		
 
 		//distribute the RemainderAlertLevel amongst adjacent regions that haven't been liberated

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
@@ -601,7 +601,7 @@ static function OnProtectRegionActivityComplete(bool bAlienSuccess, XComGameStat
 		NewGameState.AddStateObject(Outpost);
 		for (k = 0; k < Outpost.ProhibitedJobs.Length; k++)
 		{
-			OutPost.ProhibitedJobs[k].DaysLeft = 0;
+			Outpost.ProhibitedJobs[k].DaysLeft = 0;
 		}
 
 		for (k = 0; k < Outpost.CurrentRetributions.Length; k++)

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
@@ -561,6 +561,8 @@ static function OnProtectRegionActivityComplete(bool bAlienSuccess, XComGameStat
 	local StateObjectReference LinkedRegionRef;
 	local array<XComGameState_WorldRegion> ControlledLinkedRegions;
 	local array<int> ControlledLinkedAlertLevelIncreases;
+	local XComGameState_LWOutpost Outpost;
+	local int k;
 
 	if(!bAlienSuccess)
 	{
@@ -592,6 +594,15 @@ static function OnProtectRegionActivityComplete(bool bAlienSuccess, XComGameStat
 		AlertLevelsKilled = default.LIBERATION_ALERT_LEVELS_KILLED + `SYNC_RAND_STATIC (default.LIBERATION_ALERT_LEVELS_KILLED_RAND);
 		RemainderAlertLevel = Max (0, PrimaryRegionalAI.LocalAlertLevel - AlertLevelsKilled);
 		PrimaryRegionalAI.LocalAlertLevel = 1;
+
+		//Removing prohibitions on jobs
+		Outpost = `LWOUTPOSTMGR.GetOutpostForRegion(PrimaryRegionState);
+		Outpost = XComGameState_LWOutpost(NewGameState.CreateStateObject(class'XComGameState_LWOutpost', Outpost.ObjectID));
+		NewGameState.AddStateObject(Outpost);
+		for (k = 0; k < Outpost.ProhibitedJobs.Length; k++)
+		{
+			OutPost.ProhibitedJobs[k].DaysLeft = 0;
+		}
 
 		//distribute the RemainderAlertLevel amongst adjacent regions that haven't been liberated
 		foreach PrimaryRegionState.LinkedRegions(LinkedRegionRef)

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
@@ -604,6 +604,11 @@ static function OnProtectRegionActivityComplete(bool bAlienSuccess, XComGameStat
 			OutPost.ProhibitedJobs[k].DaysLeft = 0;
 		}
 
+		for (k = 0; k < Outpost.CurrentRetributions.Length; k++)
+		{
+			OutPost.CurrentRetributions[k].DaysLeft = 0;
+		}		
+
 		//distribute the RemainderAlertLevel amongst adjacent regions that haven't been liberated
 		foreach PrimaryRegionState.LinkedRegions(LinkedRegionRef)
 		{


### PR DESCRIPTION
This clears job prohibitions and retributions affecting the region when the region is liberated. The ingame notification may occur slightly after, but you can start assigning rebels to the job immediately.
Was reported in #686.