### PR TITLE
Make Locked On not lose the bonus on non-offensive abilities

### DIFF
--- a/LongWarOfTheChosen/Config/XComClassData.ini
+++ b/LongWarOfTheChosen/Config/XComClassData.ini
@@ -1159,7 +1159,7 @@ NumInDeck=0
 							   (AbilityName="FieldMedic"), \\
 							   (AbilityName="PrecisionShot", ApplyToWeaponSlot=eInvSlot_PrimaryWeapon), \\
 							   (AbilityName="SmokeGrenade"), \\
-							   (AbilityName="LockedOn",  ApplyToWeaponSlot=eInvSlot_Unknown), \\
+							   (AbilityName="LockedOn",  ApplyToWeaponSlot=eInvSlot_PrimaryWeapon), \\
 							   (AbilityName="Flashbanger",  ApplyToWeaponSlot=eInvSlot_Unknown), \\
 							   (AbilityName="Preservation_LW",  ApplyToWeaponSlot=eInvSlot_Unknown) \\
 					))
@@ -1327,7 +1327,7 @@ NumInDeck=0
 							   (AbilityName="CenterMass", ApplyToWeaponSlot=eInvSlot_PrimaryWeapon), \\
 							   (AbilityName="BringEmOn", ApplyToWeaponSlot=eInvSlot_PrimaryWeapon), \\
 							   (AbilityName="Salvo",  ApplyToWeaponSlot=eInvSlot_Unknown), \\
-							   (AbilityName="LockedOn",  ApplyToWeaponSlot=eInvSlot_Unknown), \\
+							   (AbilityName="LockedOn",  ApplyToWeaponSlot=eInvSlot_PrimaryWeapon), \\
 							   (AbilityName="Bombard_LW",  ApplyToWeaponSlot=eInvSlot_Unknown), \\
 							   (AbilityName="VolatileMix"), \\
 							   (AbilityName="Sprinter"), \\
@@ -1557,7 +1557,7 @@ bHasClassMovie=true
 							   (AbilityName="HailOfBullets", ApplyToWeaponSlot=eInvSlot_PrimaryWeapon), \\
 							   (AbilityName="SurvivalInstinct_LW",  ApplyToWeaponSlot=eInvSlot_Unknown), \\
 							   (AbilityName="Infighter",  ApplyToWeaponSlot=eInvSlot_Unknown), \\
-							   (AbilityName="LockedOn"), \\
+							   (AbilityName="LockedOn", ApplyToWeaponSlot=eInvSlot_PrimaryWeapon), \\
 							   (AbilityName="PrimaryReturnFire", ApplyToWeaponSlot=eInvSlot_PrimaryWeapon), \\
 							   (AbilityName="Paramedic_LW"), \\
 							   (AbilityName="SkirmisherStrike", ApplyToWeaponSlot=eInvSlot_PrimaryWeapon) \\

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -336,11 +336,11 @@ LocPromotionPopupText="<Bullet/> Gain +20 aim on your next shot with your primar
 [LockedOn X2AbilityTemplate]
 LocFriendlyName="Locked On"
 LocFlyOverText="Locked On"
