### PR TITLE
Various impairment standardizations

### DIFF
--- a/LongWarOfTheChosen/Localization/LW_FactionBalance/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_FactionBalance/XComGame.int
@@ -34,19 +34,18 @@ LocPromotionPopupText="<Bullet/> Adds a disorient effect that applies to all org
 
 [DisablingShot X2AbilityTemplate]
 LocFriendlyName="Disabling Shot"
-LocLongDescription="Stun enemies with a precise shot, with a bonus stun duration if the shot crits. The shot can not do critical damage."
-LocHelpText="Stun enemies with a precise shot, with a bonus stun duration if the shot crits. The shot can not do critical damage."
+LocLongDescription="Fire a shot that deals <Ability:DisablingShotDamagePenalty>% less damage, but stuns if it hits. Critical hits with this attack do not deal extra damage, but apply a longer stun."
+LocHelpText="Stun the target for <Ability:DisablingShotStunActions> actions. Critical hits do not deal extra damage, but extend the stun by <Ability:DisablingShotCritStunActions> actions."
 ; LWOTC Needs Translation (2)
-LocPromotionPopupText="<Bullet/> Stuns enemies for <Ability:DisablingShotStunActions/> actions if the shot hits (including if it grazes).<br/><Bullet/> Stuns for an extra <Ability:DisablingShotCritStunActions/> actions if the shot crits, but the shot won't inflict the critical damage.<br/><Bullet/> Disabling Shot requires <Ability:SelfAmmoCost/> ammo to use.<br/><Bullet/> Disabling Shot has a <Ability:SelfCooldown_LW/> turn cooldown.<br/><Bullet/> Only Avatars and Psi Zombies can not be stunned."
+LocPromotionPopupText="<Bullet/> Stuns the target for <Ability:DisablingShotStunActions/> actions if it hits, even on a graze.<br/><Bullet/> Stuns for an extra <Ability:DisablingShotCritStunActions/> actions if the shot crits, but the shot won't inflict the critical damage.<br/><Bullet/> Disabling Shot requires <Ability:SelfAmmoCost/> ammo to use.<br/><Bullet/> Disabling Shot has a <Ability:SelfCooldown_LW/> turn cooldown.<br/><Bullet/> Disabling Shot cannot be used against stun immune enemies.<br/>"
 ; End Translation (2)
-
 
 [DisablingShotSnapShot X2AbilityTemplate]
 LocFriendlyName="Disabling Shot (Snap Shot)"
-LocLongDescription="Stun enemies with a precise shot, with a bonus stun duration if the shot crits. The shot can not do critical damage."
-LocHelpText="Stun enemies with a precise shot, with a bonus stun duration if the shot crits. The shot can not do critical damage."
+LocLongDescription="Fire a shot that deals <Ability:DisablingShotDamagePenalty>% less damage, but stuns if it hits. Critical hits with this attack do not deal extra damage, but apply a longer stun."
+LocHelpText="Stun the target for <Ability:DisablingShotStunActions> actions. Critical hits do not deal extra damage, but apply a <Ability:DisablingShotCritStunActions> action stun."
 ; LWOTC Needs Translation (2)
