### PR TITLE
Allow Lightning Slash with last action

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.chn
+++ b/LongWarOfTheChosen/Localization/XComGame.chn
@@ -6391,6 +6391,14 @@ LocHelpText="使用<Ability:BOUND_WEAPON_NAME/>攻击蓝色移动范围内的任
 LocPromotionPopupText="<Bullet/> 使用<Ability:BOUND_WEAPON_NAME/>攻击蓝色移动范围内的任何敌人。<br/><Bullet/> 这次攻击不会结束回合。<br/><Bullet/> 闪电裂斩有<Ability:LIGHTNINGSLASH_COOLDOWN/>回合冷却时间。<br/>"
 ; End Translation (2)
 
+[LightningSlashLastAction_LW X2AbilityTemplate]
+LocFriendlyName="闪电裂斩"
+LocLongDescription="使用<Ability:BOUND_WEAPON_NAME/>攻击蓝色移动范围内的任何敌人不会结束回合。"
+LocHelpText="使用<Ability:BOUND_WEAPON_NAME/>攻击蓝色移动范围内的任何敌人不会结束回合。"
+; LWOTC Needs Translation (2)
+LocPromotionPopupText="<Bullet/> 使用<Ability:BOUND_WEAPON_NAME/>攻击蓝色移动范围内的任何敌人。<br/><Bullet/> 这次攻击不会结束回合。<br/><Bullet/> 闪电裂斩有<Ability:LIGHTNINGSLASH_COOLDOWN/>回合冷却时间。<br/>"
+; End Translation (2)
+
 [InspireAgility_LW X2AbilityTemplate]
 LocFriendlyName="灵感"
 LocFlyOverText="灵感"

--- a/LongWarOfTheChosen/Localization/XComGame.cht
+++ b/LongWarOfTheChosen/Localization/XComGame.cht
@@ -6339,6 +6339,14 @@ LocHelpText="使用<Ability:BOUND_WEAPON_NAME/>攻擊藍色移動範圍內的任
 LocPromotionPopupText="<Bullet/> 使用<Ability:BOUND_WEAPON_NAME/>攻擊藍色移動範圍內的任何敵人。<br/><Bullet/> 這次攻擊不會結束回合。<br/><Bullet/> 閃電裂斬有<Ability:LIGHTNINGSLASH_COOLDOWN/>回合冷卻時間。<br/>"
 ; End Translation (2)
 
+[LightningSlashLastAction_LW X2AbilityTemplate]
+LocFriendlyName="閃電裂斬"
+LocLongDescription="使用<Ability:BOUND_WEAPON_NAME/>攻擊藍色移動範圍內的任何敵人不會結束回合。"
+LocHelpText="使用<Ability:BOUND_WEAPON_NAME/>攻擊藍色移動範圍內的任何敵人不會結束回合。"
+; LWOTC Needs Translation (2)
+LocPromotionPopupText="<Bullet/> 使用<Ability:BOUND_WEAPON_NAME/>攻擊藍色移動範圍內的任何敵人。<br/><Bullet/> 這次攻擊不會結束回合。<br/><Bullet/> 閃電裂斬有<Ability:LIGHTNINGSLASH_COOLDOWN/>回合冷卻時間。<br/>"
+; End Translation (2)
+
 [InspireAgility_LW X2AbilityTemplate]
 LocFriendlyName="靈感"
 LocFlyOverText="靈感"

--- a/LongWarOfTheChosen/Localization/XComGame.deu
+++ b/LongWarOfTheChosen/Localization/XComGame.deu
@@ -5993,6 +5993,12 @@ LocLongDescription="Greife einen Feind innerhalb deiner blauen Bewegungsreichwei
 LocHelpText="Greife einen Feind innerhalb deiner blauen Bewegungsreichweite mit der Waffe \"<Ability:BOUND_WEAPON_NAME/>\" an. Beendet deine Runde nicht."
 LocPromotionPopupText="<Bullet/> Greife einen Feind innerhalb deiner blauen Bewegungsreichweite mit der Waffe \"<Ability:BOUND_WEAPON_NAME/>\" an.<br/><Bullet/> Der Angriff beendet deine Runde nicht.<br/><Bullet/> Blitzschneller Schlitzer hat eine Abklingzeit von <Ability:LIGHTNINGSLASH_COOLDOWN/> Runden.<br/>"
 
