### PR TITLE
add min haven count to invasion activity 

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2LWActivityCondition_MinRebels.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2LWActivityCondition_MinRebels.uc
@@ -18,10 +18,10 @@ simulated function bool MeetsConditionWithRegion(X2LWActivityCreation ActivityCr
 	OutpostState = OutpostManager.GetOutpostForRegion(Region);
 	if (OutPostState.Rebels.length >= MinRebels)
 	{
-		`LWTRACE ("Passed X2LWActivityCondition_MinRebels, can launch" @ ActivityCreation.ActivityTemplate.ActivityName);
+		`LWTRACE ("Passed X2LWActivityCondition_MinRebels, can launch" @ ActivityCreation.ActivityTemplate.ActivityName @ "in" $ Region.GetMyTemplateName());
 		return true;
 	}
-	`LWTRACE ("Passed X2LWActivityCondition_MinRebels, can't launch" @ ActivityCreation.ActivityTemplate.ActivityName);
+	`LWTRACE ("Passed X2LWActivityCondition_MinRebels, can't launch" @ ActivityCreation.ActivityTemplate.ActivityName @ "in" $ Region.GetMyTemplateName());
 	return false;
 
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2LWActivityCondition_MinRebels.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2LWActivityCondition_MinRebels.uc
@@ -18,10 +18,10 @@ simulated function bool MeetsConditionWithRegion(X2LWActivityCreation ActivityCr
 	OutpostState = OutpostManager.GetOutpostForRegion(Region);
 	if (OutPostState.Rebels.length >= MinRebels)
 	{
-		`LWTRACE ("Passed X2LWActivityCondition_MinRebels" @ ActivityCreation.ActivityTemplate.ActivityName);
+		`LWTRACE ("Passed X2LWActivityCondition_MinRebels, can launch" @ ActivityCreation.ActivityTemplate.ActivityName);
 		return true;
 	}
-	`LWTRACE ("Passed X2LWActivityCondition_MinRebels" @ ActivityCreation.ActivityTemplate.ActivityName);
+	`LWTRACE ("Passed X2LWActivityCondition_MinRebels, can't launch" @ ActivityCreation.ActivityTemplate.ActivityName);
 	return false;
 
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2StrategyElement_DefaultAlienActivities.uc
@@ -2688,6 +2688,7 @@ static function X2DataTemplate CreateInvasionTemplate()
 	local X2LWActivityCooldown Cooldown;
 	local X2LWActivityCondition_LiberatedDays FreedomDuration;
 	local X2LWActivityCondition_RNG_Region AlienSearchCondition;
+	local X2LWActivityCondition_MinRebels RebelCondition1;
 
 	`CREATE_X2TEMPLATE(class'X2LWAlienActivityTemplate', Template, default.InvasionName);
 
@@ -2698,6 +2699,11 @@ static function X2DataTemplate CreateInvasionTemplate()
 	//these define the requirements for creating each activity
 	Template.ActivityCreation = new class'X2LWActivityCreation_Invasion';
 	Template.ActivityCreation.Conditions.AddItem(default.SingleActivityInRegion);
+
+	// This makes sure there are enough warm bodies for the mission to be meaningful
+	RebelCondition1 = new class 'X2LWActivityCondition_MinRebels';
+	RebelCondition1.MinRebels = default.ATTEMPT_COUNTERINSURGENCY_MIN_REBELS;
+	Template.ActivityCreation.Conditions.AddItem(RebelCondition1);
 
 	RegionStatus = new class'X2LWActivityCondition_RegionStatus';
 	RegionStatus.bAllowInLiberated = true;


### PR DESCRIPTION
This adds the min haven count condition to the invasion activity similar to haven retaliations so that there are still some rebels that can be rescued. This should help resolve [Invasions with 0 rebels](https://github.com/long-war-2/lwotc/issues/1547) that just ends up in an automatic failure as there was no one to rescue.

Currently just using the haven retaliation count as it made the most sense to keep the two the same. 

Also updated the logging for "MinRebel" to make it clear whether the activity can launch in a given region.