-LocPromotionPopupText="<Bullet/> Stuns enemies for <Ability:DisablingShotStunActions/> actions if the shot hits (including if it grazes).<br/><Bullet/> Stuns for an extra <Ability:DisablingShotCritStunActions/> actions if the shot crits, but the shot won't inflict the critical damage.<br/><Bullet/> Disabling Shot requires <Ability:SelfAmmoCost/> ammo to use.<br/><Bullet/> Disabling Shot has a <Ability:SelfCooldown_LW/> turn cooldown.<br/><Bullet/> Only Avatars and Psi Zombies can not be stunned."
+LocPromotionPopupText="<Bullet/> Stuns the target for <Ability:DisablingShotStunActions/> actions if it hits, even on a graze.<br/><Bullet/> Stuns for an extra <Ability:DisablingShotCritStunActions/> actions if the shot crits, but the shot won't inflict the critical damage.<br/><Bullet/> Disabling Shot requires <Ability:SelfAmmoCost/> ammo to use.<br/><Bullet/> Disabling Shot has a <Ability:SelfCooldown_LW/> turn cooldown.<br/><Bullet/> Disabling Shot cannot be used against stun immune enemies.<br/>"
 ; End Translation (2)
 
 [Meditation X2AbilityTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -7728,3 +7728,10 @@ LocFlyOverText="Psi Zombie Immunities"
 LocLongDescription="Psi Zombies are immune to mental impairments and poison."
 LocHelpText="Psi Zombies are immune to mental impairments and poison.
 LocPromotionPopupText=""
+
+[SpectralZombieImmunitiesPassive X2AbilityTemplate]
+LocFriendlyName="Spectral Zombie Immunities"
+LocFlyOverText="Spectral Zombie Immunities"
+LocLongDescription="Spectral Zombies are immune to mental impairments, fire, poison, and acid."
+LocHelpText="Spectral Zombies are immune to mental impairments, fire, poison, and acid.
+LocPromotionPopupText=""

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -7271,10 +7271,17 @@ AbilityDescName="Purifier Flamethrower"
 
 [Solace X2AbilityTemplate]
 LocFriendlyName="Solace Aura"
-LocLongDescription="The Priest is surrounded by an aura that immediately extinguishes or blocks any mental impairments for themselves and any nearby squadmates."
-LocHelpText="The Priest is surrounded by an aura that immediately extinguishes or blocks any mental impairments for for themselves and any nearby squadmates."
+LocLongDescription="This unit is affected by an aura that protects it from any mental impairments."
+LocHelpText="This unit is affected by an aura that protects it from any mental impairments."
 LocFlyOverText="Solace"
-LocPromotionPopupText="<Bullet/> Solace has a 4 tile radius.<br/><Bullet/> Moving next to afflicted allies will immediately cleanse their mental impairments.<br/>"
+LocPromotionPopupText="<Bullet/> Solace has a 4 tile radius.<br/><Bullet/> Moving next to afflicted organic allies will immediately cleanse their mental impairments.<br/>"
+
+[SolacePassive X2AbilityTemplate]
+LocFriendlyName="Solace"
+LocLongDescription="This unit is surrounded by an aura that immediately extinguishes or blocks any mental impairments for themselves and any nearby organic allies."
+LocHelpText="This unit is surrounded by an aura that immediately extinguishes or blocks any mental impairments for themselves and any nearby organic allies."
+LocFlyOverText="Solace"
+LocPromotionPopupText="<Bullet/> Solace has a 4 tile radius.<br/><Bullet/> Moving next to afflicted organic allies will immediately cleanse their mental impairments.<br/>"
 
 ; End Translation
 

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -7128,8 +7128,8 @@ LocFlyOverText="Chosen Prime Reaction"
 ; LWOTC Needs Translation (3)
 [ChosenImmunities X2AbilityTemplate]
 LocFriendlyName="Chosen Immunities"
-LocLongDescription="Chosen are immune to stun, disorient, and frost."
-LocHelpText="Chosen are immune to stun, disorient, and frost."
+LocLongDescription="Chosen are immune to all mental impairments and frost."
+LocHelpText="Chosen are immune to all mental impairments and frost."
 LocFlyOverText="Chosen Immunities"
 ; End Translation (3)
 

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -721,10 +721,10 @@ LocPromotionPopupText="<Bullet/> Medium-range, cone-based shotgun attack.<br/><B
 [ChainLightning X2AbilityTemplate]
 LocFriendlyName="Chain Lightning"
 ; LWOTC Needs Translation (3)
-LocLongDescription="An Arc Thrower attack that jumps from target to target up to 4 times, while each target is within 6 tiles of each other."
-LocHelpText="An Arc Thrower attack that jumps from target to target up to 4 times, while each target is within 6 tiles of each other."
+LocLongDescription="A chaining arc thrower attack that stuns up to <Ability:CHAIN_LIGHTNING_TARGETS> targets.
+LocHelpText="A chaining arc thrower attack that stuns up to <Ability:CHAIN_LIGHTNING_TARGETS> targets.
 LocFlyOverText="Chain Lightning"
-LocPromotionPopupText="<Bullet/> Fires the Arc Thrower at a target in vision, with the arc chaining up to 4 times to other targets within 6 tiles of each other.<br/><Bullet/> Requires one action and ends your turn.<br/><Bullet/> Chain Lightning has a <Ability:SelfCooldown_LW/> turn cooldown.<br/><Bullet/> Cannot be used from concealment."
+LocPromotionPopupText="<Bullet/> Chain Lightning chains from target to target in a sequence. Successive targets can be up to <Ability:CHAIN_LIGHTNING_CHAIN_RANGE_TILES> tiles away from each other. The attack will not chain to previous targets in the sequence.<br/><Bullet/> The sequence of targets will be shown when you preview a target. A hit roll will be made against all targets in the sequence, even if you miss against a previous target. Cover bonuses are calculated from your position, not from the previous target.<br/><Bullet/> Chain Lightning cannot be fired at robotic enemies, and it will not chain to them.<br/><Bullet/> Requires one action and ends your turn.<br/><Bullet/> Chain Lightning has a <Ability:SelfCooldown_LW/> turn cooldown.<br/><Bullet/> Cannot be used from concealment."
 ; End Translation (3)
 
 [Leadership X2AbilityTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -7721,3 +7721,10 @@ LocFlyOverText="The Lost Immunities"
 LocLongDescription="The Lost are immune to mental impairments, poison, and acid."
 LocHelpText="The Lost are immune to mental impairments, poison, and acid.
 LocPromotionPopupText=""
+
+[PsiZombieImmunitiesPassive X2AbilityTemplate]
+LocFriendlyName="Psi Zombie Immunities"
+LocFlyOverText="Psi Zombie Immunities"
+LocLongDescription="Psi Zombies are immune to mental impairments and poison."
+LocHelpText="Psi Zombies are immune to mental impairments and poison.
+LocPromotionPopupText=""

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -7714,3 +7714,10 @@ m_strLockedTT=We cannot make contact with the Resistance in this region. We must
 m_strUnlockedTT=The Resistance in <XGParam:StrValue0/!WorldRegionName/> would join our cause if we made contact with them!
 m_strContactTT=The Resistance in <XGParam:StrValue0/!WorldRegionName/> is generating an income of <XGParam:StrValue1/!Quantity/> supplies for us.
 m_strOutpostTT=We have installed a radio relay in this region! The relay increases the efficiency of rebel jobs and it reduces the cost of contact with any connected regions.
+
+[LostImmunitiesPassive X2AbilityTemplate]
+LocFriendlyName="The Lost Immunities"
+LocFlyOverText="The Lost Immunities"
+LocLongDescription="The Lost are immune to mental impairments, poison, and acid."
+LocHelpText="The Lost are immune to mental impairments, poison, and acid.
+LocPromotionPopupText=""

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -320,9 +320,9 @@ LocPromotionPopupText="<Bullet/> Attacks with your gauntlet, and fires set by ga
 [ConcussionRocket X2AbilityTemplate]
 LocFriendlyName="Concussion Rocket"
 LocFlyOverText="Concussion Rocket"
-LocLongDescription="Fire a special rocket that does limited damage but has a chance to stun or disorient organic enemies within its area of effect."
-LocHelpText="Rocket that stuns or disorients targets. <Ability:ROCKETSCATTER/>"
-LocPromotionPopupText="<Bullet/> One use per mission.<br/><Bullet/> Stun chance is 20% .<br/><Bullet/> Disorientation chance is 100% and bypasses disorient resist (but not immunity).<br/><Bullet/> Requires one action and ends the soldier's turn.<br/><Bullet/> Elite Codexes and Psi Zombies are immune to all effects including damage.<br/><Bullet/> Allies cannot be injured by this attack.<br/>"
+LocLongDescription="Fire a special rocket that deals low damage but impairs organic enemies within its area of effect."
+LocHelpText="Fire a rocket that always disorients organic enemies. It also has a <Ability:CONCUSSION_ROCKET_STUN_CHANCE>% chance to stun them. <Ability:ROCKETSCATTER/>"
+LocPromotionPopupText="<Bullet/> Deals 2 damage.<br/><Bullet/> Always disorients organic targets. Additionally, each organic target has a <Ability:CONCUSSION_ROCKET_STUN_CHANCE>% chance to be stunned instead.<br/><Bullet/> Requires one action and ends the soldier's turn.<br/><Bullet/> One use per mission.<br/>"
 ; End Translation (4)
 
 ;;;;;;;;;;;;;;;;;;;;  SHINOBI ABILITIES ;;;;;;;;;;;;;;;;;;;;;;;

--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_ReaperAbilitySet_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_ReaperAbilitySet_LW.uc
@@ -459,15 +459,14 @@ static function X2DataTemplate AddBloodTrailBleedingAbility()
 static function X2AbilityTemplate AddDisablingShot()
 {
 	local X2AbilityTemplate					Template;
-	local X2AbilityCost_Ammo                AmmoCost;
-	local X2AbilityCost_ActionPoints        ActionPointCost;
-	local X2AbilityCooldown_Shared          Cooldown;
-	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
+	local X2AbilityCost_Ammo				AmmoCost;
+	local X2AbilityCost_ActionPoints		ActionPointCost;
+	local X2AbilityCooldown_Shared			Cooldown;
+	local X2AbilityToHitCalc_StandardAim	ToHitCalc;
 	local X2Condition_Visibility			VisibilityCondition;
 	local X2Effect_DisablingShotStunned		StunEffect;
 	local X2Condition_UnitEffects			SuppressedCondition;
 	local X2Condition_UnitProperty			UnitPropertyCondition;
-	local X2Condition_UnitType				ImmuneUnitCondition;
 
 	`CREATE_X2ABILITY_TEMPLATE (Template, 'DisablingShot');
 	Template.IconImage = "img:///UILibrary_LWOTC.LW_AbilityElectroshock";
@@ -489,7 +488,7 @@ static function X2AbilityTemplate AddDisablingShot()
 	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
 	Template.AbilityTargetConditions.AddItem(default.LivingHostileTargetProperty);
 	Template.AddShooterEffectExclusions();
-	Template.ActivationSpeech = 'Reaper';
+	Template.ActivationSpeech = 'StunTarget';
 	Template.AdditionalAbilities.AddItem('DisablingShotCritRemoval');
 
 	VisibilityCondition = new class'X2Condition_Visibility';
@@ -512,7 +511,6 @@ static function X2AbilityTemplate AddDisablingShot()
 	ActionPointCost.bConsumeAllPoints = true;
 	Template.AbilityCosts.AddItem(ActionPointCost);
 
-	// Can't target dead; Can't target friendlies
 	UnitPropertyCondition = new class'X2Condition_UnitProperty';
 	UnitPropertyCondition.ExcludeRobotic = false;
 	UnitPropertyCondition.ExcludeOrganic = false;
@@ -520,12 +518,6 @@ static function X2AbilityTemplate AddDisablingShot()
 	UnitPropertyCondition.ExcludeFriendlyToSource = true;
 	UnitPropertyCondition.RequireWithinRange = true;
 	Template.AbilityTargetConditions.AddItem(UnitPropertyCondition);
-	
-	ImmuneUnitCondition = new class'X2Condition_UnitType';
-	ImmuneUnitCondition.ExcludeTypes.AddItem('PsiZombie');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM2');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM3');
-	Template.AbilityTargetConditions.AddItem(ImmuneUnitCondition);
 
 	SuppressedCondition = new class'X2Condition_UnitEffects';
 	SuppressedCondition.AddExcludeEffect(class'X2Effect_Suppression'.default.EffectName, 'AA_UnitIsSuppressed');
@@ -537,9 +529,9 @@ static function X2AbilityTemplate AddDisablingShot()
 	Template.AbilityToHitOwnerOnMissCalc = ToHitCalc;
 
 	Cooldown = new class'X2AbilityCooldown_Shared';
-    Cooldown.iNumTurns = default.DisablingShotCooldown;
+	Cooldown.iNumTurns = default.DisablingShotCooldown;
 	Cooldown.SharingCooldownsWith.AddItem('DisablingShotSnapShot');
-    Template.AbilityCooldown = Cooldown;
+	Template.AbilityCooldown = Cooldown;
 
 	AmmoCost = new class'X2AbilityCost_Ammo';
 	AmmoCost.iAmmo = default.DisablingShotAmmoCost;
@@ -550,7 +542,7 @@ static function X2AbilityTemplate AddDisablingShot()
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
 	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
 	Template.BuildInterruptGameStateFn = TypicalAbility_BuildInterruptGameState;
-	
+
 	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
 	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
 	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotLostSpawnIncreasePerUse;
@@ -561,16 +553,15 @@ static function X2AbilityTemplate AddDisablingShot()
 static function X2AbilityTemplate AddDisablingShotSnapShot()
 {
 	local X2AbilityTemplate					Template;
-	local X2AbilityCost_Ammo                AmmoCost;
-	local X2AbilityCost_ActionPoints        ActionPointCost;
-	local X2AbilityCooldown_Shared                 Cooldown;
-	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
+	local X2AbilityCost_Ammo				AmmoCost;
+	local X2AbilityCost_ActionPoints		ActionPointCost;
+	local X2AbilityCooldown_Shared			Cooldown;
+	local X2AbilityToHitCalc_StandardAim	ToHitCalc;
 	local X2Condition_Visibility			VisibilityCondition;
 	local X2Effect_DisablingShotStunned		StunEffect;
 	local X2Condition_UnitEffects			SuppressedCondition;
 	local X2Condition_UnitProperty			UnitPropertyCondition;
-	local X2Condition_UnitType				ImmuneUnitCondition;
-	local X2Condition_AbilityProperty   	AbilityCondition;
+	local X2Condition_AbilityProperty		AbilityCondition;
 	local X2Condition_UnitActionPoints		ActionPointCondition;
 
 	`CREATE_X2ABILITY_TEMPLATE (Template, 'DisablingShotSnapShot');
@@ -592,7 +583,7 @@ static function X2AbilityTemplate AddDisablingShotSnapShot()
 	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
 	Template.AbilityTargetConditions.AddItem(default.LivingHostileTargetProperty);
 	Template.AddShooterEffectExclusions();
-	Template.ActivationSpeech = 'Reaper';
+	Template.ActivationSpeech = 'StunTarget';
 	Template.AdditionalAbilities.AddItem('DisablingShotSnapShotCritRemoval');
 
 	VisibilityCondition = new class'X2Condition_Visibility';
@@ -622,12 +613,6 @@ static function X2AbilityTemplate AddDisablingShotSnapShot()
 	UnitPropertyCondition.ExcludeFriendlyToSource = true;
 	UnitPropertyCondition.RequireWithinRange = true;
 	Template.AbilityTargetConditions.AddItem(UnitPropertyCondition);
-	
-	ImmuneUnitCondition = new class'X2Condition_UnitType';
-	ImmuneUnitCondition.ExcludeTypes.AddItem('PsiZombie');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM2');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM3');
-	Template.AbilityTargetConditions.AddItem(ImmuneUnitCondition);
 
 	SuppressedCondition = new class'X2Condition_UnitEffects';
 	SuppressedCondition.AddExcludeEffect(class'X2Effect_Suppression'.default.EffectName, 'AA_UnitIsSuppressed');
@@ -639,9 +624,9 @@ static function X2AbilityTemplate AddDisablingShotSnapShot()
 	Template.AbilityToHitOwnerOnMissCalc = ToHitCalc;
 
 	Cooldown = new class'X2AbilityCooldown_Shared';
-    Cooldown.iNumTurns = default.DisablingShotCooldown;
+	Cooldown.iNumTurns = default.DisablingShotCooldown;
 	Cooldown.SharingCooldownsWith.AddItem('DisablingShot');
-    Template.AbilityCooldown = Cooldown;
+	Template.AbilityCooldown = Cooldown;
 
 	AmmoCost = new class'X2AbilityCost_Ammo';
 	AmmoCost.iAmmo = default.DisablingShotAmmoCost;
@@ -656,13 +641,12 @@ static function X2AbilityTemplate AddDisablingShotSnapShot()
 	Template.AbilityShooterConditions.Additem(AbilityCondition);
 
 	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1,class'X2CharacterTemplateManager'.default.StandardActionPoint,false,eCheck_LessThanOrEqual);
+	ActionPointCondition.AddActionPointCheck(1, class'X2CharacterTemplateManager'.default.StandardActionPoint, false, eCheck_LessThanOrEqual);
 	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
 	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1,class'X2CharacterTemplateManager'.default.RunAndGunActionPoint,false,eCheck_LessThanOrEqual);
