### PR TITLE
Normalize wound at end

### DIFF
--- a/LongWarOfTheChosen/Config/XComGameData.ini
+++ b/LongWarOfTheChosen/Config/XComGameData.ini
@@ -202,7 +202,7 @@ BuildFacilityProject_TimeScalar[3]=1.0 ;Impossible
 
 !WoundSeverities=()
 
-+WoundSeverities=(MinHealthPercent=-10000, MaxHealthPercent=09, MinPointsToHeal=45000, MaxPointsToHeal=55000, Difficulty=0) ;Easy
++WoundSeverities=(MinHealthPercent=-10000, MaxHealthPercent=09, MinPointsToHeal=45000, MaxPointsToHeal=50000, Difficulty=0) ;Easy
 +WoundSeverities=(MinHealthPercent=09, MaxHealthPercent=19, MinPointsToHeal=40000, MaxPointsToHeal=47500, Difficulty=0)
 +WoundSeverities=(MinHealthPercent=19, MaxHealthPercent=29, MinPointsToHeal=35000, MaxPointsToHeal=42500, Difficulty=0)
 +WoundSeverities=(MinHealthPercent=29, MaxHealthPercent=39, MinPointsToHeal=30000, MaxPointsToHeal=37500, Difficulty=0)
@@ -213,7 +213,7 @@ BuildFacilityProject_TimeScalar[3]=1.0 ;Impossible
 +WoundSeverities=(MinHealthPercent=79, MaxHealthPercent=89, MinPointsToHeal=5000, MaxPointsToHeal=12500, Difficulty=0)
 +WoundSeverities=(MinHealthPercent=89, MaxHealthPercent=10000, MinPointsToHeal=1000, MaxPointsToHeal=7500, Difficulty=0)
 
-+WoundSeverities=(MinHealthPercent=-10000, MaxHealthPercent=09, MinPointsToHeal=45000, MaxPointsToHeal=75000, Difficulty=1) ;Veteran
++WoundSeverities=(MinHealthPercent=-10000, MaxHealthPercent=09, MinPointsToHeal=45000, MaxPointsToHeal=52500, Difficulty=1) ;Veteran
 +WoundSeverities=(MinHealthPercent=09, MaxHealthPercent=19, MinPointsToHeal=40000, MaxPointsToHeal=47500, Difficulty=1)
 +WoundSeverities=(MinHealthPercent=19, MaxHealthPercent=29, MinPointsToHeal=35000, MaxPointsToHeal=42500, Difficulty=1)
 +WoundSeverities=(MinHealthPercent=29, MaxHealthPercent=39, MinPointsToHeal=30000, MaxPointsToHeal=37500, Difficulty=1)
@@ -224,7 +224,7 @@ BuildFacilityProject_TimeScalar[3]=1.0 ;Impossible
 +WoundSeverities=(MinHealthPercent=79, MaxHealthPercent=89, MinPointsToHeal=5000, MaxPointsToHeal=12500, Difficulty=1)
 +WoundSeverities=(MinHealthPercent=89, MaxHealthPercent=10000, MinPointsToHeal=1000, MaxPointsToHeal=7500, Difficulty=1)
 
-+WoundSeverities=(MinHealthPercent=-10000, MaxHealthPercent=09, MinPointsToHeal=45000, MaxPointsToHeal=75000, Difficulty=2) ;Commander
++WoundSeverities=(MinHealthPercent=-10000, MaxHealthPercent=09, MinPointsToHeal=45000, MaxPointsToHeal=52500, Difficulty=2) ;Commander
 +WoundSeverities=(MinHealthPercent=09, MaxHealthPercent=19, MinPointsToHeal=40000, MaxPointsToHeal=47500, Difficulty=2)
 +WoundSeverities=(MinHealthPercent=19, MaxHealthPercent=29, MinPointsToHeal=35000, MaxPointsToHeal=42500, Difficulty=2)
 +WoundSeverities=(MinHealthPercent=29, MaxHealthPercent=39, MinPointsToHeal=30000, MaxPointsToHeal=37500, Difficulty=2)
@@ -235,7 +235,7 @@ BuildFacilityProject_TimeScalar[3]=1.0 ;Impossible
 +WoundSeverities=(MinHealthPercent=79, MaxHealthPercent=89, MinPointsToHeal=5000, MaxPointsToHeal=12500, Difficulty=2)
 +WoundSeverities=(MinHealthPercent=89, MaxHealthPercent=10000, MinPointsToHeal=1000, MaxPointsToHeal=7500, Difficulty=2)
 
-+WoundSeverities=(MinHealthPercent=-10000, MaxHealthPercent=09, MinPointsToHeal=45000, MaxPointsToHeal=75000, Difficulty=3) ;Legend
++WoundSeverities=(MinHealthPercent=-10000, MaxHealthPercent=09, MinPointsToHeal=45000, MaxPointsToHeal=52500, Difficulty=3) ;Legend
 +WoundSeverities=(MinHealthPercent=09, MaxHealthPercent=19, MinPointsToHeal=40000, MaxPointsToHeal=47500, Difficulty=3)
 +WoundSeverities=(MinHealthPercent=19, MaxHealthPercent=29, MinPointsToHeal=35000, MaxPointsToHeal=42500, Difficulty=3)
 +WoundSeverities=(MinHealthPercent=29, MaxHealthPercent=39, MinPointsToHeal=30000, MaxPointsToHeal=37500, Difficulty=3)


### PR DESCRIPTION
the last 10% of wound time setting has a range of 30k to heal vs the other intervals which have a standard of a 7.5k range. Most soldier's will never reach this interval and for those that do can end up with unnecessarily long wounds if they get gravely wounded and makes it up in the air to RNG which isn't great. This can also in a sense make more HP worse if you do get to this wound interval which is counterpoint to having more HP that should be making them more overall healthier than those with low HP. 

This change sets it so that the range is 7.5k like the rest of the wound settings dropping the max wound healing time to be 52.5k (except for rookie which is set to still be lower than other difficulties).