### PR TITLE
Change Trojan damage to account for items' Hack bonuses

### DIFF
--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_TrojanVirus.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_TrojanVirus.uc
@@ -60,7 +60,7 @@ static function EventListenerReturn PostEffectTickCheck(Object EventData, Object
 	// effect has worn off, Trojan Virus now kicks in
 	// Compute damage
 	Damage = 0;
-	AttackerHackStat = SourceState.GetCurrentStat(eStat_Hacking);
+	AttackerHackStat = SourceState.GetCurrentStat(eStat_Hacking) + SourceState.GetUIStatFromAbilities(eStat_Hacking) + SourceState.GetUIStatFromInventory(eStat_Hacking, GameState);
 	DefenderHackDefense = OldTargetState.GetCurrentStat(eStat_HackDefense);
 	for(idx = 0; idx < default.TROJANVIRUSROLLS; idx++)
 	{


### PR DESCRIPTION
Related to https://github.com/long-war-2/lwotc/issues/1491.
Currently, Trojan damage rolls use soldier's raw hacking stat without accounting for bonuses to Hack from gremlin/skulljack.
This may or may not have been intended. Personally, I find it non-intuitive, thus proposing this change. It does buff trojan average damage considerably though.