### PR TITLE
Add Overwatch to the DoubleTapAbilities whitelist

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1420,6 +1420,7 @@ AutopsyAdventPsiWitchIntelCost=0
 +DoubleTapAbilities=ChainShot
 +DoubleTapAbilities=Maim_LW
 +DoubleTapAbilities=LeadTheTarget_LW
++DoubleTapAbilities=Overwatch
 
 +ENEMY_FLASHBANG_RESIST=(UnitName=Gatekeeper, Chance=75)
 +ENEMY_FLASHBANG_RESIST=(UnitName=MutonM2_LW, Chance=20)


### PR DESCRIPTION
Simple fix to Double Tap ability.

Classes other than Sharpshooter can get Double Tap ability with XCom row, but they won't be able to use it for overwatching despite the description explicitly saying they should be able to. Normal 'Overwatch' ability isn't on the list of allowed abilities which you can spend bonus action point on (only SniperRifleOverwatch is). This fixes it.