+	ActionPointCondition.AddActionPointCheck(1, class'X2CharacterTemplateManager'.default.RunAndGunActionPoint, false, eCheck_LessThanOrEqual);
 	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
 
-	
 	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
 	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
 	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotLostSpawnIncreasePerUse;

--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2DownloadableContentInfo_LW_FactionBalance.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2DownloadableContentInfo_LW_FactionBalance.uc
@@ -118,6 +118,9 @@ static function bool AbilityTagExpandHandler(string InString, out string OutStri
 	case 'DisablingShotStunActions':
 		OutString = string(class'X2Ability_ReaperAbilitySet_LW'.default.DisablingShotBaseStunActions);
 		return true;
+	case 'DisablingShotDamagePenalty':
+		OutString = string(int(100*class'X2Ability_ReaperAbilitySet_LW'.default.DisablingShotDamagePenalty));
+		return true;
 	case 'PARAMEDIC_BONUS_CHARGES':
 		OutString = string(class'X2Ability_ReaperAbilitySet_LW'.default.PARAMEDIC_BONUS_CHARGES);
 		return true;

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -2283,6 +2283,9 @@ function GeneralCharacterMod(X2CharacterTemplate Template, int Difficulty)
 			Template.Abilities.AddItem('MC_Stock_Strike');
 			Template.Abilities.AddItem('GetUp');
 			break;
+		case 'PsiZombie':
+			Template.Abilities.AddItem('PsiZombieImmunitiesPassive');
+			break;
 		//Need to rescale the loadouts of these templates, and can't think of a better way since it needs to be by hp basis
 		case 'TheLost':
 			Template.Abilities.AddItem('LostImmunitiesPassive');

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -2283,44 +2283,58 @@ function GeneralCharacterMod(X2CharacterTemplate Template, int Difficulty)
 			Template.Abilities.AddItem('MC_Stock_Strike');
 			Template.Abilities.AddItem('GetUp');
 			break;
-		//Need to rescale the loadouts of these templates, and can't think of a better way since it needs to be by hp basis 
+		//Need to rescale the loadouts of these templates, and can't think of a better way since it needs to be by hp basis
+		case 'TheLost':
+			Template.Abilities.AddItem('LostImmunitiesPassive');
+			break;
 		case 'TheLostHP2':
 		case 'TheLostHP3':
+			Template.Abilities.AddItem('LostImmunitiesPassive');
 			Template.DefaultLoadout='TheLostTier1_Loadout';
 			break;
 		case 'TheLostHP4':
 		case 'TheLostHP5':
 		case 'TheLostHP6':
+			Template.Abilities.AddItem('LostImmunitiesPassive');
 			Template.DefaultLoadout='TheLostTier2_Loadout';
 			break;
 		case 'TheLostHP7':
 		case 'TheLostHP8':
 		case 'TheLostHP9':
+			Template.Abilities.AddItem('LostImmunitiesPassive');
 			Template.DefaultLoadout='TheLostTier3_Loadout';
 			break;
 		case 'TheLostHP10':
 		case 'TheLostHP11':
 		case 'TheLostHP12':
+			Template.Abilities.AddItem('LostImmunitiesPassive');
 			Template.DefaultLoadout='TheLostTier4_Loadout';
 			break;
 
+		case 'TheLostDasher':
+			Template.Abilities.AddItem('LostImmunitiesPassive');
+			break;
 		case 'TheLostDasherHP2':
 		case 'TheLostDasherHP3':
+			Template.Abilities.AddItem('LostImmunitiesPassive');
 			Template.DefaultLoadout='TheLostDasherTier1_Loadout';
 			break;
 		case 'TheLostDasherHP4':
 		case 'TheLostDasherHP5':
 		case 'TheLostDasherHP6':
+			Template.Abilities.AddItem('LostImmunitiesPassive');
 			Template.DefaultLoadout='TheLostDasherTier2_Loadout';
 			break;
 		case 'TheLostDasherHP7':
 		case 'TheLostDasherHP8':
 		case 'TheLostDasherHP9':
+			Template.Abilities.AddItem('LostImmunitiesPassive');
 			Template.DefaultLoadout='TheLostDasherTier3_Loadout';
 			break;
 		case 'TheLostDasherHP10':
 		case 'TheLostDasherHP11':
 		case 'TheLostDasherHP12':
+			Template.Abilities.AddItem('LostImmunitiesPassive');
 			Template.DefaultLoadout='TheLostDasherTier4_Loadout';
 			break;
 		case 'SpectralStunLancerM1':

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -2392,8 +2392,10 @@ function GeneralCharacterMod(X2CharacterTemplate Template, int Difficulty)
 		Template.Abilities.AddItem('ChosenSummonFollowers');
 
 		Template.ImmuneTypes.AddItem('Frost');
-
-
+	}
+	if (Template.CharacterGroupName == 'SpectralZombie')
+	{
+		Template.Abilities.AddItem('SpectralZombieImmunitiesPassive');
 	}
 	if (Template.CharacterGroupName == 'ChosenSniper')
 	{

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_AssaultAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_AssaultAbilitySet.uc
@@ -525,9 +525,7 @@ static function X2AbilityTemplate CreateChainLightningAbility()
 	local X2Effect_ArcthrowerStunned		StunnedEffect;
 	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
 	local X2AbilityCooldown					Cooldown;	
-	local X2Condition_UnitType				ImmuneUnitCondition;
 	local X2Condition_UnitEffects			SuppressedCondition;
-	//local X2Effect_RemoveEffects			CleanUpEffect;
 
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'ChainLightning');
 	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.CLASS_COLONEL_PRIORITY;
