### PR TITLE
Fix some code issues where uc-analyzer gives up

### DIFF
--- a/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Ability_LWAlienAbilities.uc
+++ b/LongWarOfTheChosen/Src/LW_AlienPack_Integrated/Classes/X2Ability_LWAlienAbilities.uc
@@ -348,7 +348,7 @@ function WarCry_BuildVisualization(XComGameState VisualizeGameState)
 
 	History = `XCOMHISTORY;
 	context = XComGameStateContext_Ability(VisualizeGameState.GetContext());
-	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, 1, VisualizeGameState.HistoryIndex - 1));
+	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1));
 	InteractingUnitRef = context.InputContext.SourceObject;
 	BuildTrack = EmptyTrack;
 	BuildTrack.StateObject_OldState = History.GetGameStateForObjectID(InteractingUnitRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1);
@@ -1052,7 +1052,7 @@ simulated function ReadyForAnything_BuildVisualization(XComGameState VisualizeGa
 	History = `XCOMHISTORY;
 	context = XComGameStateContext_Ability(VisualizeGameState.GetContext());
 	InteractingUnitRef = Context.InputContext.SourceObject;
-	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, 1, VisualizeGameState.HistoryIndex - 1));
+	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1));
 	BuildTrack = EmptyTrack;
 	BuildTrack.StateObject_OldState = History.GetGameStateForObjectID(InteractingUnitRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1);
 	BuildTrack.StateObject_NewState = VisualizeGameState.GetGameStateForObjectID(InteractingUnitRef.ObjectID);

--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_ReaperAbilitySet_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_ReaperAbilitySet_LW.uc
@@ -1150,7 +1150,7 @@ static function ChargeBattery_BuildVisualization(XComGameState VisualizeGameStat
 
 	History = `XCOMHISTORY;
 	Context = XComGameStateContext_Ability(VisualizeGameState.GetContext());
-	Ability = XComGameState_Ability(History.GetGameStateForObjectID(Context.InputContext.AbilityRef.ObjectID, 1, VisualizeGameState.HistoryIndex - 1));
+	Ability = XComGameState_Ability(History.GetGameStateForObjectID(Context.InputContext.AbilityRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1));
 	InteractingUnitRef = Context.InputContext.SourceObject;
 	BuildTrack = EmptyTrack;
 	BuildTrack.StateObject_OldState = History.GetGameStateForObjectID(InteractingUnitRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1);

--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_TemplarAbilitySet_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_TemplarAbilitySet_LW.uc
@@ -176,7 +176,7 @@ static function X2AbilityTemplate AddTemplarFleche()
 	FlecheBonusDamageEffect.MaxBonusDamage = default.MAX_REND_FLECHE_DAMAGE;
 	FlecheBonusDamageEffect.AbilityNames.AddItem('Rend');
 	FlecheBonusDamageEffect.AbilityNames.AddItem('ArcWave');
-	FlecheBonusDamageEffect.SetDisplayInfo(0, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false,,Template.AbilitySourceName);
+	FlecheBonusDamageEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false,,Template.AbilitySourceName);
 	FlecheBonusDamageEffect.BuildPersistentEffect (1, true, false);
 	Template.AddTargetEffect (FlecheBonusDamageEffect);
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
@@ -549,7 +549,7 @@ static function Apotheosis_BuildVisualization(XComGameState VisualizeGameState)
 
 	History = `XCOMHISTORY;
 	Context = XComGameStateContext_Ability(VisualizeGameState.GetContext());
-	Ability = XComGameState_Ability(History.GetGameStateForObjectID(Context.InputContext.AbilityRef.ObjectID, 1, VisualizeGameState.HistoryIndex - 1));
+	Ability = XComGameState_Ability(History.GetGameStateForObjectID(Context.InputContext.AbilityRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1));
 	InteractingUnitRef = Context.InputContext.SourceObject;
 	BuildTrack = EmptyTrack;
 	BuildTrack.StateObject_OldState = History.GetGameStateForObjectID(InteractingUnitRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1);

--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2Ability_OfficerAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2Ability_OfficerAbilitySet.uc
@@ -742,7 +742,7 @@ static function X2AbilityTemplate AddCommandAbility()
 
 	ActionPointPersistEffect = new class'X2Effect_Persistent';
     ActionPointPersistEffect.EffectName = 'Command';
-    ActionPointPersistEffect.BuildPersistentEffect(1, false, true, false, 8);
+    ActionPointPersistEffect.BuildPersistentEffect(1, false, true, false, eGameRule_PlayerTurnEnd);
     ActionPointPersistEffect.bRemoveWhenTargetDies = true;
     Template.AddTargetEffect(ActionPointPersistEffect);
 
@@ -1244,7 +1244,7 @@ function GetSome_BuildVisualization(XComGameState VisualizeGameState)
 
     History = `XCOMHISTORY;
     context = XComGameStateContext_Ability(VisualizeGameState.GetContext());
-	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, 1, VisualizeGameState.HistoryIndex - 1));
+	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1));
     InteractingUnitRef = context.InputContext.SourceObject;
     BuildTrack = EmptyTrack;
     BuildTrack.StateObject_OldState = History.GetGameStateForObjectID(InteractingUnitRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1);
@@ -1291,7 +1291,7 @@ function Incoming_BuildVisualization(XComGameState VisualizeGameState)
 
     History = `XCOMHISTORY;
     context = XComGameStateContext_Ability(VisualizeGameState.GetContext());
-	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, 1, VisualizeGameState.HistoryIndex - 1));
+	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1));
     InteractingUnitRef = context.InputContext.SourceObject;
     BuildTrack = EmptyTrack;
     BuildTrack.StateObject_OldState = History.GetGameStateForObjectID(InteractingUnitRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1);
