### PR TITLE
Fix covert action display

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.chn
+++ b/LongWarOfTheChosen/Localization/XComGame.chn
@@ -3289,6 +3289,10 @@ BonusText="治愈速率+%AVENGERBONUS%"
 FilledText="%UNITNAME的先进医疗设备提高了士兵的受伤恢复的速率！"
 LockedText="未解锁：购入升级"
 
+[CovertActionIntenseTrainingStaffSlot X2StaffSlotTemplate]
+EmptyText="士兵"
+BonusText="隐秘行动训练中"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Techs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [Tech_AlienFacilityLead X2TechTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.cht
+++ b/LongWarOfTheChosen/Localization/XComGame.cht
@@ -3275,6 +3275,10 @@ BonusText="治癒速率+%AVENGERBONUS%"
 FilledText="%UNITNAME的先進醫療設備提高了士兵的受傷恢復的速率！"
 LockedText="未解鎖：購入升級"
 
+[CovertActionIntenseTrainingStaffSlot X2StaffSlotTemplate]
+EmptyText="士兵"
+BonusText="隱秘行動訓練中"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Techs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [Tech_AlienFacilityLead X2TechTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.deu
+++ b/LongWarOfTheChosen/Localization/XComGame.deu
@@ -3110,6 +3110,10 @@ BonusText="HEILUNGSRATE +%AVENGERBONUS %"
 FilledText="Zusätzliche medizinische Unterstützung durch %UNITNAME erhöht die Rate, mit der sich Soldaten von Verletzungen erholen."
 LockedText="GESPERRT: VERBESSERUNG KAUFEN"
 
+[CovertActionIntenseTrainingStaffSlot X2StaffSlotTemplate]
+EmptyText="OLDAT"
+BonusText="IN VERDECKTER AKTION"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Techs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [Tech_AlienFacilityLead X2TechTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.esn
+++ b/LongWarOfTheChosen/Localization/XComGame.esn
@@ -3174,6 +3174,10 @@ BonusText="+%AVENGERBONUS% VELOCIDAD DE CURACIÓN"
 FilledText="El equipo médico avanzado de %UNITNAME está aumentando la velocidad a la que se recuperan los soldados de sus heridas."
 LockedText="BLOQUEADO: COMPRAR MEJORA"
 
+[CovertActionIntenseTrainingStaffSlot X2StaffSlotTemplate]
+EmptyText="SOLDADO"
+BonusText="EN OPERACIÓN ENCUBIERTA"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Techs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [Tech_AlienFacilityLead X2TechTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.fra
+++ b/LongWarOfTheChosen/Localization/XComGame.fra
@@ -3231,6 +3231,10 @@ BonusText="VITESSE DE GUÉRISON +%AVENGERBONUS%"
 FilledText="L'équipement médical avancé de %UNITNAME augmente la vitesse de récupération des soldats blessés."
 LockedText="VERROUILLÉ: ACHETER AMÉLIORATION"
 
+[CovertActionIntenseTrainingStaffSlot X2StaffSlotTemplate]
+EmptyText="SOLDAT"
+BonusText="EN MISSION SECRÈTE"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Techs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [Tech_AlienFacilityLead X2TechTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -3394,6 +3394,10 @@ BonusText="HEALING RATE +%AVENGERBONUS%"
 FilledText="%UNITNAME's advanced medical equipment is increasing the rate soldiers recover from injuries."
 LockedText="LOCKED: PURCHASE UPGRADE"
 
+[CovertActionIntenseTrainingStaffSlot X2StaffSlotTemplate]
+EmptyText="SOLDIER"
+BonusText="ON COVERT ACTION"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Techs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [Tech_AlienFacilityLead X2TechTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.ita
+++ b/LongWarOfTheChosen/Localization/XComGame.ita
@@ -2820,6 +2820,10 @@ BonusText="TASSO DI GUARIGIONE +%AVENGERBONUS%"
 FilledText="L'attrezzatura medica avanzata di %UNITNAME sta aumentando il tasso di guarigione con il quale i soldati si riprendono dalle ferite."
 LockedText="BLOCCATO: ACQUISTA POTENZIAMENTO"
 
+[CovertActionIntenseTrainingStaffSlot X2StaffSlotTemplate]
+EmptyText="SOLDATO"
+BonusText="IN MISSIONE SEGRETA"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Techs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [Tech_AlienFacilityLead X2TechTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.jpn
+++ b/LongWarOfTheChosen/Localization/XComGame.jpn
@@ -2814,6 +2814,10 @@ BonusText="回復速度+%AVENGERBONUS%"
 FilledText="%UNITNAMEの先進医療装備により、兵士の回復速度が向上する。"
 LockedText="ロック中：アップグレードを購入する"
 
+[CovertActionIntenseTrainingStaffSlot X2StaffSlotTemplate]
+EmptyText="兵士"
+BonusText="秘密工作中"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Techs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [Tech_AlienFacilityLead X2TechTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.kor
+++ b/LongWarOfTheChosen/Localization/XComGame.kor
@@ -2818,6 +2818,10 @@ BonusText="치료 속도 +%AVENGERBONUS%"
 FilledText="%UNITNAME의 고급 의료 설비는 병사들이 부상에서 회복하는 속도를 증가시킵니다."
 LockedText="잠김: 업그레이드 구매"
 
+[CovertActionIntenseTrainingStaffSlot X2StaffSlotTemplate]
+EmptyText="병사"
+BonusText="기밀 작전 중"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Techs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [Tech_AlienFacilityLead X2TechTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.pol
+++ b/LongWarOfTheChosen/Localization/XComGame.pol
@@ -3174,6 +3174,10 @@ BonusText="SZYBKOŚĆ LECZENIA +%AVENGERBONUS%"
 FilledText="Specjalistyczna opieka medyczna, której udziela %UNITNAME, przyspiesza czas gojenia się ran żołnierzy."
 LockedText="ZABLOKOWANE: KUP ULEPSZENIE"
 
+[CovertActionIntenseTrainingStaffSlot X2StaffSlotTemplate]
+EmptyText="ŻOŁNIERZ"
+BonusText="NA TAJNEJ OPERACJI"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Techs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [Tech_AlienFacilityLead X2TechTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.rus
+++ b/LongWarOfTheChosen/Localization/XComGame.rus
@@ -3519,6 +3519,10 @@ BonusText="ТЕМП ВОССТАНОВЛЕНИЯ +%AVENGERBONUS%"
 FilledText="%UNITNAME ускоряет восстановление солдат после ранений с помощью продвинутого медицинского оборудования."
 LockedText="НЕДОСТУПНО: ПРИОБРЕТИТЕ УЛУЧШЕНИЕ"
 
+[CovertActionIntenseTrainingStaffSlot X2StaffSlotTemplate]
+EmptyText="СОЛДАТ"
+BonusText="НА СЕКРЕТНОМ ЗАДАНИИ"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Techs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 [Tech_AlienFacilityLead X2TechTemplate]

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
@@ -215,12 +215,6 @@ static protected function EventListenerReturn OnOverridePersonnelStatus(Object E
 	local XComGameState_LWPersistentSquad Squad;
 	local XComGameState_LWSquadManager SquadMgr;
 	local int						HoursToInfiltrate;
-	local XComGameStateHistory		History;
-	local XComGameState_CovertAction ActionState;
-	local XComGameState_CovertAction UnitActionState;
-	local XComGameState_StaffSlot	SlotState;
-	local XComGameState_Unit		SlotUnitState;
-	local int						idx, HoursToCovertAction;
 
 	OverrideTuple = XComLWTuple(EventData);
 	if (OverrideTuple == none)
@@ -283,42 +277,6 @@ static protected function EventListenerReturn OnOverridePersonnelStatus(Object E
 					HoursToInfiltrate,				// TimeValue
 					eUIState_Warning,
 					false);
-			}
-		}
-		else if (UnitState.GetStatus() == eStatus_CovertAction)
-		{
-			History = `XCOMHISTORY;
-			foreach History.IterateByClassType(class'XComGameState_CovertAction', ActionState)
-			{
-				if (ActionState.bStarted)
-				{
-					// Trying to find the Covert Action the soldier is currently on.
-					for (idx = ActionState.StaffSlots.Length - 1; idx >= 0; idx--)
-					{
-						SlotState = ActionState.GetStaffSlot(idx);
-						if (SlotState != none && SlotState.IsSoldierSlot() && SlotState.IsSlotFilled())
-						{
-							SlotUnitState = SlotState.GetAssignedStaff();
-							if (UnitState.ObjectID == SlotUnitState.ObjectID) {
-								UnitActionState = ActionState;
-								break;
-							}
-						}
-					}
-
-					if (UnitActionState != none) {
-						HoursToCovertAction = UnitActionState.GetNumHoursRemaining();
-						SetStatusTupleData(
-							OverrideTuple,
-							SlotState.GetMyTemplate().BonusText,	// Status
-							"",								// TimeLabel
-							"",								// TimeLabelOverride
-							HoursToCovertAction,				// TimeValue
-							eUIState_Warning,
-							false);
-						break;
-					}
-				}
 			}
 		}
 	}


### PR DESCRIPTION

![QQ截图20240331073637](https://github.com/long-war-2/lwotc/assets/7258723/86d702ba-10eb-4656-b1f8-3bb033ce67d0)

The Covert Action for training that boosts attributes by spending AP does not display a name in the soldier list, and the time always shows as 0 without changing until the mission is completed.
After analysis and testing, it appears that the reason may be the absence of 'BonusText' in the CovertActionIntenseTrainingStaffSlot. It seems that adding 'BonusText' to the translation file should resolve the display issue.