### PR TITLE
Fix Paramedic visualization

### DIFF
--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_ReaperAbilitySet_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_ReaperAbilitySet_LW.uc
@@ -933,7 +933,7 @@ static function X2DataTemplate AddParamedic()
 	Template.GetBonusWeaponAmmoFn = Paramedic_BonusCharges;
 
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
-	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
+	//  NOTE: No visualization on purpose!
 
 	return Template;
 }


### PR DESCRIPTION
If a Reaper have Paramedic skill he will currently shoot in the air at the beginning of a mission. I believe assigning TypicalAbility_BuildVisualization is unneeded here.