### PR TITLE
Add conditional check on $cookedMaps to fix build error

### DIFF
--- a/.scripts/X2ModBuildCommon/build_common.ps1
+++ b/.scripts/X2ModBuildCommon/build_common.ps1
@@ -756,8 +756,13 @@ class BuildProject {
 
 		# Dedupe for cases when collection maps are manually made
 		# Also sort for consitency and ease of reading of the command line arguments
-		$cookedMaps = $cookedMaps | Sort-Object -unique
-		$dirtyMaps = $dirtyMaps | Sort-Object -unique
+		if ($cookedMaps.Length -gt 0) {
+			$cookedMaps = $cookedMaps | Sort-Object -unique
+		}
+
+		if ($dirtyMaps.Length -gt 0) {
+			$dirtyMaps = $dirtyMaps | Sort-Object -unique
+		}
 
 		# Prepare the command line arguments
 		# Note that we still need the -TFCSUFFIX even though -DLCName suffixes the TFCs as with only the latter using TFCs will crash at runtime (reads from base game ones?)


### PR DESCRIPTION
When pulling the repo down for the first time and building, I
received a build error relating to these sorting methods on the
cookedMaps variable in this script.

The list had a Length of 0 and when sorted, the variable's type was changed.
Further along in the build I would then see the error:
"The property 'Length' cannot be found on this object."

This fixed the issue by preventing the sort of an empty list and the
unintended type-change which occurs.