### PR TITLE
Overcharge description fixes

### DIFF
--- a/LongWarOfTheChosen/Localization/LW_FactionBalance/XComGame.fra
+++ b/LongWarOfTheChosen/Localization/LW_FactionBalance/XComGame.fra
@@ -48,9 +48,9 @@ LocPromotionPopupText="<Bullet/> Augmente de <Ability:MeditationFocusRecovery/> 
 
 [Overcharge_LW X2AbilityTemplate]
 LocFriendlyName="Surcharge"
-LocLongDescription="Gagnez un bonus de visée et de défense pour chaque niveau de concentration du Templier."
-LocHelpText="Gagnez un bonus de visée et de défense pour chaque niveau de concentration du Templier."
-LocPromotionPopupText="<Bullet/> Visée +<Ability:OverchargeAimBonus/> et défense +<Ability:OverchargeDefenseBonus/> pour chaque niveau de concentration.<br/><Bullet/> Surcharge prend en compte le niveau de concentration actuel du Templier (et non son niveau maximum)."
+LocLongDescription="Gagnez un bonus de visée et de chances de coup critique pour chaque niveau de concentration du Templier."
+LocHelpText="Gagnez un bonus de visée et de chances de coup critique pour chaque niveau de concentration du Templier."
+LocPromotionPopupText="<Bullet/> +<Ability:OverchargeAimBonus/> en visée et +<Ability:OverchargeCritBonus/> en chances de coup critique pour chaque niveau de concentration.<br/><Bullet/> Surcharge prend en compte le niveau de concentration actuel du Templier (et non son niveau maximum)."
 
 [VoltDangerZone X2AbilityTemplate]
 LocFriendlyName="Haute tension"

--- a/LongWarOfTheChosen/Localization/LW_FactionBalance/XComGame.rus
+++ b/LongWarOfTheChosen/Localization/LW_FactionBalance/XComGame.rus
@@ -46,9 +46,9 @@ LocPromotionPopupText="<Bullet/> Добавляет <Ability:MeditationFocusReco
 
 [Overcharge_LW X2AbilityTemplate]
 LocFriendlyName="Заряженность"
-LocLongDescription="Дает бонус к Меткости и Защите за каждую единицу концентрации Храмовника."
-LocHelpText="Дает бонус к Меткости и Защите за каждую единицу концентрации Храмовника."
-LocPromotionPopupText="<Bullet/> Каждая единица дает бонус в +<Ability:OverchargeAimBonus/> к меткости и +<Ability:OverchargeDefenseBonus/> к защите.<br/><Bullet/> Рассчитывается по текущему (а не максимальному) показателю концентрации."
+LocLongDescription="Дает бонус к Меткости и Шансу критического попадания за каждую единицу концентрации Храмовника."
+LocHelpText="Дает бонус к Меткости и Шансу критического попадания за каждую единицу концентрации Храмовника."
+LocPromotionPopupText="<Bullet/> Каждая единица дает бонус в +<Ability:OverchargeAimBonus/> к меткости и +<Ability:OverchargeCritBonus/> к шансу критического попадания.<br/><Bullet/> Рассчитывается по текущему (а не максимальному) показателю концентрации."
 
 [VoltDangerZone X2AbilityTemplate]
 LocFriendlyName="Высокое напряжение"

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_XMBPerkAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_XMBPerkAbilitySet.uc
@@ -2572,6 +2572,7 @@ static function X2AbilityTemplate HunterMarkHit()
 
 	NameCondition = new class'XMBCondition_AbilityName';
 	NameCondition.IncludeAbilityNames.AddItem('SniperStandardFire');
+	NameCondition.IncludeAbilityNames.AddItem('SnapShot');
 
 
 	RefundEffect.AbilityTargetConditions.AddItem(NeedOneOfTheEffects);


### PR DESCRIPTION
Fixes Russian and French description of Templar's Overcharge incorrectly mentioning defence bonus instead of crit bonus