@@ -1346,7 +1346,7 @@ function OscarMike_BuildVisualization(XComGameState VisualizeGameState)
 
     History = `XCOMHISTORY;
     context = XComGameStateContext_Ability(VisualizeGameState.GetContext());
-	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, 1, VisualizeGameState.HistoryIndex - 1));
+	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1));
     InteractingUnitRef = context.InputContext.SourceObject;
     BuildTrack = EmptyTrack;
     BuildTrack.StateObject_OldState = History.GetGameStateForObjectID(InteractingUnitRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1);
@@ -1395,7 +1395,7 @@ function FocusFire_BuildVisualization(XComGameState VisualizeGameState)
 
     History = `XCOMHISTORY;
     context = XComGameStateContext_Ability(VisualizeGameState.GetContext());
-	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, 1, VisualizeGameState.HistoryIndex - 1));
+	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1));
     InteractingUnitRef = context.InputContext.SourceObject;
     BuildTrack = EmptyTrack;
     BuildTrack.StateObject_OldState = History.GetGameStateForObjectID(InteractingUnitRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1);
@@ -1446,7 +1446,7 @@ static function X2AbilityTemplate AddLeadershipAbility()
 
 	PersistentEffect = new class'X2Effect_Persistent';
     PersistentEffect.BuildPersistentEffect(1, true, false);
-    PersistentEffect.SetDisplayInfo(0, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, true,, Template.AbilitySourceName);
+    PersistentEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, true,, Template.AbilitySourceName);
     Template.AddTargetEffect(PersistentEffect);
 
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;

--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2DownloadableContentInfo_LWOfficerPack.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2DownloadableContentInfo_LWOfficerPack.uc
@@ -469,5 +469,5 @@ static function bool AbilityTagExpandHandler(string InString, out string OutStri
         default:
             return false;
     }
-	return ReturnValue;
+	return false;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -1012,7 +1012,7 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		SerialCritReduction.CritReductionPerKill = default.SERIAL_CRIT_MALUS_PER_KILL;
 		SerialCritReduction.AimReductionPerKill = default.SERIAL_AIM_MALUS_PER_KILL;
 		SerialCritReduction.Damage_Falloff = default.SERIAL_DAMAGE_FALLOFF;
-		SerialCritReduction.SetDisplayInfo (ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage, true,, Template.AbilitySourceName);
+		SerialCritReduction.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage, true,, Template.AbilitySourceName);
 		SerialCritReduction.EffectName = 'SerialCritReduction';
 		Template.AbilityTargetEffects.AddItem(SerialCritReduction);
 	}
@@ -1037,11 +1037,11 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		Template.AbilityTargetEffects.Length = 0;
 		DFAEffect = New class'X2Effect_CancelLongRangePenalty';
 		DFAEffect.BuildPersistentEffect (1, true, false);
-		DFAEffect.SetDisplayInfo (0, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, false,, Template.AbilitySourceName);
+		DFAEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, false,, Template.AbilitySourceName);
 		Template.AddTargetEffect(DFAEffect);
 		DeathEffect = new class'X2Effect_DeathFromAbove_LW';
 		DeathEffect.BuildPersistentEffect(1, true, false, false);