@@ -542,7 +540,7 @@ static function X2AbilityTemplate CreateChainLightningAbility()
 	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
 	Template.AbilityTargetConditions.AddItem(default.LivingTargetUnitOnlyProperty);
 	Template.AbilityTargetConditions.AddItem(default.GameplayVisibilityCondition);
-	
+
 	Template.AbilityTargetStyle = default.SimpleSingleTarget;
 	Template.AbilityMultiTargetStyle = new class'X2AbilityMultiTarget_Volt';
 	Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
@@ -554,8 +552,6 @@ static function X2AbilityTemplate CreateChainLightningAbility()
 	Template.AbilityTargetConditions.AddItem(default.GameplayVisibilityCondition);
 	Template.AbilityTargetConditions.AddItem(default.LivingHostileUnitDisallowMindControlProperty);
 
-
-	//Template.bAllowAmmoEffects = true;
 	Template.bAllowBonusWeaponEffects = true;
 
 	// Can't target dead; Can't target friendlies -- must be enemy organic
@@ -565,7 +561,7 @@ static function X2AbilityTemplate CreateChainLightningAbility()
 	UnitPropertyCondition.ExcludeDead = true;
 	UnitPropertyCondition.ExcludeFriendlyToSource = true;
 	Template.AbilityTargetConditions.AddItem(UnitPropertyCondition);
