### PR TITLE
Fix to InfiltrationHackBonus change

### DIFF
--- a/LongWarOfTheChosen/Config/XComGameData_SoldierSkills.ini
+++ b/LongWarOfTheChosen/Config/XComGameData_SoldierSkills.ini
@@ -100,6 +100,9 @@ GET_OVER_HERE_MAX_RANGE=768;  8 tiles in units
 ShadowMobilityMod=1.0
 ShadowCooldown=4
 RemoteStartCooldown=5
+; Infiltration is solely used to prevent towers from breaking Shadow, so
+; removing Hacking bonus
+InfiltrationHackBonus=0
 
 StingCooldown=1  ; Just prevent the use of Sting twice in a turn
 StingCharges=2

--- a/LongWarOfTheChosen/Config/XComLW_SoldierSkills.ini
+++ b/LongWarOfTheChosen/Config/XComLW_SoldierSkills.ini
@@ -949,8 +949,3 @@ SHIELD_BASH_COOLDOWN=3
 GREATER_PADDING_CV=2
 GREATER_PADDING_MG=4
 GREATER_PADDING_BM=6
-
-; Infiltration is solely used to prevent towers from breaking Shadow, so
-; removing Hacking bonus
-[XComGame.X2Ability_ReaperAbilitySet]
-InfiltrationHackBonus=0


### PR DESCRIPTION
The config change of setting InfiltrationHackBonus value to 0 was put in the wrong ini file and does not take the effect.
A trivial fix, which you even might have made locally already. It is here mainly in case its issue was accidentally skipped over and so to not be forgotten about.