### PR TITLE
Fix to Chosen selecting uncontacted regions for Retribution

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
@@ -2894,7 +2894,7 @@ static function XComGameState_WorldRegion ChooseRetributionRegion(XComGameState_
 	// territory contacted to meet the chosen, and you can't lose contact to regions in
 	// LWOTC.
 	ChosenState.RegionAttackDeck = ChosenState.TerritoryRegions;
-	for (i = 0; i < ChosenState.RegionAttackDeck.length; i++)
+	for (i = ChosenState.RegionAttackDeck.length - 1; i >= 0 ; i--)
 	{
 		if (XComGameState_WorldRegion(History.GetGameStateForObjectID(ChosenState.RegionAttackDeck[i].ObjectID)).ResistanceLevel < eResLevel_Contact)
 		ChosenState.RegionAttackDeck.Remove(i, 1);


### PR DESCRIPTION
Currently Chosen can sometimes select uncontacted region as a target for their Retribution activity.
I am fairly sure that if you iterate over array in such order, while removing  elements from it, you will skip over some regions and thus allow some uncontacted regions into the deck. Iterating in inverse order should fix it.