+[LightningSlashLastAction_LW X2AbilityTemplate]
+LocFriendlyName="Blitzschneller Schlitzer"
+LocLongDescription="Greife einen Feind innerhalb deiner blauen Bewegungsreichweite mit der Waffe \"<Ability:BOUND_WEAPON_NAME/>\" an. Der Angriff beendet deine Runde nicht."
+LocHelpText="Greife einen Feind innerhalb deiner blauen Bewegungsreichweite mit der Waffe \"<Ability:BOUND_WEAPON_NAME/>\" an. Beendet deine Runde nicht."
+LocPromotionPopupText="<Bullet/> Greife einen Feind innerhalb deiner blauen Bewegungsreichweite mit der Waffe \"<Ability:BOUND_WEAPON_NAME/>\" an.<br/><Bullet/> Der Angriff beendet deine Runde nicht.<br/><Bullet/> Blitzschneller Schlitzer hat eine Abklingzeit von <Ability:LIGHTNINGSLASH_COOLDOWN/> Runden.<br/>"
+
 [InspireAgility_LW X2AbilityTemplate]
 LocFriendlyName="Anspornen"
 LocFlyOverText="Anspornen"

--- a/LongWarOfTheChosen/Localization/XComGame.esn
+++ b/LongWarOfTheChosen/Localization/XComGame.esn
@@ -6488,6 +6488,14 @@ LocHelpText="Ataca a cualquier enemigo con tu <Ability:BOUND_WEAPON_NAME/> dentr
 LocPromotionPopupText="<Bullet/> Abalánzate sobre cualquier enemigo con tu <Ability:BOUND_WEAPON_NAME/> dentro del rango de movimiento visualizado en azul.<br/><Bullet/> Este ataque no termina el turno.<br/><Bullet/> Tiempo de enfriamiento de <Ability:LIGHTNINGSLASH_COOLDOWN/> turnos.<br/>"
 ; End translated
 
+[LightningSlashLastAction_LW X2AbilityTemplate]
+LocFriendlyName="Ataque relámpago"
+; LWOTC translated
+LocLongDescription="Ataca a cualquier enemigo con tu <Ability:BOUND_WEAPON_NAME/> dentro del rango de movimiento visualizado en azul. Este ataque no termina el turno."
+LocHelpText="Ataca a cualquier enemigo con tu <Ability:BOUND_WEAPON_NAME/> dentro del rango de movimiento visualizado en azul>. Este ataque no termina el turno."
+LocPromotionPopupText="<Bullet/> Abalánzate sobre cualquier enemigo con tu <Ability:BOUND_WEAPON_NAME/> dentro del rango de movimiento visualizado en azul.<br/><Bullet/> Este ataque no termina el turno.<br/><Bullet/> Tiempo de enfriamiento de <Ability:LIGHTNINGSLASH_COOLDOWN/> turnos.<br/>"
+; End translated
+
 [InspireAgility_LW X2AbilityTemplate]
 LocFriendlyName="Inspirar agilidad"
 LocFlyOverText="Inspirar agilidad"

--- a/LongWarOfTheChosen/Localization/XComGame.fra
+++ b/LongWarOfTheChosen/Localization/XComGame.fra
@@ -6374,6 +6374,14 @@ LocHelpText="Attaquez un ennemi à portée de déplacement bleu avec votre <Abil
 LocPromotionPopupText="<Bullet/> Attaquez un ennemi à portée de déplacement bleu avec votre <Ability:BOUND_WEAPON_NAME/>. Cette attaque ne met pas fin à votre tour.<br/> <Bullet/> Temps de rechargement de <Ability:LIGHTNINGSLASH_COOLDOWN/> tour(s).<br/>"
 ; End translated (3)
 
+[LightningSlashLastAction_LW X2AbilityTemplate]
+LocFriendlyName="Iaijutsu"
+; LWOTC translated (3)
+LocLongDescription="Attaquez un ennemi à portée de déplacement bleu avec votre <Ability:BOUND_WEAPON_NAME/>. Cette attaque ne met pas fin à votre tour."
+LocHelpText="Attaquez un ennemi à portée de déplacement bleu avec votre <Ability:BOUND_WEAPON_NAME/>. Cette attaque ne met pas fin à votre tour."
+LocPromotionPopupText="<Bullet/> Attaquez un ennemi à portée de déplacement bleu avec votre <Ability:BOUND_WEAPON_NAME/>. Cette attaque ne met pas fin à votre tour.<br/> <Bullet/> Temps de rechargement de <Ability:LIGHTNINGSLASH_COOLDOWN/> tour(s).<br/>"
+; End translated (3)
+
 [InspireAgility_LW X2AbilityTemplate]
 LocFriendlyName="Ange gardien"
 LocFlyOverText="Ange gardien"

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -6619,6 +6619,14 @@ LocHelpText="Attack any enemy within blue movement range with your <Ability:BOUN
 LocPromotionPopupText="<Bullet/> Attack any enemy within blue movement range with your <Ability:BOUND_WEAPON_NAME/>.<br/><Bullet/> This attack does not end the turn.<br/><Bullet/> Lightning Slash has a <Ability:LIGHTNINGSLASH_COOLDOWN/> turn cooldown.<br/>"
 ; End Translation (3)
 