-		DeathEffect.SetDisplayInfo(0, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, true,, Template.AbilitySourceName);
+		DeathEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, true,, Template.AbilitySourceName);
 		Template.AddTargetEffect(DeathEffect);
 	}
 
@@ -1201,7 +1201,7 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		DamageModifier.BonusDamage = class'X2Ability_RangerAbilitySet'.default.INSTINCT_DMG;
 		DamageModifier.BonusCritChance = class'X2Ability_RangerAbilitySet'.default.INSTINCT_CRIT;
 		DamageModifier.BuildPersistentEffect(1, true, false, true);
-		DamageModifier.SetDisplayInfo(0, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true,, Template.AbilitySourceName);
+		DamageModifier.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true,, Template.AbilitySourceName);
 		Template.AddTargetEffect(DamageModifier);
 	}
 
@@ -1211,7 +1211,7 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		Template.AbilityTargetEffects.length = 0;
 		Squadsight = new class'X2Effect_Squadsight';
 		Squadsight.BuildPersistentEffect(1, true, false, true);
-		Squadsight.SetDisplayInfo(0, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,, Template.AbilitySourceName);
+		Squadsight.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,, Template.AbilitySourceName);
 		Template.AddTargetEffect(Squadsight);
 	}
 
@@ -1220,8 +1220,8 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		Template.AbilityTargetEffects.length = 0;
 		ToHitModifier = new class'X2Effect_ToHitModifier';
 		ToHitModifier.BuildPersistentEffect(1, true, false, true);
-		ToHitModifier.SetDisplayInfo(0, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,, Template.AbilitySourceName);
-		ToHitModifier.AddEffectHitModifier(1, class'X2Ability_SharpshooterAbilitySet'.default.HITWHEREITHURTS_CRIT, Template.LocFriendlyName,, false, true, true, true);
+		ToHitModifier.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,, Template.AbilitySourceName);
+		ToHitModifier.AddEffectHitModifier(eHit_Crit, class'X2Ability_SharpshooterAbilitySet'.default.HITWHEREITHURTS_CRIT, Template.LocFriendlyName,, false, true, true, true);
 		Template.AddTargetEffect(ToHitModifier);
 	}
 
@@ -1230,7 +1230,7 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		Template.AbilityTargetEffects.length = 0;
 		PersistentEffect = new class'X2Effect_Persistent';
 		PersistentEffect.BuildPersistentEffect(1, true, false);
-		PersistentEffect.SetDisplayInfo(0, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, true,, Template.AbilitySourceName);
+		PersistentEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, true,, Template.AbilitySourceName);
 		Template.AddTargetEffect(PersistentEffect);
 	}
 
@@ -1239,7 +1239,7 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		Template.AbilityTargetEffects.length = 0;
 		MixEffect = new class'X2Effect_VolatileMix';
 		MixEffect.BuildPersistentEffect(1, true, false, true);
-		MixEffect.SetDisplayInfo(0, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,, Template.AbilitySourceName);
+		MixEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,, Template.AbilitySourceName);
 		MixEffect.BonusDamage = class'X2Ability_GrenadierAbilitySet'.default.VOLATILE_DAMAGE;
 		Template.AddTargetEffect(MixEffect);
 	}   
@@ -1251,7 +1251,7 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		ReactionFire.bAllowCrit = true;
 		ReactionFire.ReactionModifier = class'X2Ability_SpecialistAbilitySet'.default.UNDER_PRESSURE_BONUS;
 		ReactionFire.BuildPersistentEffect(1, true, false, true);
-		ReactionFire.SetDisplayInfo(0, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,, Template.AbilitySourceName);
+		ReactionFire.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,, Template.AbilitySourceName);
 		Template.AddTargetEffect(ReactionFire);
 	}   
 
@@ -1613,7 +1613,7 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		HunkerDownEffect = new class 'X2Effect_HunkerDown_LW';
 		HunkerDownEffect.EffectName = 'HunkerDown';
 		HunkerDownEffect.DuplicateResponse = eDupe_Refresh;
-		HunkerDownEFfect.BuildPersistentEffect (1,,,, 7);
+		HunkerDownEffect.BuildPersistentEffect (1,,,, eGameRule_PlayerTurnBegin);
 		HunkerDownEffect.SetDisplayInfo (ePerkBuff_Bonus, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage);
 		Template.AddTargetEffect(HunkerDownEffect);
 
@@ -1642,7 +1642,7 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		Template.AbilityTargetEffects.length = 0;
 		GuardianEffect = new class'X2Effect_Guardian_LW';
 		GuardianEffect.BuildPersistentEffect(1, true, false);