-	
+
 	Template.AbilityMultiTargetConditions.AddItem(UnitPropertyCondition);
 	UnitPropertyCondition2 = new class'X2Condition_UnitProperty';
 	UnitPropertyCondition2.ExcludeConcealed = true;
@@ -576,15 +572,6 @@ static function X2AbilityTemplate CreateChainLightningAbility()
 	SuppressedCondition.AddExcludeEffect(class'X2Effect_AreaSuppression'.default.EffectName, 'AA_UnitIsSuppressed');
 	Template.AbilityShooterConditions.AddItem(SuppressedCondition);
 
-	ImmuneUnitCondition = new class'X2Condition_UnitType';
-	ImmuneUnitCondition.ExcludeTypes.AddItem('PsiZombie');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM2');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM3');
-	Template.AbilityTargetConditions.AddItem(ImmuneUnitCondition);
-	Template.AbilityMultiTargetConditions.AddItem(ImmuneUnitCondition);
-
-
-
 	Cooldown = new class'X2AbilityCooldown';
 	Cooldown.iNumTurns = default.CHAIN_LIGHTNING_COOLDOWN;
 	Template.AbilityCooldown = Cooldown;
@@ -594,31 +581,27 @@ static function X2AbilityTemplate CreateChainLightningAbility()
 	ActionPointCost.iNumPoints = default.CHAIN_LIGHTNING_MIN_ACTION_REQ;
 	ActionPointCost.DoNotConsumeAllSoldierAbilities.AddItem('Unlimitedpower_LW');
 	ActionPointCost.bConsumeAllPoints = true;
-	Template.AbilityCosts.AddItem(ActionPointCost);	
+	Template.AbilityCosts.AddItem(ActionPointCost);
 
-	//Stun Effect
+	// Stun Effect
 	StunnedEffect = CreateArcthrowerStunnedStatusEffect(100);
 	Template.AddTargetEffect(StunnedEffect);
 	Template.AddMultiTargetEffect(StunnedEffect);
 
-	//CleanUpEffect = CreateStunnedEffectsCleanUpEffect();
-	//Template.AddTargetEffect(CleanUpEffect);
-
-
 	Template.AssociatedPassives.AddItem('Electroshock');
 	Template.AddMultiTargetEffect(ElectroshockDisorientEffect());
-	
+
 	ToHitCalc = new class'X2AbilityToHitCalc_StandardAim';
 	ToHitCalc.bOnlyMultiHitWithSuccess = false;
 	ToHitCalc.BuiltInHitMod = default.CHAIN_LIGHTNING_AIM_MOD;
 	Template.AbilityToHitCalc = ToHitCalc;
 	Template.AdditionalAbilities.AddItem('CLFocus');
-	
+
 	Template.ActionFireClass = class'X2Action_Fire_ChainLightning';
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
 	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
 	Template.BuildInterruptGameStateFn = TypicalAbility_BuildInterruptGameState;
-	
+
 	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
 	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotLostSpawnIncreasePerUse;
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_AssaultAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_AssaultAbilitySet.uc
@@ -266,24 +266,21 @@ static function X2AbilityTemplate StunGunner()
 //EM Pulser alternative attack, which allows targeting and damaging robots
 static function X2AbilityTemplate AddEMPulser()
 {
-	local X2AbilityCooldown                 Cooldown;
-	local X2AbilityTemplate                 Template;	
-	local X2Condition_UnitProperty			UnitPropertyCondition;
-	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
-	local X2AbilityCost_ActionPoints        ActionPointCost;
-	local X2Effect_ArcthrowerStunned	    StunnedEffect;
-	local array<name>                       SkipExclusions;
-	local X2Condition_UnitType				ImmuneUnitCondition;
-	//local X2Effect_RemoveEffects			CleanUpEffect;
-	// Macro to do localisation and stuffs
+	local X2AbilityCooldown								Cooldown;
+	local X2AbilityTemplate								Template;
+	local X2Condition_UnitProperty						UnitPropertyCondition;
+	local X2AbilityToHitCalc_StandardAim				ToHitCalc;
+	local X2AbilityCost_ActionPoints					ActionPointCost;
+	local X2Effect_ArcthrowerStunned					StunnedEffect;
+	local array<name>									SkipExclusions;
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'EMPulser');
 
 	// Icon Properties
-	Template.IconImage = "img:///UILibrary_LWOTC.LW_AbilityEMPulser"; 
+	Template.IconImage = "img:///UILibrary_LWOTC.LW_AbilityEMPulser";
 	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.STANDARD_PISTOL_SHOT_PRIORITY;
 	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_AlwaysShow;
 	Template.DisplayTargetHitChance = true;
-	Template.AbilitySourceName = 'eAbilitySource_Perk';                                       // color of the icon
+	Template.AbilitySourceName = 'eAbilitySource_Perk'; // color of the icon
 
 	// Activated by a button press; additionally, tells the AI this is an activatable
 	Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
@@ -299,20 +296,15 @@ static function X2AbilityTemplate AddEMPulser()
 	// Targeting Details
 	// Can only shoot visible enemies
 	Template.AbilityTargetConditions.AddItem(default.GameplayVisibilityCondition);
-	// Can't target dead; Can't target friendlies -- must be enemy organic
+	// Can't target dead; Can't target friendlies
 	UnitPropertyCondition = new class'X2Condition_UnitProperty';
 	UnitPropertyCondition.ExcludeRobotic = false;  // change from basic stun to allow targeting robotic units
 	UnitPropertyCondition.ExcludeOrganic = false;
 	UnitPropertyCondition.ExcludeDead = true;
 	UnitPropertyCondition.ExcludeFriendlyToSource = true;
 	UnitPropertyCondition.RequireWithinRange = true;
+	UnitPropertyCondition.FailOnNonUnits = true;
 	Template.AbilityTargetConditions.AddItem(UnitPropertyCondition);
