### PR TITLE
Edit Darklance's TacticalText to not include mention of complex reload

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -6616,7 +6616,7 @@ FriendlyName="Darklance"
 FriendlyNamePlural="Darklances"
 BriefSummary="This rifle belonging to the Chosen Hunter has probably seen more death than we can possibly imagine."
 ; LWOTC Needs Translation (2)
-TacticalText="<Bullet/> This rifle is capable of insane burst damage against units that have been marked for death.<br/><Bullet/> However because of its size it has proven to be difficult to reload for our operatives.<br/>"
+TacticalText="<Bullet/> This rifle is capable of insane burst damage against units that have been marked for death.<br/>"
 ; End Translation (2)
 AbilityDescName="sniper rifle"
 


### PR DESCRIPTION
Darklance has had a standard reload for a long time, TacticalText was misleading.

Found by Rifleman
https://discord.com/channels/590853492084572170/690570972117336064/1158295652791496726