### PR TITLE
Fix to the effects which check 'unarmored' status 

### DIFF
--- a/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
+++ b/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
@@ -655,6 +655,7 @@
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_Failsafe.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_Fatality_LW.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_FireEventOnCrit.uc" />
+    <Content Include="Src\LW_Overhaul\Classes\X2Effect_FlechetteRounds.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_GeneralDamageModifier.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_GreatestChampion.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_Guardian_LW.uc" />

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GearAbilities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GearAbilities.uc
@@ -69,11 +69,11 @@ static function array<X2DataTemplate> CreateTemplates()
 	Templates.AddItem(CreateNanofiberBonusAbility_LW());
 	Templates.AddItem(CreateNeurowhipAbility());
 	Templates.AddItem(CreateStilettoRoundsAbility());
+	Templates.AddItem(CreateFlechetteRoundsAbility());
 
 	Templates.AddItem(PurePassive('Stiletto_Rounds_Ability_PP', "img:///UILibrary_PerkIcons.UIPerk_ammo_stiletto", false));
 	Templates.AddItem(PurePassive('Needle_Rounds_Ability', "img:///UILibrary_PerkIcons.UIPerk_ammo_needle", false));
 	Templates.AddItem(PurePassive('Redscreen_Rounds_Ability', "img:///UILibrary_LW_Overhaul.LW_AbilityRedscreen", false));
-	Templates.AddItem(PurePassive('Flechette_Rounds_Ability', "img:///UILibrary_PerkIcons.UIPerk_ammo_fletchette", false)); // notice bad spelling in perk filename
 	Templates.AddItem(PurePassive('Shredder_Rounds_Ability', "img:///UILibrary_PerkIcons.UIPerk_maximumordanance", false));
 	
 	Templates.AddItem(PurePassive('Dragon_Rounds_Ability_PP', "img:///UILibrary_PerkIcons.UIPerk_ammo_incendiary", false));
@@ -366,6 +366,34 @@ static function X2AbilityTemplate CreateStilettoRoundsAbility()
 	Effect.BuildPersistentEffect (1, true, false, false);
 	Effect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false, , Template.AbilitySourceName);
 	Template.AddTargetEffect (Effect);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+
