### PR TITLE
Use "attacks" instead of "fire" in Return Fire ability loc

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -129,8 +129,8 @@ LocFlyOverText="Hunker Down"
 ; End translation
 
 [ReturnFire X2AbilityTemplate]
-LocHelpText="When targeted by enemy fire, automatically fire back with your pistol once per turn."
-LocLongDescription="When targeted by enemy fire, automatically fire back with your pistol once per turn."
+LocHelpText="When targeted by enemy attacks, automatically fire back with your pistol once per turn."
+LocLongDescription="When targeted by enemy attacks, automatically fire back with your pistol once per turn."
 ; LWOTC Needs Translation
 [Quickdraw X2AbilityTemplate]
 LocLongDescription="Negates the mobility penalty for carrying a pistol, and firing your pistol with your first action no longer ends your turn."
@@ -6508,26 +6508,26 @@ LocPromotionPopupText="<Bullet/> Give a friendly unit <Ability:INSPIRE_DODGE/> D
 
 [PrimaryReturnFire X2AbilityTemplate]
 LocFriendlyName="Return Fire"
-LocHelpText="When targeted by enemy fire, automatically fire back with your <Ability:WeaponName/> once per turn."
-LocLongDescription="When targeted by enemy fire, automatically fire back with your <Ability:WeaponName/> once per turn."
+LocHelpText="When targeted by enemy attacks, automatically fire back with your <Ability:WeaponName/> once per turn."
+LocLongDescription="When targeted by enemy attacks, automatically fire back with your <Ability:WeaponName/> once per turn."
 LocPromotionPopupText="<Bullet/> Return Fire will only trigger once per turn.<br/><Bullet/> Return Fire can be triggered by melee attacks and area of effect attacks.<br/><Bullet/> Return Fire will not trigger when targeted by overwatch fire.<br/>"
 
 [PrimaryReturnFireShot X2AbilityTemplate]
 LocFriendlyName="Return Fire"
-LocHelpText="When targeted by enemy fire, automatically fire back with your <Ability:WeaponName/> once per turn."
-LocLongDescription="When targeted by enemy fire, automatically fire back with your <Ability:WeaponName/> once per turn."
+LocHelpText="When targeted by enemy attacks, automatically fire back with your <Ability:WeaponName/> once per turn."
+LocLongDescription="When targeted by enemy attacks, automatically fire back with your <Ability:WeaponName/> once per turn."
 LocPromotionPopupText="<Bullet/> Return Fire will only trigger once per turn.<br/><Bullet/> Return Fire can be triggered by melee attacks and area of effect attacks.<br/><Bullet/> Return Fire will not trigger when targeted by overwatch fire.<br/>"
 
 [TriggerBot X2AbilityTemplate]
 LocFriendlyName="Trigger Bot"
-LocHelpText="When targeted by enemy fire, automatically fire back with your <Ability:WeaponName/> once per turn with an attack that has a <Ability:TRIGGER_BOT_DAMAGE_PENALTY/>% damage penalty, but is a guaranteed hit."
-LocLongDescription="When targeted by enemy fire, automatically fire back with your <Ability:WeaponName/> once per turn with an attack that has a <Ability:TRIGGER_BOT_DAMAGE_PENALTY/>% damage penalty, but is a guaranteed hit."
+LocHelpText="When targeted by enemy attacks, automatically fire back with your <Ability:WeaponName/> once per turn with an attack that has a <Ability:TRIGGER_BOT_DAMAGE_PENALTY/>% damage penalty, but is a guaranteed hit."
+LocLongDescription="When targeted by enemy attacks, automatically fire back with your <Ability:WeaponName/> once per turn with an attack that has a <Ability:TRIGGER_BOT_DAMAGE_PENALTY/>% damage penalty, but is a guaranteed hit."
 LocPromotionPopupText="<Bullet/> Trigger Bot will only trigger once per turn.<br/><Bullet/> Trigger Bot can be triggered by melee attacks and area of effect attacks.<br/><Bullet/> Trigger Bot will not trigger when targeted by overwatch fire.<br/>"
 
 [TriggerBotShot X2AbilityTemplate]
 LocFriendlyName="Trigger Bot"
-LocHelpText="When targeted by enemy fire, automatically fire back with your <Ability:WeaponName/> once per turn with an attack that has a <Ability:TRIGGER_BOT_DAMAGE_PENALTY/>% damage penalty, but is a guaranteed hit."
-LocLongDescription="When targeted by enemy fire, automatically fire back with your <Ability:WeaponName/> once per turn with an attack that has a <Ability:TRIGGER_BOT_DAMAGE_PENALTY/>% damage penalty, but is a guaranteed hit."
+LocHelpText="When targeted by enemy attacks, automatically fire back with your <Ability:WeaponName/> once per turn with an attack that has a <Ability:TRIGGER_BOT_DAMAGE_PENALTY/>% damage penalty, but is a guaranteed hit."
+LocLongDescription="When targeted by enemy attacks, automatically fire back with your <Ability:WeaponName/> once per turn with an attack that has a <Ability:TRIGGER_BOT_DAMAGE_PENALTY/>% damage penalty, but is a guaranteed hit."
 LocPromotionPopupText="<Bullet/> Trigger Bot will only trigger once per turn.<br/><Bullet/> Trigger Bot can be triggered by melee attacks and area of effect attacks.<br/><Bullet/> Trigger Bot will not trigger when targeted by overwatch fire.<br/>"
 
 [DeadeyeSnapShot X2AbilityTemplate]


### PR DESCRIPTION
Same as #1719, but for abilities. The text for Officer/Priest variant seems to be omitted in base game, not going to bother with that one.