### PR TITLE
Correct typo of "material" in user-facing strings.

### DIFF
--- a/LongWarOfTheChosen/Localization/LW_Overhaul.int
+++ b/LongWarOfTheChosen/Localization/LW_Overhaul.int
@@ -176,7 +176,7 @@ ActivityObjectives[0]="Protect Resistance Assets"
 [SupplyConvoy X2LWAlienActivityTemplate]
 ActivityName="SupplyConvoyActivity"
 ActivityObjectives[0]="Protect Resistance Assets"
-+MissionDescriptions=(MissionFamily="SupplyConvoy_LW", Description="ADVENT forces are moving to strike a Resistance supply convoy. We need to protect our people and materiel.")
++MissionDescriptions=(MissionFamily="SupplyConvoy_LW", Description="ADVENT forces are moving to strike a Resistance supply convoy. We need to protect our people and material.")
 
 [RecruitRaid X2LWAlienActivityTemplate]
 ActivityName="RecruitRaidActivity"

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -4755,7 +4755,7 @@ DescriptionEntry="In Long War 2, the Commander will take over management of the 
 [OutpostManagement_Supply X2EncyclopediaTemplate]
 ListTitle="The Supply Job"
 DescriptionTitle="The Supply Job"
-DescriptionEntry="Resistance personnel on the SUPPLY job are focused on scavenging supplies from around their regions. More rebels assigned to the Supply job will mean a larger Supply drop each month. Note that over time in a given region, the Supply job will grow less effective as the Resistance scrounges the most easily recovered materiel."
+DescriptionEntry="Resistance personnel on the SUPPLY job are focused on scavenging supplies from around their regions. More rebels assigned to the Supply job will mean a larger Supply drop each month. Note that over time in a given region, the Supply job will grow less effective as the Resistance scrounges the most easily recovered material."
 
 [OutpostManagement_Recruit X2EncyclopediaTemplate]
 ListTitle="The Recruit Job"


### PR DESCRIPTION
This typo appears in the screenshots on the Nexus Mods page, so I couldn't ignore it :)