-	
-	ImmuneUnitCondition = new class'X2Condition_UnitType';
-	ImmuneUnitCondition.ExcludeTypes.AddItem('PsiZombie');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM2');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM3');
-	Template.AbilityTargetConditions.AddItem(ImmuneUnitCondition);
 
 	// Can't shoot while dead
 	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
@@ -324,7 +316,7 @@ static function X2AbilityTemplate AddEMPulser()
 	ActionPointCost.iNumPoints = 1;
 	ActionPointCost.bConsumeAllPoints = true;
 	ActionPointCost.DoNotConsumeAllSoldierAbilities.AddItem('Unlimitedpower_LW');
-	Template.AbilityCosts.AddItem(ActionPointCost);	
+	Template.AbilityCosts.AddItem(ActionPointCost);
 
 	// Hit Calculation (Different weapons now have different calculations for range)
 	ToHitCalc = new class'X2AbilityToHitCalc_StandardAim';
@@ -336,14 +328,11 @@ static function X2AbilityTemplate AddEMPulser()
 	//Stun Effect
 	StunnedEffect = CreateArcthrowerStunnedStatusEffect(100);
 	Template.AddTargetEffect(StunnedEffect);
-	
-	//CleanUpEffect = CreateStunnedEffectsCleanUpEffect();
-	//Template.AddTargetEffect(CleanUpEffect);
 
-	Template.AssociatedPassives.AddItem( 'Electroshock' );
+	Template.AssociatedPassives.AddItem('Electroshock');
 	Template.AddTargetEffect(ElectroshockDisorientEffect());
 
-	Template.AssociatedPassives.AddItem( 'EMPulser' );
+	Template.AssociatedPassives.AddItem('EMPulser');
 	Template.AddTargetEffect(EMPulserHackDefenseReductionEffect());
 	Template.AddTargetEffect(EMPulserWeaponDamageEffect());
 
@@ -355,9 +344,9 @@ static function X2AbilityTemplate AddEMPulser()
 
 	// MAKE IT LIVE!
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
-	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;	
+	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
 	Template.BuildInterruptGameStateFn = TypicalAbility_BuildInterruptGameState;
-	
+
 	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
 	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
 	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotLostSpawnIncreasePerUse;
@@ -366,7 +355,7 @@ static function X2AbilityTemplate AddEMPulser()
 	Template.AdditionalAbilities.AddItem('EMPulserPassive');
 	Template.OverrideAbilities.AddItem('ArcthrowerStun');
 
-	return Template;	
+	return Template;
 }
 
 static function X2Effect_PersistentStatChange EMPulserHackDefenseReductionEffect()

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_AssaultAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_AssaultAbilitySet.uc
@@ -48,25 +48,23 @@ static function array<X2DataTemplate> CreateTemplates()
 static function X2AbilityTemplate AddArcthrowerStun()
 {
 
-	local X2AbilityCooldown                 Cooldown;
-	local X2AbilityTemplate                 Template;	
+	local X2AbilityCooldown					Cooldown;
+	local X2AbilityTemplate					Template;
 	local X2Condition_UnitProperty			UnitPropertyCondition;
-	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
-	local X2AbilityCost_ActionPoints        ActionPointCost;
-	local X2Effect_ArcthrowerStunned	    StunnedEffect;
-	local array<name>                       SkipExclusions;
-	local X2Condition_UnitType				ImmuneUnitCondition;
-	//local X2Effect_RemoveEffects			CleanUpEffect;
+	local X2AbilityToHitCalc_StandardAim	ToHitCalc;
+	local X2AbilityCost_ActionPoints		ActionPointCost;
+	local X2Effect_ArcthrowerStunned		StunnedEffect;
+	local array<name>						SkipExclusions;
 
 	// Macro to do localisation and stuffs
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'ArcthrowerStun');
 
 	// Icon Properties
-	Template.IconImage = "img:///UILibrary_LWOTC.LW_AbilityArcthrowerStun";  
+	Template.IconImage = "img:///UILibrary_LWOTC.LW_AbilityArcthrowerStun";
 	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.STANDARD_PISTOL_SHOT_PRIORITY;
 	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_AlwaysShow;
 	Template.DisplayTargetHitChance = true;
-	Template.AbilitySourceName = 'eAbilitySource_Perk';                                       // color of the icon
+	Template.AbilitySourceName = 'eAbilitySource_Perk'; // color of the icon
 
 	// Activated by a button press; additionally, tells the AI this is an activatable
 	Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
@@ -86,16 +84,11 @@ static function X2AbilityTemplate AddArcthrowerStun()
 	UnitPropertyCondition = new class'X2Condition_UnitProperty';
 	UnitPropertyCondition.ExcludeRobotic = true;
 	UnitPropertyCondition.ExcludeOrganic = false;
+	UnitPropertyCondition.FailOnNonUnits = true;
 	UnitPropertyCondition.ExcludeDead = true;
 	UnitPropertyCondition.ExcludeFriendlyToSource = true;
 	UnitPropertyCondition.RequireWithinRange = true;
 	Template.AbilityTargetConditions.AddItem(UnitPropertyCondition);
-	
-	ImmuneUnitCondition = new class'X2Condition_UnitType';
-	ImmuneUnitCondition.ExcludeTypes.AddItem('PsiZombie');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM2');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM3');
-	Template.AbilityTargetConditions.AddItem(ImmuneUnitCondition);
 
 	// Can't shoot while dead
 	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
@@ -107,14 +100,11 @@ static function X2AbilityTemplate AddArcthrowerStun()
 	ActionPointCost.iNumPoints = 1;
 	ActionPointCost.DoNotConsumeAllSoldierAbilities.AddItem('Unlimitedpower_LW');
 	ActionPointCost.bConsumeAllPoints = true;
-	Template.AbilityCosts.AddItem(ActionPointCost);	
+	Template.AbilityCosts.AddItem(ActionPointCost);
 
 	//Stun Effect
 	StunnedEffect = CreateArcthrowerStunnedStatusEffect(100);
 	Template.AddTargetEffect(StunnedEffect);
-
-	//CleanUpEffect = CreateStunnedEffectsCleanUpEffect();
-	//Template.AddTargetEffect(CleanUpEffect);
 
 	Template.AssociatedPassives.AddItem('Electroshock');
 	Template.AddTargetEffect(ElectroshockDisorientEffect());
@@ -125,7 +115,7 @@ static function X2AbilityTemplate AddArcthrowerStun()
 	ToHitCalc.bAllowCrit = false;
 	Template.AbilityToHitCalc = ToHitCalc;
 	Template.AbilityToHitOwnerOnMissCalc = ToHitCalc;
