### PR TITLE
Fix MAX_FACELESS_PROPORTION check

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOutpost.uc
@@ -300,8 +300,8 @@ function StateObjectReference CreateRebel(XComGameState NewGameState, XComGameSt
 			FacelessChance *= (default.FACELESS_CHANCE_MULTIPLIER_LIMIT + FacelessChanceModifier);
 		}
 	}
-
-	if (forceFaceless || (allowFaceless && `SYNC_FRAND() < FacelessChance && GetNumFaceless() / GetRebelCount() < default.MAX_FACELESS_PROPORTION))
+ 
+	if (forceFaceless || (allowFaceless && `SYNC_FRAND() < FacelessChance && GetRebelCount() > 0 && float(GetNumFaceless()) / float(GetRebelCount()) < default.MAX_FACELESS_PROPORTION))
 	{
 		CharacterTemplateName = 'FacelessRebel';
 	}


### PR DESCRIPTION
Since both GetNumFaceless() and GetRebelCount() function results are of "int" type the division applied is here is the integer division. So, GetNumFaceless() / GetRebelCount() can only be equal 1 if all rebels are faceless and 0 otherwise. Thus, this part of the check will always pass if there is at least one non-faceless rebel in the haven, and so MAX_FACELESS_PROPORTION being set to 0.32f is meaningless, as it could  have been set to 0.99f with the same effect.

Casting function results to float should fix it.

This change does affect strategic layer. Players could previously get havens with like 4/5 faceless, which would no longer be possible with this change.  As I understand there is certain hesitance to change strategic layer, so  I leave the decision to whether fix it or not to others discretion.