+	return Template;	
+}
+
+static function X2AbilityTemplate CreateFlechetteRoundsAbility()
+{
+	local X2AbilityTemplate                 Template;	
+	local X2Effect_FlechetteRounds			Effect;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'Flechette_Rounds_Ability');
+
+	Template.AbilitySourceName = 'eAbilitySource_Item';
+	Template.eAbilityIconBehaviorHUD = EAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.bDisplayInUITacticalText = false;
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_ammo_fletchette";
+
+	Template.AbilityToHitCalc = default.DeadEye;
+	Template.AbilityTargetStyle = default.SelfTarget;
+	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
+
+	Effect = new class'X2Effect_FlechetteRounds';
+	Effect.BonusDmg = class'X2Item_LWUtilityItems'.default.FLECHETTE_BONUS_DMG;
+	Effect.BuildPersistentEffect (1, true, false, false);
+	Effect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true, , Template.AbilitySourceName);
+	Template.AddTargetEffect(Effect);
 
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_FlechetteRounds.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_FlechetteRounds.uc
@@ -1,0 +1,22 @@
+class X2Effect_FlechetteRounds extends X2Effect_Persistent;
+
+var int BonusDmg;
+
+function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState)
+{
+	local XComGameState_Item SourceWeapon;
+	local XComGameState_Unit TargetUnit;
+
+	SourceWeapon = AbilityState.GetSourceWeapon();
+	if (SourceWeapon != none && SourceWeapon.LoadedAmmo.ObjectID == EffectState.ApplyEffectParameters.ItemStateObjectRef.ObjectID)
+	{
+		TargetUnit = XComGameState_Unit(TargetDamageable);
+		if(TargetUnit != none)
+		{
+			if (class'XComGameStateContext_Ability'.static.IsHitResultHit(AppliedData.AbilityResultContext.HitResult) && TargetUnit.GetArmorMitigation(AppliedData.AbilityResultContext.ArmorMitigation) == 0)
+			{
+				return BonusDmg;
+			}
+		}
+	}
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_StreetSweeper.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_StreetSweeper.uc
@@ -12,7 +12,7 @@ function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGa
 		TargetUnit = XComGameState_Unit(TargetDamageable);
 		if(TargetUnit != none)
 		{
-			if (TargetUnit.GetCurrentStat (eStat_ArmorMitigation) == 0)
+			if (TargetUnit.GetArmorMitigation(AppliedData.AbilityResultContext.ArmorMitigation) == 0)
 			{
 				if (Unarmored_Damage_Multiplier != 0.0)
 				{

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Item_LWUtilityItems.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Item_LWUtilityItems.uc
@@ -224,7 +224,6 @@ static function X2AmmoTemplate CreateFalconRounds()
 static function X2AmmoTemplate CreateFlechetteRounds()
 {
 	local X2AmmoTemplate				Template;
-	local X2Condition_UnitStatCheck		Condition;
 	local WeaponDamageValue				DamageValue;
 
 	`CREATE_X2TEMPLATE(class'X2AmmoTemplate', Template, 'FlechetteRounds');
@@ -238,15 +237,10 @@ static function X2AmmoTemplate CreateFlechetteRounds()
 	Template.CanBeBuilt = true;
 
 	DamageValue.Damage = default.FLECHETTE_DMGMOD;
-    DamageValue.DamageType = 'Flechette';
-    Template.AddAmmoDamageModifier(none, DamageValue);
+	DamageValue.DamageType = 'Flechette';
+	Template.AddAmmoDamageModifier(none, DamageValue);
 
-	Condition = new class'X2Condition_UnitStatCheck';
-	Condition.AddCheckStat (eStat_ArmorMitigation, 0, eCheck_LessThanOrEqual);
-	DamageValue.Damage = default.FLECHETTE_BONUS_DMG;
-	Template.AddAmmoDamageModifier(Condition, DamageValue);
-	
-	Template.Abilities.AddItem('Flechette_Rounds_Ability');
+	Template.Abilities.AddItem('Flechette_Rounds_Ability');	
 
 	Template.GameArchetype = "Ammo_Flechette.PJ_Flechette"; // present
 	//FX References

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_NeedleGrenades.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_NeedleGrenades.uc
@@ -34,8 +34,7 @@ function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGa
 			DamageEffect = X2Effect_ApplyWeaponDamage(class'X2Effect'.static.GetX2Effect(AppliedData.EffectRef));
 			if (TargetUnit != none)
 			{
-
-				if (DamageEffect != none && !DamageEffect.bIgnoreBaseDamage && TargetUnit.GetCurrentStat(eStat_ArmorMitigation) == 0)
+				if (DamageEffect != none && !DamageEffect.bIgnoreBaseDamage && TargetUnit.GetArmorMitigation(AppliedData.AbilityResultContext.ArmorMitigation) == 0)
 				{
 					return BonusDamage;
 				}


### PR DESCRIPTION
Currently Needle Grenades, Street Sweeper and Flechette Rounds won't apply to units whose armor was shredded.
Per discussion on the discord, I think it would be better to fix the effects, so that it would classify units with fully shredded armor as 'unarmored', as I think it is what most would expect of it.

For Needle Grenades and Street Sweeper the changes simply replace the armor check.

For Flechette Rounds I couldn't see how to easily fix the condition without creating new effect, so I created a new one, based on how stiletto rounds one was done.
One cosmetic difference to how it was previously done (and unlike how stiletto rounds is done) is not using additional PurePassive ability to display flechette rounds description, but displaying the existing effect itself. Which specifically means that it uses eAbilitySource_Item for coloring its icon, unlike every other rounds effect, which, for some reason, use the default eAbilitySource_Perk value for their PurePassive call. I would argue that using eAbilitySource_Item there is correct.