### PR TITLE
Remove Indomitable and Terrorize from templar's Ghosts

### DIFF
--- a/LongWarOfTheChosen/Config/XComGameData_SoldierSkills.ini
+++ b/LongWarOfTheChosen/Config/XComGameData_SoldierSkills.ini
@@ -172,6 +172,8 @@ STUNSTRIKE_COOLDOWN=2
 +AbilitiesGhostCantHave="GreaterPadding_CV"
 +AbilitiesGhostCantHave="GreaterPadding_MG"
 +AbilitiesGhostCantHave="GreaterPadding_BM"
++AbilitiesGhostCantHave="Indomitable"
++AbilitiesGhostCantHave="TemplarTerror"
 
 
 VoidConduitInitialDamage=1


### PR DESCRIPTION
No one bothered to add these two abilities to the exclusion list yet, so I might as well.
Indomitable should be removed because ghosts should not be able to raise their focus.
Terrorize should be removed because ghosts don't have Volt in the first place and so it is cleaner this way.