-		GuardianEffect.SetDisplayInfo(0, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true,, Template.AbilitySourceName);
+		GuardianEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true,, Template.AbilitySourceName);
 		GuardianEffect.ProcChance = class'X2Ability_SpecialistAbilitySet'.default.GUARDIAN_PROC;
 		Template.AddTargetEffect(GuardianEffect);
 	}
@@ -2806,7 +2806,7 @@ function ReconfigGear(X2ItemTemplate Template, int Difficulty)
 				case 'PlatedTemplarArmor':
 					ArmorTemplate.bAddsUtilitySlot = true;
 				case 'MediumPlatedArmor':
-					ArmorTemplate.SetUIStatMarkup(class'XLocalizedData'.default.ArmorLabel, 14, default.MEDIUM_PLATED_MITIGATION_AMOUNT);
+					ArmorTemplate.SetUIStatMarkup(class'XLocalizedData'.default.ArmorLabel, eStat_ArmorMitigation, default.MEDIUM_PLATED_MITIGATION_AMOUNT);
 					break;
 
 				case 'SparkArmor':

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIOutpostManagement.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIOutpostManagement.uc
@@ -203,7 +203,7 @@ simulated function InitScreen(XComPlayerController InitController, UIMovie InitM
 		JobDetail = Spawn(class'UIScrollingText', MainPanel);
 		JobDetail.bAnimateOnInit = false;
 		JobDetail.InitScrollingText('OutPost_JobDetail_LW', "", panelW - BorderPadding * 2, BorderPadding,
-			RegionalInfo.Y + RegionalInfo.Height + (OutPost.GetResistanceMecCount() > 0) ? ResistanceMECs.Height : 0.0f);
+			RegionalInfo.Y + RegionalInfo.Height + ((OutPost.GetResistanceMecCount() > 0) ? ResistanceMECs.Height : 0.0f));
 		JobDetail.SetHTMLText("<p align=\'RIGHT\'><font size=\'24\' color=\'#fef4cb\'>" $
 			GetJobProhibitedString(Outpost, IntelProhibited, SupplyProhibited, RecruitProhibited) $ "</font></p>");
 		JobDetail.SetAlpha(67.1875);

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GearAbilities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GearAbilities.uc
@@ -539,11 +539,11 @@ static function X2Effect_Persistent CreateSedatedStatusEffect()
 
     PersistentEffect = new class'X2Effect_Persistent';
     PersistentEffect.EffectName = class'X2StatusEffects'.default.UnconsciousName;
-    PersistentEffect.DuplicateResponse = 2;
+    PersistentEffect.DuplicateResponse = eDupe_Ignore;
     PersistentEffect.BuildPersistentEffect(1, true, false);
     PersistentEffect.bRemoveWhenTargetDies = true;
     PersistentEffect.bIsImpairing = true;
-    PersistentEffect.SetDisplayInfo(2, class'X2StatusEffects'.default.UnconsciousFriendlyName, class'X2StatusEffects'.default.UnconsciousFriendlyDesc, "img:///UILibrary_PerkIcons.UIPerk_stun", true, "img:///UILibrary_Common.status_unconscious");
+    PersistentEffect.SetDisplayInfo(ePerkBuff_Penalty, class'X2StatusEffects'.default.UnconsciousFriendlyName, class'X2StatusEffects'.default.UnconsciousFriendlyDesc, "img:///UILibrary_PerkIcons.UIPerk_stun", true, "img:///UILibrary_Common.status_unconscious");
     PersistentEffect.EffectAddedFn = class'X2StatusEffects'.static.UnconsciousEffectAdded;
     PersistentEffect.EffectRemovedFn = class'X2StatusEffects'.static.UnconsciousEffectRemoved;
     PersistentEffect.VisualizationFn = SedatedVisualization;
