### PR TITLE
Revert Whiplash CBAC bandaid fix

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -1844,7 +1844,6 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 				Template.AbilityIconColor = "Variable"; break; // This calls a function that changes the color on the fly
 			case 'EVAC': 
 				Template.AbilityIconColor = default.ICON_COLOR_FREE; break;
-			case 'Whiplash':
 			case 'IntrusionProtocol':
 			case 'IntrusionProtocol_Chest':
 			case 'Hack_Chest':


### PR DESCRIPTION
CBAC no longer ships with the config that forces Whiplash to be 0AP, we can revert our bandaid.