-			
+
 	// Targeting Method
 	Template.TargetingMethod = class'X2TargetingMethod_OverTheShoulder';
 	Template.bUsesFiringCamera = true;
@@ -134,16 +124,16 @@ static function X2AbilityTemplate AddArcthrowerStun()
 
 	// MAKE IT LIVE!
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
-	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;	
+	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
 	Template.BuildInterruptGameStateFn = TypicalAbility_BuildInterruptGameState;
-	
+
 	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
 	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
 	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotLostSpawnIncreasePerUse;
 
 	Template.AdditionalAbilities.AddItem('ArcthrowerPassive');
 
-	return Template;	
+	return Template;
 }
 
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_DefaultAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_DefaultAbilitySet.uc
@@ -20,6 +20,7 @@ static function array<X2DataTemplate> CreateTemplates()
 	Templates.AddItem(CreateReactionFireAgainstCoverBonus());
 	Templates.AddItem(CreateSmokeFlankingCritProtection());
 	Templates.AddItem(CreateFlashbangResistancePassive());
+	Templates.AddItem(PurePassive('PsiZombieImmunitiesPassive', , ,'eAbilitySource_Perk'));
 
 	return Templates;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_DefaultAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_DefaultAbilitySet.uc
@@ -21,6 +21,7 @@ static function array<X2DataTemplate> CreateTemplates()
 	Templates.AddItem(CreateSmokeFlankingCritProtection());
 	Templates.AddItem(CreateFlashbangResistancePassive());
 	Templates.AddItem(PurePassive('PsiZombieImmunitiesPassive', , ,'eAbilitySource_Perk'));
+	Templates.AddItem(PurePassive('SpectralZombieImmunitiesPassive', , ,'eAbilitySource_Perk'));
 
 	return Templates;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_TechnicalAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_TechnicalAbilitySet.uc
@@ -1679,21 +1679,19 @@ static function X2AbilityTemplate CreateHighPressureAbility()
 
 static function X2AbilityTemplate CreateConcussionRocketAbility()
 {
-	local X2AbilityTemplate						Template;
+	local X2AbilityTemplate					Template;
 	local X2AbilityCharges					Charges;
 	local X2AbilityCost_Charges				ChargeCost;
-	local X2AbilityCost_ActionPoints        ActionPointCost;
-	local X2AbilityTarget_Cursor            CursorTarget;
-	local X2AbilityMultiTarget_Radius       RadiusMultiTarget;
-	local X2AbilityToHitCalc_StandardAim    StandardAim;
+	local X2AbilityCost_ActionPoints		ActionPointCost;
+	local X2AbilityTarget_Cursor			CursorTarget;
+	local X2AbilityMultiTarget_Radius		RadiusMultiTarget;
+	local X2AbilityToHitCalc_StandardAim	StandardAim;
 	local X2Effect_PersistentStatChange		DisorientedEffect;
-	local X2Effect_ApplyWeaponDamage        WeaponDamageEffect;
-//	local X2Effect_SmokeGrenade				SmokeEffect;
-	local X2Effect_ApplySmokeGrenadeToWorld WeaponEffect;
+	local X2Effect_ApplyWeaponDamage		WeaponDamageEffect;
+	local X2Effect_ApplySmokeGrenadeToWorld	WeaponEffect;
 	local X2Effect_Stunned					StunnedEffect;
 	local X2Condition_UnitEffects			SuppressedCondition;
 	local X2Condition_UnitProperty			UnitPropertyCondition;
-	local X2Condition_UnitType				ImmuneUnitCondition;
 
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'ConcussionRocket');
 
@@ -1702,8 +1700,7 @@ static function X2AbilityTemplate CreateConcussionRocketAbility()
 	Template.IconImage = "img:///UILibrary_LWOTC.LW_AbilityConcussionRocket";
 	Template.bCrossClassEligible = false;
 	Template.Hostility = eHostility_Offensive;
-	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.CLASS_COLONEL_PRIORITY;
-	Template.bFriendlyFireWarning = false;
+	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.CLASS_SERGEANT_PRIORITY;
 
 	Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
 	Template.TargetingMethod = class'X2TargetingMethod_LWRocketLauncher';
@@ -1736,20 +1733,10 @@ static function X2AbilityTemplate CreateConcussionRocketAbility()
 	Template.AbilityCosts.AddItem(ChargeCost);
 
 	UnitPropertyCondition = new class'X2Condition_UnitProperty';
-	UnitPropertyCondition.ExcludeRobotic = true;
-	UnitPropertyCondition.ExcludeOrganic = false;
 	UnitPropertyCondition.ExcludeDead = true;
-	UnitPropertyCondition.ExcludeFriendlyToSource = true;
+	UnitPropertyCondition.ExcludeFriendlyToSource = false;
 	UnitPropertyCondition.RequireWithinRange = true;
-	Template.AbilityTargetConditions.AddItem (UnitPropertyCondition);
 	Template.AbilityMultiTargetConditions.AddItem(UnitPropertyCondition);
-
-	ImmuneUnitCondition = new class'X2Condition_UnitType';
-	ImmuneUnitCondition.ExcludeTypes.AddItem('PsiZombie');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM2');
-	ImmuneUnitCondition.ExcludeTypes.AddItem('AdvPsiWitchM3');
-	Template.AbilityTargetConditions.AddItem(ImmuneUnitCondition);
-	Template.AbilityMultiTargetConditions.AddItem(ImmuneUnitCondition);
 
 	RadiusMultiTarget = new class'X2AbilityMultiTarget_Radius';
 	RadiusMultiTarget.bUseWeaponRadius = false;
@@ -1758,34 +1745,34 @@ static function X2AbilityTemplate CreateConcussionRocketAbility()
 
 	WeaponDamageEffect = new class'X2Effect_ApplyWeaponDamage';
 	WeaponDamageEffect.bIgnoreBaseDamage = true;
-	WeaponDamageEffect.EffectDamageValue=default.CONCUSSION_ROCKET_DAMAGE_VALUE;
+	WeaponDamageEffect.EffectDamageValue = default.CONCUSSION_ROCKET_DAMAGE_VALUE;
 	WeaponDamageEffect.bExplosiveDamage = true;
 	WeaponDamageEffect.EnvironmentalDamageAmount=default.CONCUSSION_ROCKET_ENV_DAMAGE;
-	//Template.AddTargetEffect(WeaponDamageEffect);
 	Template.AddMultiTargetEffect(WeaponDamageEffect);
 
-	StunnedEffect = class'X2StatusEffects'.static.CreateStunnedStatusEffect(2,default.CONCUSSION_ROCKET_STUN_CHANCE,false);
+	StunnedEffect = class'X2StatusEffects'.static.CreateStunnedStatusEffect(2, default.CONCUSSION_ROCKET_STUN_CHANCE, false);
 	StunnedEffect.bRemoveWhenSourceDies = false;
