### PR TITLE
Fix to "Command Range 7" ability

### DIFF
--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2Ability_OfficerAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2Ability_OfficerAbilitySet.uc
@@ -81,7 +81,7 @@ static function array<X2DataTemplate> CreateTemplates()
 
 	// Add the command bonus range ability templates, one for each officer rank.
 	// i == 1 is 2nd Lieutenant.
-	for (i = 1; i < class'LWOfficerUtilities'.default.MaxOfficerRank; i++)
+	for (i = 1; i <= class'LWOfficerUtilities'.default.MaxOfficerRank; i++)
 	{
 		Templates.AddItem(PurePassive(
 			class'LWOfficerUtilities'.static.GetCommandRangeAbilityName(i),
@@ -1519,7 +1519,7 @@ static function ConfigureCommandRangeMultiTargetStyle(X2AbilityTemplate Template
 	MultiTarget.bAllowSameTarget = false;
 	MultiTarget.bExcludeSelfAsTargetIfWithinRadius = ExcludeSelf;
 
-	for (i = 1; i < class'LWOfficerUtilities'.default.MaxOfficerRank; i++)
+	for (i = 1; i <= class'LWOfficerUtilities'.default.MaxOfficerRank; i++)
 	{
 		MultiTarget.AddAbilityBonusRadius(
 			class'LWOfficerUtilities'.static.GetCommandRangeAbilityName(i),


### PR DESCRIPTION
MaxOfficerRank config variable is inclusive, so the iterating cycles using it should be as well. Right now at the latest officer rank Command Range ability shows missing text error and won't increase its radius, compared to Command Range 6. Loc strings for Command Range 7 already exists, but  simply were not used. This change fixes it.