-; LWOTC Needs Translation
-LocLongDescription="Gain +<Ability:LOCKEDON_AIM_BONUS/> aim and +<Ability:LOCKEDON_CRIT_BONUS/> crit for successive shots at the same enemy unit."
-LocHelpText="Gain +<Ability:LOCKEDON_AIM_BONUS/> aim and +<Ability:LOCKEDON_CRIT_BONUS/> crit for successive shots at the same enemy unit."
-LocPromotionPopupText="<Bullet/> Gain +<Ability:LOCKEDON_AIM_BONUS/> aim and +<Ability:LOCKEDON_CRIT_BONUS/> crit for repeated shots at the same target. Not cumulative, and only applies to enemy units.<br/><Bullet/> Area-of-Effect-based shots do not grant the bonus."
-; End Translation
+; LWOTC Needs Translation (2)
+LocLongDescription="Gain +<Ability:LOCKEDON_AIM_BONUS/> aim and +<Ability:LOCKEDON_CRIT_BONUS/> crit for successive shots with your <Ability:BOUND_WEAPON_NAME/> at the same enemy unit."
+LocHelpText="Gain +<Ability:LOCKEDON_AIM_BONUS/> aim and +<Ability:LOCKEDON_CRIT_BONUS/> crit for successive shots with your <Ability:BOUND_WEAPON_NAME/> at the same enemy unit."
+LocPromotionPopupText="<Bullet/> Gain +<Ability:LOCKEDON_AIM_BONUS/> aim and +<Ability:LOCKEDON_CRIT_BONUS/> crit for repeated shots with your <Ability:BOUND_WEAPON_NAME/> at the same target. Not cumulative, and only applies to enemy units.<br/><Bullet/> Area-of-Effect-based shots do not grant the bonus."
+; End Translation (2)
 
 [Sentinel_LW X2AbilityTemplate]
 LocFriendlyName="Sentinel"

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LockedOn.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LockedOn.uc
@@ -16,7 +16,7 @@ function RegisterForEvents(XComGameState_Effect EffectGameState)
 
 	EventMgr = `XEVENTMGR;
 	EffectObj = EffectGameState;
-	EventMgr.RegisterForEvent(EffectObj, 'AbilityActivated', EffectGameState.ZeroInListener, ELD_OnStateSubmitted, , `XCOMHISTORY.GetGameStateForObjectID(EffectGameState.ApplyEffectParameters.TargetStateObjectRef.ObjectID));
+	EventMgr.RegisterForEvent(EffectObj, 'AbilityActivated', LockedOnListener, ELD_OnStateSubmitted,,,, EffectObj);
 }
 
 function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit Attacker, XComGameState_Unit Target, XComGameState_Ability AbilityState, class<X2AbilityToHitCalc> ToHitType, bool bMelee, bool bFlanking, bool bIndirectFire, out array<ShotModifierInfo> ShotModifiers)
@@ -28,9 +28,9 @@ function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit 
 	SourceWeapon = AbilityState.GetSourceWeapon();
 	if (SourceWeapon != none && !bIndirectFire)
 	{
-		Attacker.GetUnitValue('ZeroInShots', ShotsValue);
-		Attacker.GetUnitValue('ZeroInTarget', TargetValue);
-		
+		Attacker.GetUnitValue('LockedOnShots', ShotsValue);
+		Attacker.GetUnitValue('LockedOnTarget', TargetValue);
+
 		if (ShotsValue.fValue > 0 && TargetValue.fValue == Target.ObjectID)
 		{
 			ShotMod.ModType = eHit_Success;
@@ -44,6 +44,57 @@ function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit 
 			ShotModifiers.AddItem(ShotMod);
 		}
 	}
