### PR TITLE
Add passive ability describing ENEMY_FLASHBANG_RESIST mechanic

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -7061,3 +7061,10 @@ LocLongDescription="All enemy Will reduced by <Ability:Hypnography_WillBonus/>%.
 ; LWOTC Needs Translation
 [MicroMissiles X2AbilityTemplate]
 LocHelpText="Target an area with an explosive missile attack."
+
+; LWOTC Needs Translation
+[FlashbangResistancePassive X2AbilityTemplate]
+LocFriendlyName="Flashbang Resistance"
+LocLongDescription="This unit has a <Ability:FLASHBANG_RESIST_VALUE/>% chance to resist disorientation from flashbang grenades."
+LocHelpText="This unit has a <Ability:FLASHBANG_RESIST_VALUE/>% chance to resist disorientation from flashbang grenades."
+; End translation

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -2085,6 +2085,7 @@ function GeneralCharacterMod(X2CharacterTemplate Template, int Difficulty)
 	local LootReference Loot;
 	local DarkEventAbilityDefinition AbilityDefinition;
 	local bool bApplyToUnit;
+	local int k;
 
 	if (class'X2Effect_TransferMecToOutpost'.default.VALID_FULLOVERRIDE_TYPES_TO_TRANSFER_TO_OUTPOST.Find(Template.DataName) >= 0)
 	{
@@ -2361,6 +2362,15 @@ function GeneralCharacterMod(X2CharacterTemplate Template, int Difficulty)
 	{
 		Template.Abilities.AddItem('ReactionFireAgainstCoverBonus');
 	}
+	
+	for (k = 0; k < default.ENEMY_FLASHBANG_RESIST.length; k++)
+	{
+		if (default.ENEMY_FLASHBANG_RESIST[k].UnitName == Template.DataName)
+		{
+			Template.Abilities.AddItem('FlashbangResistancePassive');
+			break;
+		}
+	}	
 }
 
 static function X2LWTemplateModTemplate CreateReconfigGearTemplate()

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_DefaultAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_DefaultAbilitySet.uc
@@ -19,6 +19,7 @@ static function array<X2DataTemplate> CreateTemplates()
 	Templates.AddItem(CreateMindControlCleanse());
 	Templates.AddItem(CreateReactionFireAgainstCoverBonus());
 	Templates.AddItem(CreateSmokeFlankingCritProtection());
+	Templates.AddItem(CreateFlashbangResistancePassive());
 
 	return Templates;
 }
@@ -244,6 +245,17 @@ static function X2AbilityTemplate CreateSmokeFlankingCritProtection()
 	Template.AddTargetEffect(SmokeAntiCritEffect);
 
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+
+	return Template;
+}
+
+static function X2AbilityTemplate CreateFlashbangResistancePassive()
+{
+	local X2AbilityTemplate		Template;
+
+	Template = PurePassive('FlashbangResistancePassive', "img:///UILibrary_XPACK_Common.PerkIcons.UIPerk_mindshield", , 'eAbilitySource_Perk');
+	Template.bDisplayInUITooltip = true;
+	Template.bDisplayInUITacticalText = true;
 
 	return Template;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
@@ -3200,6 +3200,7 @@ static function bool AbilityTagExpandHandler_CH(string InString, out string OutS
 	local XComGameState_Unit UnitState;
 	local X2AbilityTemplate AbilityTemplate;
 	local int ImpactCompensationStacks;
+	local int k;
 
 	Type = name(InString);
 	switch(Type)
@@ -3246,6 +3247,34 @@ static function bool AbilityTagExpandHandler_CH(string InString, out string OutS
 			{
 				OutString = string(int((1 - (1 - class'X2Ability_LW_ChosenAbilities'.default.IMPACT_COMPENSATION_PCT_DR) **
 						Min(ImpactCompensationStacks, class'X2Ability_LW_ChosenAbilities'.default.IMPACT_COMPENSATION_MAX_STACKS)) * 100));
+			}
+		}
+		return true;
+	case 'FLASHBANG_RESIST_VALUE':
+		OutString = "0";
+		AbilityState = XComGameState_Ability(ParseObj);
+		if (AbilityState != none)
+		{
+			UnitState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(AbilityState.OwnerStateObject.ObjectID));
+		}
+		else
+		{
+			EffectState = XComGameState_Effect(ParseObj);
+			if (EffectState != none)
+			{
+				UnitState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(EffectState.ApplyEffectParameters.TargetStateObjectRef.ObjectID));
+			}
+		}
+
+		if (UnitState != none)
+		{
+			for (k = 0; k < class'LWTemplateMods'.default.ENEMY_FLASHBANG_RESIST.length; k++)
+			{
+				if (class'LWTemplateMods'.default.ENEMY_FLASHBANG_RESIST[k].UnitName == UnitState.GetMyTemplateName())
+				{
+					OutString = string(class'LWTemplateMods'.default.ENEMY_FLASHBANG_RESIST[k].Chance);
+					break;
+				}
 			}
 		}
 		return true;


### PR DESCRIPTION
Certain enemy types have a chance to resist disorientation from flashbang grenades, which is defined by ENEMY_FLASHBANG_RESIST array. However, apart from a vague and brief mention in flashbang grenades description, players have no way of knowing about existence of such a mechanic and it can (and does) lead to confusing gameplay moments.
This change add a passive ability to relevant enemy types which provide information about this innate property in its description. The ability itself is purely cosmetic, as the resistance code is integrated into flashbang grenades themselves.

I added ability template creation into X2Ability_LW_DefaultAbilitySet because I couldn't find more appropriate class to add it to, and creating a new one felt like overcomplication. But it being in X2Ability_LW_DefaultAbilitySet doesn't feel entirely right either, so if it does matter where it is placed I am not opposed to move it elsewhere.

The naming (and the description) of the ability is bland and might be changed to something more thematically fitting if one can come up with something better. Also, perk image icon was chosen at my discretion, which is rather poor, because I generally don't know what icons are there or how they look like.