### PR TITLE
SPARK stat label localizations

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -3234,11 +3234,11 @@ function ReconfigGear(X2ItemTemplate Template, int Difficulty)
 				{
 					case 'SparkBit_MG':
 						EquipmentTemplate.Abilities.AddItem('Plated_BIT_Bonus_Dodge');
-						EquipmentTemplate.SetUIStatMarkup("Dodge", eStat_Dodge, class'X2Ability_LW_GearAbilities'.default.PLATED_BIT_DODGE_BONUS);
+						EquipmentTemplate.SetUIStatMarkup(class'XLocalizedData'.default.DodgeLabel, eStat_Dodge, class'X2Ability_LW_GearAbilities'.default.PLATED_BIT_DODGE_BONUS);
 						break;
 					case 'SparkBit_BM':
 						EquipmentTemplate.Abilities.AddItem('Powered_BIT_Bonus_Dodge');
-						EquipmentTemplate.SetUIStatMarkup("Dodge", eStat_Dodge, class'X2Ability_LW_GearAbilities'.default.POWERED_BIT_DODGE_BONUS);
+						EquipmentTemplate.SetUIStatMarkup(class'XLocalizedData'.default.DodgeLabel, eStat_Dodge, class'X2Ability_LW_GearAbilities'.default.POWERED_BIT_DODGE_BONUS);
 						break;
 					default:
 						break;

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
@@ -1419,8 +1419,8 @@ static function X2DataTemplate RebootTriggered()
 	Template.AddTargetEffect(HackEffect);
 
 	Template.SetUIStatMarkup(class'XLocalizedData'.default.TechBonusLabel, eStat_Hacking, default.REBOOT_HACK);
-	Template.SetUIStatMarkup(class'XLocalizedData'.default.TechBonusLabel, eStat_Offense, default.REBOOT_AIM);
-	Template.SetUIStatMarkup(class'XLocalizedData'.default.TechBonusLabel, eStat_Mobility, default.REBOOT_MOB);
+	Template.SetUIStatMarkup(class'XLocalizedData'.default.AimLabel, eStat_Offense, default.REBOOT_AIM);
+	Template.SetUIStatMarkup(class'XLocalizedData'.default.MobilityLabel, eStat_Mobility, default.REBOOT_MOB);
 
 	EventTrigger = new class'X2AbilityTrigger_EventListener';
 	EventTrigger.ListenerData.Deferral = ELD_OnStateSubmitted;


### PR DESCRIPTION
* Fix SPARK BIT dodge being labeled in English even when playing in another language
* Fix SPARK Reboot stat labels (even though they don't seem to appear anywhere)