### PR TITLE
Replace XComLWTuple with LWTuple in OnShouldShowPsi

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
@@ -367,10 +367,10 @@ static function EventListenerReturn OnOverridePersonnelStatusTime(Object EventDa
 
 static function EventListenerReturn OnShouldShowPsi(Object EventData, Object EventSource, XComGameState NewGameState, Name InEventID, Object CallbackData)
 {
-	local XComLWTuple			Tuple;
+	local LWTuple				Tuple;
 	local XComGameState_Unit	UnitState;
 
-	Tuple = XComLWTuple(EventData);
+	Tuple = LWTuple(EventData);
 	if (Tuple == none)
 	{
 		`REDSCREEN("OnShouldShowPsi event triggered with invalid event data.");


### PR DESCRIPTION
As far as I can understand OnShouldShowPsi function exists to provide support for Detailed Soldiers List mod (which I use), where the 'DSLShouldShowPsi' event is triggered in the first place. However, right now this function spam the logs with 'Warning: OnShouldShowPsi event triggered with invalid event data.' messages. It seems to me that it is because the DSL sends LWTuple-s instead of XComLWTuple objects. Changing it does fix it.

Visibly, this change replaced the display of ComInt stat for rookies with psi offense values. It may or may not be desirable, but it is what it was meant to do in the first place I think.

I don't know why OnShouldShowPsi expected XComLWTuple in the first place. Was it changed in DSL at some point? I am fuzzy on the distinction in usage of XComLWTuple / LWTuple. Given that there is some history with integrating/de-integrating DSL, I am also unclear on whether this function is even still meant to be there. In any way, even if it is just a remnant, then it should be removed altogether to not spam the logs.