+[LightningSlashLastAction_LW X2AbilityTemplate]
+LocFriendlyName="Lightning Slash"
+; LWOTC Needs Translation (3)
+LocLongDescription="Attack any enemy within blue movement range with your <Ability:BOUND_WEAPON_NAME/>. This attack does not end the turn."
+LocHelpText="Attack any enemy within blue movement range with your <Ability:BOUND_WEAPON_NAME/>. This attack does not end the turn."
+LocPromotionPopupText="<Bullet/> Attack any enemy within blue movement range with your <Ability:BOUND_WEAPON_NAME/>.<br/><Bullet/> This attack does not end the turn.<br/><Bullet/> Lightning Slash has a <Ability:LIGHTNINGSLASH_COOLDOWN/> turn cooldown.<br/>"
+; End Translation (3)
+
 [InspireAgility_LW X2AbilityTemplate]
 LocFriendlyName="Inspire Agility"
 LocFlyOverText="Inspire Agility"

--- a/LongWarOfTheChosen/Localization/XComGame.pol
+++ b/LongWarOfTheChosen/Localization/XComGame.pol
@@ -6055,6 +6055,12 @@ LocLongDescription="Zaatakuj dowolnego wroga w niebieskim zasięgu ruchu za pomo
 LocHelpText="Zaatakuj dowolnego wroga w niebieskim zasięgu ruchu za pomocą <Ability:BOUND_WEAPON_NAME/>. Atak nie kończy tury."
 LocPromotionPopupText="<Bullet/> Zaatakuj dowolnego wroga w niebieskim zasięgu ruchu za pomocą <Ability:BOUND_WEAPON_NAME/>.<br/><Bullet/> Atak nie kończy tury.<br/><Bullet/> Wymaga <Ability:LIGHTNINGSLASH_COOLDOWN/> tur(y) odnowienia.<br/>"
 
+[LightningSlashLastAction_LW X2AbilityTemplate]
+LocFriendlyName="Błyskawiczny cios"
+LocLongDescription="Zaatakuj dowolnego wroga w niebieskim zasięgu ruchu za pomocą <Ability:BOUND_WEAPON_NAME/>. Atak nie kończy tury."
+LocHelpText="Zaatakuj dowolnego wroga w niebieskim zasięgu ruchu za pomocą <Ability:BOUND_WEAPON_NAME/>. Atak nie kończy tury."
+LocPromotionPopupText="<Bullet/> Zaatakuj dowolnego wroga w niebieskim zasięgu ruchu za pomocą <Ability:BOUND_WEAPON_NAME/>.<br/><Bullet/> Atak nie kończy tury.<br/><Bullet/> Wymaga <Ability:LIGHTNINGSLASH_COOLDOWN/> tur(y) odnowienia.<br/>"
+
 [InspireAgility_LW X2AbilityTemplate]
 LocFriendlyName="Inspiruj zwinnością"
 LocFlyOverText="Inspiruj zwinnością"

--- a/LongWarOfTheChosen/Localization/XComGame.rus
+++ b/LongWarOfTheChosen/Localization/XComGame.rus
@@ -3420,6 +3420,12 @@ LocLongDescription="Атака по врагу в пределах одного 
 LocHelpText="Атака по врагу в пределах одного действия перемещения (оружие: <Ability:SecondaryWeaponName/>). Не заканчивает ход"
 LocPromotionPopupText="<Bullet/>Атака по врагу в пределах одного действия перемещения (оружие: <Ability:SecondaryWeaponName/>). Не заканчивает ход.<br/> <Bullet/>  <Ability:LIGHTNINGSLASH_COOLDOWN/> ходов перезарядки.<br/>"
 
+[LightningSlashLastAction_LW X2AbilityTemplate]
+LocFriendlyName="Молниеносный удар"
+LocLongDescription="Атака по врагу в пределах одного действия перемещения (оружие: <Ability:SecondaryWeaponName/>). Не заканчивает ход"
+LocHelpText="Атака по врагу в пределах одного действия перемещения (оружие: <Ability:SecondaryWeaponName/>). Не заканчивает ход"
+LocPromotionPopupText="<Bullet/>Атака по врагу в пределах одного действия перемещения (оружие: <Ability:SecondaryWeaponName/>). Не заканчивает ход.<br/> <Bullet/>  <Ability:LIGHTNINGSLASH_COOLDOWN/> ходов перезарядки.<br/>"
+
 [InspireAgility_LW X2AbilityTemplate]
 LocFriendlyName="Не зевай!"
 LocFlyOverText="Не зевай!"


### PR DESCRIPTION
Create a copy of Lightning Slash that's only usable with one action left, has no movement range modifier, and shares cooldown with the regular Lightning Slash. Basically the same as what was done to a couple of special shots to work with Snap Shot.