### PR TITLE
Fix attachment icons

### DIFF
--- a/LongWarOfTheChosen/Config/XComGame.ini
+++ b/LongWarOfTheChosen/Config/XComGame.ini
@@ -123,6 +123,9 @@ bDontTouchSquadSize=true
 ;+RunBefore="PrimarySecondaries"
 +RunAfter="EncounterListReplacerWOTC"
 
+[robojumperSquadSelect CHDLCRunOrder]
+RunPriorityGroup=RUN_LAST
+
 [LongWarOfTheChosen CHModDependency]
 DisplayName="Long War of the Chosen"
 


### PR DESCRIPTION
Moving RJSS in run order to last fixes attachment icons, because LWOTC creates more attachments (for lasers and coils) after RJSS is done changing their icons.