-	if(default.USE_CONCUSSION_ROCKET_WILL_CALCS)
+	if (default.USE_CONCUSSION_ROCKET_WILL_CALCS)
+	{
 		StunnedEffect.ApplyChanceFn = ApplyChance_Concussion_Stunned;
-	//Template.AddTargetEffect(StunnedEffect);
+	}
 	Template.AddMultiTargetEffect(StunnedEffect);
 
-	DisorientedEffect = class'X2StatusEffects'.static.CreateDisorientedStatusEffect(, , false);
-	if(default.USE_CONCUSSION_ROCKET_WILL_CALCS)
+	DisorientedEffect = class'X2StatusEffects'.static.CreateDisorientedStatusEffect(, , true);
+	if (default.USE_CONCUSSION_ROCKET_WILL_CALCS)
+	{
 		DisorientedEffect.ApplyChanceFn = ApplyChance_Concussion_Disoriented;
-	//Template.AddTargetEffect(DisorientedEffect);
+	}
 	Template.AddMultiTargetEffect(DisorientedEffect);
 
-	if(default.ENABLE_CONCUSSION_ROCKET_SMOKE)
+	if (default.ENABLE_CONCUSSION_ROCKET_SMOKE)
 	{
 		WeaponEffect = new class'X2Effect_ApplySmokeGrenadeToWorld';
-		Template.AddMultiTargetEffect (WeaponEffect);
-
-		Template.AddMultiTargetEffect (class'X2Item_DefaultGrenades'.static.SmokeGrenadeEffect());
+		Template.AddMultiTargetEffect(WeaponEffect);
+		Template.AddMultiTargetEffect(class'X2Item_DefaultGrenades'.static.SmokeGrenadeEffect());
 	}
-	
-	Template.ActivationSpeech = 'Explosion';
+
+	Template.ActivationSpeech = 'RocketLauncher';
 	Template.CinescriptCameraType = "Soldier_HeavyWeapons";
 
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_TheLost_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_TheLost_LW.uc
@@ -8,11 +8,12 @@ class X2Ability_TheLost_LW extends X2Ability config(LW_SoldierSkills);
 
 static function array<X2DataTemplate> CreateTemplates()
 {
-    local array<X2DataTemplate> Templates;
-    
+	local array<X2DataTemplate> Templates;
+
 	Templates.AddItem(CreateLostBladestormAttack());
 	Templates.AddItem(CreateLostBladestorm());
 	Templates.AddItem(CreateBruteAcid());
+	Templates.AddItem(PurePassive('LostImmunitiesPassive', , ,'eAbilitySource_Perk'));
 	return Templates;
 }
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Character_TheLost_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Character_TheLost_LW.uc
@@ -35,7 +35,7 @@ static function array<X2DataTemplate> CreateTemplates()
 	Templates.AddItem(CreateTemplate_TheLostGrappler('TheLostGrapplerHP11_LW', 'TheLostGrapplerTier4_Loadout'));
 	Templates.AddItem(CreateTemplate_TheLostGrappler('TheLostGrapplerHP12_LW', 'TheLostGrapplerTier4_Loadout'));
 
-    return Templates;
+	return Templates;
 }
 
 static function X2CharacterTemplate CreateTemplate_TheLostGrappler(name LostName, name LoadoutName)
@@ -47,6 +47,8 @@ static function X2CharacterTemplate CreateTemplate_TheLostGrappler(name LostName
 	CharTemplate.strPawnArchetypes.Length = 0;
 	CharTemplate.strPawnArchetypes.AddItem("GameUnit_TheLost.ARC_GameUnit_TheLost_Howler");
 	CharTemplate.AIOrderPriority = 100;
+
+	CharTemplate.Abilities.AddItem('LostImmunitiesPassive');
 
 	return CharTemplate;
 }
@@ -68,6 +70,8 @@ static function X2CharacterTemplate CreateTemplate_TheLostBrute(name LostName, n
 	{
 		CharTemplate.strPawnArchetypes.AddItem("GameUnit_TheLost.ARC_GameUnit_TheLost_Howler");
 	}
+
+	CharTemplate.Abilities.AddItem('LostImmunitiesPassive');
 
 	return CharTemplate;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
@@ -3974,6 +3974,9 @@ static function bool AbilityTagExpandHandler(string InString, out string OutStri
 		case 'MULTI_TARGETING_COOLDOWN_LW':
 			OutString = string(class'X2Ability_LW_SharpshooterAbilitySet'.default.MULTI_TARGETING_COOLDOWN);
 			return true;
+		case 'CONCUSSION_ROCKET_STUN_CHANCE':
+			OutString = string(class'X2Ability_LW_TechnicalAbilitySet'.default.CONCUSSION_ROCKET_STUN_CHANCE);
+			return true;
 		case 'BURNOUT_RADIUS_LW':
 			OutString = Repl(string(class'X2Ability_LW_TechnicalAbilitySet'.default.BURNOUT_RADIUS), "0", "");
 			return true;

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
@@ -4222,6 +4222,12 @@ static function bool AbilityTagExpandHandler(string InString, out string OutStri
 		case 'CHAIN_LIGHTNING_AIM_MOD_LW':
 			Outstring = string(class'X2Ability_LW_AssaultAbilitySet'.default.CHAIN_LIGHTNING_AIM_MOD);
 			return true;
+		case 'CHAIN_LIGHTNING_TARGETS':
+			Outstring = string(class'X2Ability_LW_AssaultAbilitySet'.default.CHAIN_LIGHTNING_TARGETS);
+			return true;
+		case 'CHAIN_LIGHTNING_CHAIN_RANGE_TILES':
+			Outstring = string(int(`UNITSTOTILES(sqrt(class'X2AbilityMultiTarget_Volt'.default.DistanceBetweenTargets))));
+			return true;
 		case 'STUNGUNNER_BONUS_CV_LW':
 			Outstring = string(class'X2Effect_StunGunner'.default.STUNGUNNER_BONUS_CV);
 			return true;


### PR DESCRIPTION
* Arc Thrower, Arc Pulser, Chain Lightning and Disabling Shot can now target Psi Zombies and Avatars -- they're still immune though
* Modify Concussion Rocket to deal damage to everyone in the AoE, including robots and friendlies, and impair all organics
* List immunities in F1 for Psi Zombie, Spectral Zombie and The Lost

Updated localizations:
* Concussion Rocket
* Chain Lightning
* Disabling Shot
* Solace and Solace Aura
* Chosen Immunities

Updated soldier speeches:
* Concussion Rocket now uses `RocketLauncher` (was `Explosion`, which is unused)
* Disabling Shot now uses `StunTarget` (same as Arc Thrower's - was `Reaper`)