### PR TITLE
Nerf unholyascension

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -6981,8 +6981,8 @@ LocFlyOverText="Blood Thirst"
 ; LWOTC Needs Translation (2)
 [UnholyAscension_LW X2AbilityTemplate]
 LocFriendlyName="Unholy Ascension"
-LocLongDescription="Warlock's Greatest Champion's Shield, Aim, Crit, Will, and Psi Offense bonuses are doubled and grant crit immunity."
-LocHelpText="Warlock's Greatest Champion's Shield, Aim, Crit, Will, and Psi Offense bonuses are doubled and grant crit immunity."
+LocLongDescription="Warlock's Greatest Champion's Aim, Crit, Will, and Psi Offense bonuses are doubled and grant crit immunity."
+LocHelpText="Warlock's Greatest Champion's Aim, Crit, Will, and Psi Offense bonuses are doubled and grant crit immunity."
 LocFlyOverText="Unholy Ascension"
 
 [RuptureImmunity X2AbilityTemplate]

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_ChosenAbilities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_ChosenAbilities.uc
@@ -526,7 +526,7 @@ static function X2AbilityTemplate CreateShieldAlly(name Templatename, int Shield
 	Template.AddTargetEffect(StatBuffsEffect);
 
 
-	ShieldedEffect = CreateShieldedEffect(Template.LocFriendlyName, Template.GetMyLongDescription(), int(ShieldAmount * default.UNHOLY_ASCENSION_MOD));
+	ShieldedEffect = CreateShieldedEffect(Template.LocFriendlyName, Template.GetMyLongDescription(), ShieldAmount);
 	ShieldedEffect.TargetConditions.AddItem(AbilityCondition);
 	Template.AddTargetEffect(ShieldedEffect);
 


### PR DESCRIPTION
it no longer grants bonus shields, the extra shields was a lot of extra effective hp added to the chosen that was re-usable so it felt unfair