### PR TITLE
Display Banish hit mod as int

### DIFF
--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2DownloadableContentInfo_LW_FactionBalance.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2DownloadableContentInfo_LW_FactionBalance.uc
@@ -180,7 +180,7 @@ static function bool AbilityTagExpandHandler(string InString, out string OutStri
 		OutString = string(class'X2LWModTemplate_ReaperAbilities'.default.DEATH_DEALER_CRIT);
 		return true;
 	case 'BANISH_HIT_MOD':
-		OutString = string(abs(class'X2Effect_BanishHitMod'.default.BANISH_HIT_MOD));
+		OutString = string(int(abs(class'X2Effect_BanishHitMod'.default.BANISH_HIT_MOD)));
 		return true;
 	case 'THEBANISHER_HIT_BUFF':
 		OutString = string(class'X2Effect_BanishHitMod'.default.THEBANISHER_HIT_BUFF);


### PR DESCRIPTION
After the most recent change to Banish loc, the aim penalty was displaying as `20.0000`.