### PR TITLE
Fix Fire Discipline

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_OfficerPack.ini
+++ b/LongWarOfTheChosen/Config/XComLW_OfficerPack.ini
@@ -142,7 +142,7 @@ LEADERSHIP_DEFENSE_CAP=0
 
 TRIAL_BY_FIRE_RANK_CAP=4
 
-[LW_OfficerPack_Integrated.X2Ability_OfficerAbilitySet_PassiveAuras]
+[LW_OfficerPack_Integrated.X2Effect_FireDiscipline]
 FIREDISCIPLINE_REACTIONFIRE_BONUS=10
 
 [LW_OfficerPack_Integrated.X2Effect_Defilade]


### PR DESCRIPTION
So, it seems to me that Fire Discipline officer perk did absolutely nothing this whole time. Because FIREDISCIPLINE_REACTIONFIRE_BONUS value was assigned in the wrong section of the ini file, the value X2Effect_FireDiscpline used was 0. Fascinating.