@@ -641,17 +641,17 @@ static function X2AbilityTemplate CreateConsumeWhenActivatedAbility(name Ability
 	Template.AbilityToHitCalc = default.DeadEye;
 	Template.bDontDisplayInAbilitySummary = true;
 
-	Template.eAbilityIconBehaviorHUD = 2;
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
     Template.Hostility = eHostility_Neutral;
 
     Template.AbilitySourceName = 'eAbilitySource_Item';
 	Template.AbilityCosts.AddItem(new class'X2AbilityCost_ConsumeItem');
 
 	EventListener = new class'X2AbilityTrigger_EventListener';
-	EventListener.ListenerData.Deferral = 1;
+	EventListener.ListenerData.Deferral = ELD_OnStateSubmitted;
 	EventListener.ListenerData.EventID = EventName;
 	EventListener.ListenerData.EventFn = class'XComGameState_Ability'.static.AbilityTriggerEventListener_Self;
-	EventListener.ListenerData.Filter = 1;
+	EventListener.ListenerData.Filter = eFilter_Unit;
     Template.AbilityTriggers.AddItem(EventListener);
 
 	Template.AbilityTargetStyle = default.SelfTarget;

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GrenadierAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GrenadierAbilitySet.uc
@@ -62,7 +62,7 @@ static function X2AbilityTemplate AddBiggestBooms_LW()
     Template.AbilityTriggers.AddItem(Trigger);
     BiggestBoomsEffect = new class'X2Effect_BiggestBooms_LW';
     BiggestBoomsEffect.BuildPersistentEffect(1, true, false, true);
-    BiggestBoomsEffect.SetDisplayInfo(0, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,, Template.AbilitySourceName);
+    BiggestBoomsEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,, Template.AbilitySourceName);
     Template.AddTargetEffect(BiggestBoomsEffect);
     Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
     return Template;
@@ -381,8 +381,8 @@ static function X2AbilityTemplate AddVanishingActAbility()
 	Template.AddTargetEffect(class'X2Item_DefaultGrenades'.static.SmokeGrenadeEffect());
 
 	StealthEffect = new class'X2Effect_RangerStealth';
-    StealthEffect.BuildPersistentEffect(1, true, false, false, 8);
-    StealthEffect.SetDisplayInfo(1, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage, true);
+    StealthEffect.BuildPersistentEffect(1, true, false, false, eGameRule_PlayerTurnEnd);
+    StealthEffect.SetDisplayInfo(ePerkBuff_Bonus, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage, true);
     StealthEffect.bRemoveWhenTargetConcealmentBroken = true;
     Template.AddTargetEffect(StealthEffect);
     Template.AddTargetEffect(class'X2Effect_Spotted'.static.CreateUnspottedEffect());

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GunnerAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GunnerAbilitySet.uc
@@ -429,8 +429,8 @@ static function X2AbilityTemplate FlushDamage()
     `CREATE_X2ABILITY_TEMPLATE (Template, 'FlushDamage');
     Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_momentum";
     Template.AbilitySourceName = 'eAbilitySource_Perk';
-    Template.eAbilityIconBehaviorHUD = 2;
-    Template.Hostility = 2;
+    Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+    Template.Hostility = eHostility_Neutral;
     Template.AbilityToHitCalc = default.DeadEye;
     Template.AbilityTargetStyle = default.SelfTarget;
     Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_SpecialistAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_SpecialistAbilitySet.uc
@@ -383,7 +383,7 @@ static function X2AbilityTemplate AddHackRewardControlRobot_Permanent()
 
 	Buff = new class'X2Effect_PersistentStatChange';
 	Buff.BuildPersistentEffect (1, true, true);
-	Buff.SetDisplayInfo(1, class'X2Ability_HackRewards'.default.ControlRobotStatName, class'X2Ability_HackRewards'.default.ControlRobotStatDesc, "img:///UILibrary_PerkIcons.UIPerk_hack_reward", true);
+	Buff.SetDisplayInfo(ePerkBuff_Bonus, class'X2Ability_HackRewards'.default.ControlRobotStatName, class'X2Ability_HackRewards'.default.ControlRobotStatDesc, "img:///UILibrary_PerkIcons.UIPerk_hack_reward", true);
 	Buff.AddPersistentStatChange(eStat_Offense, float(class'X2Ability_HackRewards'.default.CONTROL_ROBOT_AIM_BONUS));
     Buff.AddPersistentStatChange(eStat_CritChance, float(class'X2Ability_HackRewards'.default.CONTROL_ROBOT_CRIT_BONUS));
     Buff.AddPersistentStatChange(eStat_Mobility, float(class'X2Ability_HackRewards'.default.CONTROL_ROBOT_MOBILITY_BONUS));
@@ -558,7 +558,7 @@ static function X2AbilityTemplate AddRescueProtocol()
 
 	ActionPointPersistEffect = new class'X2Effect_Persistent';
     ActionPointPersistEffect.EffectName = 'Rescued';
-    ActionPointPersistEffect.BuildPersistentEffect(1, false, true, false, 8);
+    ActionPointPersistEffect.BuildPersistentEffect(1, false, true, false, eGameRule_PlayerTurnEnd);
     ActionPointPersistEffect.bRemoveWhenTargetDies = true;
     Template.AddTargetEffect(ActionPointPersistEffect);
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_TechnicalAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_TechnicalAbilitySet.uc
@@ -1085,7 +1085,7 @@ static function X2AbilityTemplate CreateHighPressureAbility()
 	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
 	PersistentEffect = new class'X2Effect_Persistent';
 	PersistentEffect.BuildPersistentEffect(1, true, false);
-	PersistentEffect.SetDisplayInfo(0, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, true,, Template.AbilitySourceName);
+	PersistentEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, true,, Template.AbilitySourceName);
 	Template.AddTargetEffect(PersistentEffect);
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
 	Template.bCrossClassEligible =false;
@@ -1388,7 +1388,7 @@ static function Quickburn_BuildVisualization(XComGameState VisualizeGameState)
 
 	History = `XCOMHISTORY;
 	context = XComGameStateContext_Ability(VisualizeGameState.GetContext());