+}
+
+static function EventListenerReturn LockedOnListener(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameStateContext_Ability AbilityContext;
+	local XComGameState_Ability AbilityState;
+	local XComGameState NewGameState;
+	local XComGameState_Unit UnitState;
+	local XComGameState_Unit LockedOnOwnerUnitState;
+	local XComGameState_Item SourceWeapon;
+	local XComGameState_Effect EffectGameState;
+
+	AbilityContext = XComGameStateContext_Ability(GameState.GetContext());
+	`assert(AbilityContext != none);
+	if (AbilityContext.InterruptionStatus == eInterruptionStatus_Interrupt)
+		return ELR_NoInterrupt;
+
+	AbilityState = XComGameState_Ability(EventData);
+	`assert(AbilityState != none);
+	UnitState = XComGameState_Unit(EventSource);
+	`assert(UnitState != none);
+
+	EffectGameState = XComGameState_Effect(CallbackData);
+	if (EffectGameState == none)
+		return ELR_NoInterrupt;
+
+	LockedOnOwnerUnitState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(EffectGameState.ApplyEffectParameters.TargetStateObjectRef.ObjectID));
+
+	if (UnitState.ObjectID != LockedOnOwnerUnitState.ObjectID)
+		return ELR_NoInterrupt;
+
+	if (AbilityState.IsAbilityInputTriggered())
+	{
+		SourceWeapon = AbilityState.GetSourceWeapon();
+		if (AbilityState.GetMyTemplate().Hostility == eHostility_Offensive && SourceWeapon != none && SourceWeapon.InventorySlot == eInvSlot_PrimaryWeapon)
+		{
+			NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("LockedOn");
+			UnitState = XComGameState_Unit(NewGameState.ModifyStateObject(UnitState.Class, UnitState.ObjectID));
+			UnitState.SetUnitFloatValue('LockedOnShots', 1);
+			UnitState.SetUnitFloatValue('LockedOnTarget', AbilityContext.InputContext.PrimaryTarget.ObjectID);
+
+			if (UnitState.ActionPoints.Length > 0)
+			{
+				//	show flyover for boost, but only if they have actions left to potentially use them
+				NewGameState.ModifyStateObject(class'XComGameState_Ability', EffectGameState.ApplyEffectParameters.AbilityStateObjectRef.ObjectID);		//	create this for the vis function
+				XComGameStateContext_ChangeContainer(NewGameState.GetContext()).BuildVisualizationFn = EffectGameState.TriggerAbilityFlyoverVisualizationFn;
+			}
+			`TACTICALRULES.SubmitGameState(NewGameState);
+		}
+	}
+	return ELR_NoInterrupt;
 }
 
 defaultproperties

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LockedOn.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LockedOn.uc
@@ -82,8 +82,8 @@ static function EventListenerReturn LockedOnListener(Object EventData, Object Ev
 		{
 			NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("LockedOn");
 			UnitState = XComGameState_Unit(NewGameState.ModifyStateObject(UnitState.Class, UnitState.ObjectID));
-			UnitState.SetUnitFloatValue('LockedOnShots', 1);
-			UnitState.SetUnitFloatValue('LockedOnTarget', AbilityContext.InputContext.PrimaryTarget.ObjectID);
+			UnitState.SetUnitFloatValue('LockedOnShots', 1, eCleanup_BeginTactical);
+			UnitState.SetUnitFloatValue('LockedOnTarget', AbilityContext.InputContext.PrimaryTarget.ObjectID, eCleanup_BeginTactical);
 
 			if (UnitState.ActionPoints.Length > 0)
 			{

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LockedOn.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LockedOn.uc
@@ -26,7 +26,7 @@ function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit 
 	local UnitValue ShotsValue, TargetValue;
 
 	SourceWeapon = AbilityState.GetSourceWeapon();
-	if (SourceWeapon != none && !bIndirectFire)
+	if (SourceWeapon != none && !bIndirectFire && SourceWeapon.InventorySlot == eInvSlot_PrimaryWeapon)
 	{
 		Attacker.GetUnitValue('LockedOnShots', ShotsValue);
 		Attacker.GetUnitValue('LockedOnTarget', TargetValue);


### PR DESCRIPTION
Currently ranger's Locked On effect is lost when using any non-offensive ability or using non-primary weapon. This behavior differs from original LW2 and, I think, feels very janky.

From what I can tell, here is how it happened. Originally Locked On relied on XComGameState_Effect_LastShotDetails class to keep track of who was shot last. However, this class' event listener does not make the check that the unit using an ability is the same as the unit which have relevant effect (which is unclear as to why for me, but I suspect it is either the difference in how it is triggered in vanilla or how it was subscribed to in LW2).  Which lead to there being an issue where locked on was cleared by other soldiers using their abilities. That issue was fixed there #621 by replacing Locked On listener to vanilla ZeroIn listener.  However, said ZeroIn listener differs from the original RecordShot in certain details. Namely, it resets its counters if the unit uses any non-offensive ability or uses non-primary weapon.

The fix is to use custom listener, which mostly copied from ZeroIn, but with resetting counters removed.
Another difference from RecordShot is that it used SHOTFIRED_ABILITYNAMES whitelist of abilities which could apply Locked On. Now it uses ZeroIn criteria which is any targeted attack with primary weapon. I couldn't think of an ability which would be in one set but not another, but there could be some.


The second commit makes LockedOn both triggered by and applied to primary weapon shots only.  It is less obvious of a change to make, so take it  or leave it, but for the reasons outlined in said commit message I think it would be good change as well.