### PR TITLE
Expand list of abilities usable after Double Tap

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -1568,8 +1568,9 @@ AutopsyAdventPsiWitchIntelCost=0
 ;+DefensiveReflexAbilities=AnimaInversion
 ;+DefensiveReflexAbilities=MassReanimation_LW
 
-+DoubleTapAbilities=SniperStandardFire
 +DoubleTapAbilities=StandardShot
++DoubleTapAbilities=Overwatch
++DoubleTapAbilities=SniperStandardFire
 +DoubleTapAbilities=SniperRifleOverwatch
 +DoubleTapAbilities=LongWatch
 +DoubleTapAbilities=PrecisionShot
@@ -1580,7 +1581,25 @@ AutopsyAdventPsiWitchIntelCost=0
 +DoubleTapAbilities=ChainShot
 +DoubleTapAbilities=Maim_LW
 +DoubleTapAbilities=LeadTheTarget_LW
-+DoubleTapAbilities=Overwatch
++DoubleTapAbilities=CyclicFire
++DoubleTapAbilities=HailOfBullets
++DoubleTapAbilities=Flush
++DoubleTapAbilities=IronCurtainShot
++DoubleTapAbilities=KillZone
++DoubleTapAbilities=BulletShred
++DoubleTapAbilities=LightEmUp
++DoubleTapAbilities=WalkFire
++DoubleTapAbilities=Suppression_LW
++DoubleTapAbilities=AreaSuppression
++DoubleTapAbilities=SoulReaper
++DoubleTapAbilities=SaturationFire
++DoubleTapAbilities=DoubleTap2
++DoubleTapAbilities=SlugShot
++DoubleTapAbilities=Sting
++DoubleTapAbilities=StreetSweeper
++DoubleTapAbilities=StreetSweeper2
++DoubleTapAbilities=SlugShot
++DoubleTapAbilities=BondmateDualStrike
 
 +ENEMY_FLASHBANG_RESIST=(UnitName=Gatekeeper, Chance=75)
 +ENEMY_FLASHBANG_RESIST=(UnitName=MutonM2_LW, Chance=20)


### PR DESCRIPTION
Includes abilities that (currently) don't appear on classes that can get Double Tap. It's future proofing / being mod friendly.