-	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, 1, VisualizeGameState.HistoryIndex - 1));
+	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1));
 	InteractingUnitRef = context.InputContext.SourceObject;
 	BuildTrack = EmptyTrack;
 	BuildTrack.StateObject_OldState = History.GetGameStateForObjectID(InteractingUnitRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1);

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_DLC2_HideSpecialTurnOverlay.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_DLC2_HideSpecialTurnOverlay.uc
@@ -15,9 +15,9 @@ function RegisterForEvents(XComGameState_Effect EffectGameState)
     EventMgr = `XEVENTMGR;
     EffectObj = EffectGameState;
     UnitState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(EffectGameState.ApplyEffectParameters.TargetStateObjectRef.ObjectID));
-    EventMgr.RegisterForEvent(EffectObj, 'ExhaustedActionPoints', ExhaustedActionCheck, 2,, UnitState);
-    EventMgr.RegisterForEvent(EffectObj, 'NoActionPointsAvailable', ExhaustedActionCheck, 2,, UnitState);
-    EventMgr.RegisterForEvent(EffectObj, 'UnitDied', ExhaustedActionCheck, 2,, UnitState);
+    EventMgr.RegisterForEvent(EffectObj, 'ExhaustedActionPoints', ExhaustedActionCheck, ELD_OnVisualizationBlockCompleted,, UnitState);
+    EventMgr.RegisterForEvent(EffectObj, 'NoActionPointsAvailable', ExhaustedActionCheck, ELD_OnVisualizationBlockCompleted,, UnitState);
+    EventMgr.RegisterForEvent(EffectObj, 'UnitDied', ExhaustedActionCheck, ELD_OnVisualizationBlockCompleted,, UnitState);
 }
 
 static function EventListenerReturn ExhaustedActionCheck(

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_FireEventOnCrit.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_FireEventOnCrit.uc
@@ -22,7 +22,7 @@ function RegisterForEvents(XComGameState_Effect EffectGameState)
 		EventMgr = `XEVENTMGR;
 		EffectObj = EffectGameState;
 		UnitState = XComGameState_Unit(class'XComGameStateHistory'.static.GetGameStateHistory().GetGameStateForObjectID(EffectGameState.ApplyEffectParameters.SourceStateObjectRef.ObjectID));
