### PR TITLE
Fix Jammer charges persistence

### DIFF
--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2Ability_OfficerAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2Ability_OfficerAbilitySet.uc
@@ -1176,6 +1176,7 @@ function XComGameState JammerAbility_BuildGameState( XComGameStateContext Contex
 	AbilityContext = XComGameStateContext_Ability(NewGameState.GetContext());
 	AbilityState = XComGameState_Ability(History.GetGameStateForObjectID(AbilityContext.InputContext.AbilityRef.ObjectID, eReturnType_Reference));
 	AbilityTemplate = AbilityState.GetMyTemplate();
+	AbilityState = XComGameState_Ability(NewGameState.ModifyStateObject(AbilityState.Class, AbilityState.ObjectID));
 
 	UnitState = XComGameState_Unit(NewGameState.CreateStateObject(class'XComGameState_Unit', AbilityContext.InputContext.SourceObject.ObjectID));
 	//Apply the cost of the ability


### PR DESCRIPTION
Currently, if you use Jammer ability, save the game, then reload it, Jammer charges will be restored.
Adding this line (taken from TypicalAbility_BuildGameState) fixes it.