### PR TITLE
Fixed the issue where Crusader's Rage sometimes had lower damage bonu…

### DIFF
--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2AbilityCharges_Repair_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2AbilityCharges_Repair_LW.uc
@@ -25,19 +25,19 @@ simulated function int GetInitialCharges(XComGameState_Ability Ability, XComGame
 
 	if (SparkBITTemplate != none)
 	{
-		if (SparkBITTemplate.GetItemFriendlyNameNoStats() == "SPARK BIT")
+		if (SparkBITTemplate.DataName == 'SparkBit_CV')
 		{
 			RepairCharges = default.T1_CHARGES;
 			`log("T1 SparkBIT detected, applying T1_CHARGES to Repair ability");
 			`log(`SHOWVAR(default.T1_CHARGES));
 		}
-		else if (SparkBITTemplate.GetItemFriendlyNameNoStats() == "Plated BIT")
+		else if (SparkBITTemplate.DataName == 'SparkBit_MG')
 		{
 			RepairCharges = default.T2_CHARGES;
 			`log("T2 SparkBIT detected, applying T2_CHARGES to Repair ability");
 			`log(`SHOWVAR(default.T2_CHARGES));
 		}
-		else if (SparkBITTemplate.GetItemFriendlyNameNoStats() == "Powered BIT")
+		else if (SparkBITTemplate.DataName == 'SparkBit_BM')
 		{
 			RepairCharges = default.T3_CHARGES;
 			`log("T3 SparkBIT detected, applying T3_CHARGES to Repair ability");

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_XMBPerkAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_XMBPerkAbilitySet.uc
@@ -3654,9 +3654,9 @@ static function X2AbilityTemplate CrusaderRage()
 	Effect = new class'XMBEffect_ConditionalBonus';
 
 	//Need to add for all of them because apparently if you crit you don't hit lol
-	Effect.AddPercentDamageModifier(20, eHit_Success);
-	Effect.AddPercentDamageModifier(20, eHit_Graze);
-	Effect.AddPercentDamageModifier(20, eHit_Crit);
+	Effect.AddPercentDamageModifier(50, eHit_Success);
+	Effect.AddPercentDamageModifier(50, eHit_Graze);
+	Effect.AddPercentDamageModifier(50, eHit_Crit);
 	Effect.EffectName = 'CrusaderRage_Bonus2';
 
 	// The effect only applies while wounded
@@ -3673,6 +3673,7 @@ static function X2AbilityTemplate CrusaderRage()
 
 	Condition = new class'X2Condition_UnitStatCheck';
 	Condition.AddCheckStat(eStat_HP, 76, eCheck_LessThan,,, true);
+	Condition.AddCheckStat(eStat_HP, 51, eCheck_GreaterThanOrEqual,,, true);
 
 	// Create a conditional bonus effect
 	Effect = new class'XMBEffect_ConditionalBonus';


### PR DESCRIPTION
![5fce9c05b1667724358e19c95b858fb7](https://github.com/long-war-2/lwotc/assets/7258723/984e9107-353b-49af-8996-3e080f679e97)
![9902ef675c6c82522fee101444a5a2a3](https://github.com/long-war-2/lwotc/assets/7258723/15a6a16e-c541-4da6-be9a-ddcccfb3826d)
As shown in the images above, when the health is noticeably below 50%, the damage bonus of Crusader's Rage clearly does not reach 50%. Through analysis and testing, it was found that the damage bonus of Crusader's Rage is split into two parts when health is at or below 50%: one part is 25%, and the other part is 20%, resulting in a final effect of (1+0.25)*(1+0.2)=1.5. However, due to floating-point arithmetic and rounding, this splitting scheme sometimes led to instances of lower damage. To mitigate this, the two split parts are now merged, aiming to minimize occurrences of reduced damage.