### PR TITLE
Fix Focus Fire inconsistent applicability for SPARKS

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_OfficerPack.ini
+++ b/LongWarOfTheChosen/Config/XComLW_OfficerPack.ini
@@ -170,6 +170,7 @@ VALIDWEAPONCATEGORIES[9]="wristblade"
 VALIDWEAPONCATEGORIES[10]="gauntlet"  ; Templar Gauntlet
 VALIDWEAPONCATEGORIES[11]="sidearm"
 VALIDWEAPONCATEGORIES[12]="throwingknife"
+VALIDWEAPONCATEGORIES[13]="sparkrifle"
 
 [LW_OfficerPack_Integrated.X2Effect_Scavenger]
 ;bonus mission supplies from Scavenger ability


### PR DESCRIPTION
Currently, SPARKs' main weapon attacks get bonus aim from already applied stacks of Focus Fire, but do not contribute to it. Adding 'sparkrifle' to Focus Fire VALIDWEAPONCATEGORIES list make SPARKs fully benefit from Focus Fire.
It may be argued, that it should be made that the SPARKs do not get _any_ Focus Fire benefits, including the aim, due to how officer abilities generally do not apply to SPARKs (with couple exceptions). However, making both parts works is an easier fix to do, so I chose this approach.