-		EventMgr.RegisterForEvent(EffectObj, EventId, EffectGameState.TriggerAbilityFlyover, 1,, UnitState);  
+		EventMgr.RegisterForEvent(EffectObj, EventId, EffectGameState.TriggerAbilityFlyover, ELD_OnStateSubmitted,, UnitState);  
 	}
 }
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
@@ -4687,3 +4687,4 @@ defaultProperties
 		MaxRestricted_Category=1
 	End Object
 	LiberationCondition = DefaultLiberationCondition;
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_LWObjectives.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_LWObjectives.uc
@@ -262,7 +262,7 @@ static function CreateBlacksiteMission_LW(XComGameState NewGameState, XComGameSt
 	RewardTemplate = X2RewardTemplate(StratMgr.FindStrategyElementTemplate('Reward_None')); // no rewards for completing story objectives
 	RewardState = RewardTemplate.CreateInstanceFromTemplate(NewGameState);
 	Rewards.AddItem(RewardState);
-	MissionState = CreateMission(NewGameState, Rewards, 'MissionSource_BlackSite', 8); // as far away from player as possible, because reasons
+	MissionState = CreateMission(NewGameState, Rewards, 'MissionSource_BlackSite', eGameRule_PlayerTurnEnd); // as far away from player as possible, because reasons
 
 	RegionState = MissionState.GetWorldRegion();
 	RegionState = XComGameState_WorldRegion(NewGameState.CreateStateObject(class'XComGameState_WorldRegion', RegionState.ObjectID));

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWReinforcements.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWReinforcements.uc
@@ -233,7 +233,7 @@ function bool AnyEnemiesInRedAlert()
     AIPlayer.GetAliveUnits(Enemies_array);
     foreach Enemies_array(Enemy)
     {
-        if(Enemy.GetCurrentStat(10) > float(1))
+        if(Enemy.GetCurrentStat(eStat_AlertLevel) > float(1))
 		{
 			return true;
 		}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet.uc
@@ -748,7 +748,7 @@ static function X2AbilityTemplate AddWilltoSurviveAbility()
 
 	WillBonus = new class'X2Effect_PersistentStatChange';
 	WillBonus.AddPersistentStatChange(eStat_Will, float(default.WILLTOSURVIVE_WILLBONUS));
-	WillBonus.BuildPersistentEffect (1, true, false, false, 7);
+	WillBonus.BuildPersistentEffect (1, true, false, false, eGameRule_PlayerTurnBegin);
 	Template.AddTargetEffect(WillBonus);
 	Template.SetUIStatMarkup(class'XLocalizedData'.default.WillLabel, eStat_Will, default.WILLTOSURVIVE_WILLBONUS);
 
@@ -1273,14 +1273,14 @@ static function X2AbilityTemplate WalkFireDamage()
     `CREATE_X2ABILITY_TEMPLATE (Template, 'WalkFireDamage');
     Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_momentum";
     Template.AbilitySourceName = 'eAbilitySource_Perk';
-    Template.eAbilityIconBehaviorHUD = 2;
-    Template.Hostility = 2;
+    Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+    Template.Hostility = eHostility_Neutral;
     Template.AbilityToHitCalc = default.DeadEye;
     Template.AbilityTargetStyle = default.SelfTarget;
     Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
     DamageEffect = new class'X2Effect_WalkFireDamage';
     DamageEffect.BuildPersistentEffect(1, true, false, false);
-    DamageEffect.SetDisplayInfo(0, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false,, Template.AbilitySourceName);
+    DamageEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false,, Template.AbilitySourceName);
     Template.AddTargetEffect(DamageEffect);
     Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
     return Template;
@@ -1377,14 +1377,14 @@ static function X2AbilityTemplate PrecisionShotCritDamage()
     `CREATE_X2ABILITY_TEMPLATE (Template, 'PrecisionShotCritDamage');
     Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_momentum";
     Template.AbilitySourceName = 'eAbilitySource_Perk';
-    Template.eAbilityIconBehaviorHUD = 2;
-    Template.Hostility = 2;
+    Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+    Template.Hostility = eHostility_Neutral;
     Template.AbilityToHitCalc = default.DeadEye;
     Template.AbilityTargetStyle = default.SelfTarget;
     Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
     CritEffect = new class'X2Effect_PrecisionShotCritDamage';
     CritEffect.BuildPersistentEffect(1, true, false, false);
-    CritEffect.SetDisplayInfo(0, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false,, Template.AbilitySourceName);
+    CritEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false,, Template.AbilitySourceName);
     Template.AddTargetEffect(CritEffect);
     Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
     return Template;
@@ -3264,14 +3264,14 @@ static function X2AbilityTemplate KubikiriDamage()
 	`CREATE_X2ABILITY_TEMPLATE (Template, 'KubikuriDamage');
 	Template.IconImage = "img:///UILibrary_LW_PerkPack.LW_AbilityKubikuri";
     Template.AbilitySourceName = 'eAbilitySource_Perk';
-    Template.eAbilityIconBehaviorHUD = 2;
-    Template.Hostility = 2;
+    Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+    Template.Hostility = eHostility_Neutral;
     Template.AbilityToHitCalc = default.DeadEye;
     Template.AbilityTargetStyle = default.SelfTarget;
     Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
 	DamageEffect=new class'X2Effect_Kubikuri';
     DamageEffect.BuildPersistentEffect(1, true, false, false);
-    DamageEffect.SetDisplayInfo(0, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false,, Template.AbilitySourceName);
+    DamageEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false,, Template.AbilitySourceName);
     Template.AddTargetEffect(DamageEffect);
     Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
     return Template;
@@ -3420,7 +3420,7 @@ function CombatRush_BuildVisualization(XComGameState VisualizeGameState)
 
     History = `XCOMHISTORY;
     context = XComGameStateContext_Ability(VisualizeGameState.GetContext());
-	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, 1, VisualizeGameState.HistoryIndex - 1));
+	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1));
     InteractingUnitRef = context.InputContext.SourceObject;
     BuildTrack = EmptyTrack;
     BuildTrack.StateObject_OldState = History.GetGameStateForObjectID(InteractingUnitRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1);

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
@@ -585,7 +585,7 @@ static function RapidDeployment_BuildVisualization(XComGameState VisualizeGameSt
 
     History = `XCOMHISTORY;
     context = XComGameStateContext_Ability(VisualizeGameState.GetContext());
-	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, 1, VisualizeGameState.HistoryIndex - 1));
+	Ability = XComGameState_Ability(History.GetGameStateForObjectID(context.InputContext.AbilityRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1));
     InteractingUnitRef = context.InputContext.SourceObject;
     BuildTrack = EmptyTrack;
     BuildTrack.StateObject_OldState = History.GetGameStateForObjectID(InteractingUnitRef.ObjectID, eReturnType_Reference, VisualizeGameState.HistoryIndex - 1);

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2DownloadableContentInfo_LWPerkPack.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2DownloadableContentInfo_LWPerkPack.uc
@@ -436,7 +436,7 @@ static function bool AbilityTagExpandHandler_CH(string InString, out string OutS
         default:
             return false;
     }
-    return ReturnValue;    
+    return false;    
 }
 
 static function X2ItemTemplate GetItemBoundToAbilityFromUnit(XComGameState_Unit UnitState, name AbilityName, XComGameState GameState)

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_TemporaryItem.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_TemporaryItem.uc
@@ -178,10 +178,11 @@ simulated function XComGameState_Item AddNewItemToUnit(X2EquipmentTemplate Equip
 			AddAbilityToUnit(AbilityName, UnitState, ItemState.GetReference(), NewGameState);
 		}
 		AbilityRef = UnitState.FindAbility(AbilityName, ItemState.GetReference());
-		if(AbilityRef.ObjectID > 0)
+		if(AbilityRef.ObjectID > 0) {
 			`PPTRACE("TempItem : Post AddAbilityToUnit -- Ability + Item combo found");
-		else
+		} else {
 			`PPTRACE("TempItem : Post AddAbilityToUnit -- Ability + Item combo NOT found");
+		}
 	}
 
 	//special handling for LaunchGrenade and maybe some other stuff
@@ -215,10 +216,11 @@ simulated function XComGameState_Item AddNewItemToUnit(X2EquipmentTemplate Equip
 			}
 		}
 		AbilityRef = UnitState.FindAbility(AbilityName, ItemState.GetReference());
-		if(AbilityRef.ObjectID > 0)
+		if(AbilityRef.ObjectID > 0) {
 			`PPTRACE("TempItem : Post AddAbilityToUnit -- Ability + Item combo found");
-		else
+		} else {
 			`PPTRACE("TempItem : Post AddAbilityToUnit -- Ability + Item combo NOT found");
+		}
 	}
 
 	//Create the visualizer for the new item, and attach it if needed

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2TargetingMethod_AreaSuppression.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2TargetingMethod_AreaSuppression.uc
@@ -23,7 +23,7 @@ function Update(float DeltaTime)
 		}
 	}
 
-	MarkTargetedActors(CurrentlyMarkedTargets, ((!AbilityIsOffensive) ? FiringUnit.GetTeam() : 0));
+	MarkTargetedActors(CurrentlyMarkedTargets, ((!AbilityIsOffensive) ? FiringUnit.GetTeam() : eTeam_None));
 }
 
 function Canceled()


### PR DESCRIPTION
Apart from the dangling else fix, these should not affect the behavior at all, but allow my more restrictive [`uc-analyzer`](https://github.com/robojumper/uc-analyzer) to continue analysis instead of giving up with parser errors, type errors, or resolution errors.

---

The enum variants were found by a lint of the following form:
```
error[body-lowering-error]: type mismatch: expected enum<GameRuleStateChange>, found primitive int
   --> X2Ability_PerkPackAbilitySet:751:61
    |
751 |     WillBonus.BuildPersistentEffect (1, true, false, false, 7);
    |                                                             - 7 corresponds to eGameRule_PlayerTurnBegin
    |
```
so I'm confident I picked the correct variants, but this could be a good opportunity to double check those variants in particular.