### PR TITLE
Multiple localization edits

### DIFF
--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -366,7 +366,7 @@ LocFriendlyName="Rapid Reaction"
 LocFlyOverText="Rapid Reaction"
 LocLongDescription="When in overwatch, each shot you hit with grants another reaction fire shot, up to a maximum of three shots."
 LocHelpText="When in overwatch, each shot you hit with grants another shot, up to a maximum of three shots."
-LocPromotionPopupText="<Bullet/> When in overwatch, each shot you hit with grants another reaction fire shot, up to a maximum of three shots.<br/>"
+LocPromotionPopupText=""
 
 [LightningReflexes_LW X2AbilityTemplate]
 LocFriendlyName="Lightning Reflexes"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -171,7 +171,7 @@ LocFriendlyName="Hard Target"
 LocFlyOverText="Hard Target"
 LocLongDescription="Gain 5 dodge per enemy you can see, up to a maximum of +30."
 LocHelpText="Gain 5 dodge per enemy you can see, up to a maximum of +30."
-LocPromotionPopupText="<Bullet/> Gain 5 dodge per enemy you can see, up to a maximum of +30.<br/><Bullet/> Units visible at squadsight ranges do not confer bonus.<br/><Bullet/> This ability does not provide defensive bonuses if the unit is disoriented, stunned, panicking, on fire or otherwise impaired."
+LocPromotionPopupText="<Bullet/> Units visible at squadsight ranges do not confer bonus.<br/><Bullet/> This ability does not provide defensive bonuses if the unit is disoriented, stunned, panicking, on fire or otherwise impaired."
 
 ; LWOTC Needs Translation (2)
 [Infighter X2AbilityTemplate]

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -118,7 +118,7 @@ LocFriendlyName="Close and Personal"
 LocFlyOverText="Close and Personal"
 LocLongDescription="Confers +30 critical chance against adjacent targets. The bonus declines with distance from the target."
 LocHelpText="Confers +30 critical chance against adjacent targets. The bonus declines with distance from the target."
-LocPromotionPopupText="<Bullet/> Confers +30 critical chance against adjacent targets.<br/><Bullet/> Bonus reduced by 5% for each additional tile of distance from the target, down to 0% at 7 or more tiles.<br/>"
+LocPromotionPopupText="<Bullet/> Bonus reduced by 5% for each additional tile of distance from the target, down to 0% at 7 or more tiles.<br/>"
 
 [DamnGoodGround X2AbilityTemplate]
 LocFriendlyName="Damn Good Ground"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -1143,7 +1143,7 @@ LocFriendlyName="Cool Under Pressure"
 LocLongDescription="You gain +<Ability:COOLUNDERPRESSUREBONUS/> Aim on Overwatch and other reaction shots, and they can critically hit."
 LocHelpText="Bonus aim and chance to crit on Overwatch and reaction shots."
 LocFlyOverText="Cool Under Pressure"
-LocPromotionPopupText="<Bullet/> You gain +<Ability:COOLUNDERPRESSUREBONUS/> Aim on Overwatch and other reaction shots, and they can critically hit.<br/>
+LocPromotionPopupText=""
 
 [BiggestBooms X2AbilityTemplate]
 LocFriendlyName="Biggest Booms"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -133,7 +133,7 @@ LocFlyOverText="Executioner"
 ; LWOTC Needs Translation
 LocLongDescription="Confers +<Ability:EXECUTIONER_AIM_BONUS/> aim and +<Ability:EXECUTIONER_CRIT_BONUS/> critical chance against targets at half or less of their original hit points."
 LocHelpText="Confers +<Ability:EXECUTIONER_AIM_BONUS/> aim and +<Ability:EXECUTIONER_CRIT_BONUS/> critical chance against targets at half or less of their original hit points."
-LocPromotionPopupText="<Bullet/> Confers +<Ability:EXECUTIONER_CRIT_BONUS/> aim and +<Ability:EXECUTIONER_CRIT_BONUS/> critical chance against targets at half or less of their original hit points.<br/>"
+LocPromotionPopupText=""
 ; End Translation
 
 [Resilience X2AbilityTemplate]

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -155,7 +155,7 @@ LocFriendlyName="Aggression"
 LocFlyOverText="Aggression"
 LocLongDescription="Gain +5 critical chance for each enemy you can see, up to a maximum of 30."
 LocHelpText="Gain +5 critical chance for each enemy you can see, up to a maximum of 30."
-LocPromotionPopupText="<Bullet/> Gain +5 critical chance for each enemy you can see, up to a maximum of 30.<br/><Bullet/> Units visible at squadsight ranges do confer bonus.<br/>"
+LocPromotionPopupText="<Bullet/> Units visible at squadsight ranges do confer bonus.<br/>"
 
 [BringEmOn X2AbilityTemplate]
 LocFriendlyName="Bring 'Em On"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -179,7 +179,7 @@ LocFriendlyName="Infighter"
 LocFlyOverText="Infighter"
 LocLongDescription="Gain <Ability:INFIGHTER_DODGE_BONUS/> Dodge against attacks within four tiles."
 LocHelpText="Gain <Ability:INFIGHTER_DODGE_BONUS/> Dodge against attacks within four tiles."
-LocPromotionPopupText="<Bullet/> Gain <Ability:INFIGHTER_DODGE_BONUS/> Dodge against attacks within four tiles.<br/><Bullet/> Dodge bonus also applies to melee attacks.<br/><Bullet/> This ability does not provide defensive bonuses if the unit is disoriented, stunned, panicking or otherwise impaired.<br/><Bullet/> Burning does not affect this ability."
+LocPromotionPopupText="<Bullet/> Dodge bonus also applies to melee attacks.<br/><Bullet/> This ability does not provide defensive bonuses if the unit is disoriented, stunned, panicking or otherwise impaired.<br/><Bullet/> Burning does not affect this ability."
 ; End Translation (2)
 
 [DepthPerception X2AbilityTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -6424,7 +6424,7 @@ LocFlyOverText="Lock 'N Load"
 ; LWOTC Needs Translation (2)
 LocLongDescription="Kills with your <Ability:BOUND_WEAPON_NAME/> restore <Ability:LOCKNLOAD_AMMO_TO_RELOAD/> ammo."
 LocHelpText="Kills with your <Ability:BOUND_WEAPON_NAME/> restore <Ability:LOCKNLOAD_AMMO_TO_RELOAD/> ammo."
-LocPromotionPopupText="<Bullet/> Kills with your <Ability:BOUND_WEAPON_NAME/> restore <Ability:LOCKNLOAD_AMMO_TO_RELOAD/> ammo.<br/>"
+LocPromotionPopupText=""
 ; End Translation (2)
 
 [TrenchWarfare_LW X2AbilityTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -7588,7 +7588,7 @@ LocFriendlyName="Paramedic"
 LocLongDescription="Unlocks an ability to perform a dash move to use a medikit on an ally. Gain a free medikit. Equipped medikits have <Ability:PARAMEDIC_BONUS_CHARGES/> extra charges."
 LocHelpText="Unlocks an ability to perform a dash move to use a medikit on an ally. Gain a free medikit. Equipped medikits have <Ability:PARAMEDIC_BONUS_CHARGES/> extra charges."
 ; LWOTC Needs Translation (2)
-LocPromotionPopupText="<Bullet/> "Unlocks an ability to perform a dash move to use a medikit on an ally. Gain a free medikit. Equipped medikits have <Ability:PARAMEDIC_BONUS_CHARGES/> extra charges."
+LocPromotionPopupText="<Bullet/> This ability uses 1 action regardless of distance moved and does not end your turn.<br/><Bullet/> Only a single medikit charge is provided by this ability.<br/>"
 ; End Translation (2)
 [ParaMedikitHeal X2AbilityTemplate]
 LocFriendlyName="Paramedic Heal"
@@ -7599,7 +7599,7 @@ LocHelpText="Run towards an Ally and heal them with your medikit."
 [ParaMedikitStabilize X2AbilityTemplate]
 LocFriendlyName="Paramedic Stabilize"
 LocLongDescription="Run towards an Ally and stabilize them with your medikit."
-LocHelpText="Run towards an Ally and heal stabilize with your medikit."
+LocHelpText="Run towards an Ally and stabilize with your medikit."
 
 [SoulReaper X2AbilityTemplate]
 LocFriendlyName="Banish"

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -6456,7 +6456,7 @@ LocFlyOverText="Open Fire"
 LocLongDescription="Your ranged attacks gain <Ability:+ToHit/> Aim and <Ability:+Crit/> Crit against targets that are at full health."
 LocHelpText="Your ranged attacks gain <Ability:+ToHit/> Aim and <Ability:+Crit/> Crit against targets that are at full health."
 ; LWOTC Needs Translation (2)
-LocPromotionPopupText="<Bullet/> Your ranged attacks gain <Ability:+ToHit/> Aim and <Ability:+Crit/> Crit against targets that are at full health.<br/>"
+LocPromotionPopupText=""
 ; End Translation (2)
 
 [WatchThemRun_LW X2AbilityTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -6564,7 +6564,7 @@ LocFriendlyName="Scrap Metal"
 LocFlyOverText="Scrap Metal: Recovered ammo"
 LocLongDescription="Kills with your <Ability:BOUND_WEAPON_NAME/> restore one sawed-off shotgun charge."
 LocHelpText="Kills with your <Ability:BOUND_WEAPON_NAME/> restore one sawed-off shotgun charge."
-LocPromotionPopupText="<Bullet/> Kills with your <Ability:BOUND_WEAPON_NAME/> restore one sawed-off shotgun charge.<br/><Bullet/> This does not apply to kills from using the sawed-off shotgun itself.<br/><Bullet/> This ability cannot grant ammo if the sawed-off shotgun charges are already at their starting value.<br/>"
+LocPromotionPopupText="<Bullet/> This does not apply to kills from using the sawed-off shotgun itself.<br/><Bullet/> With this ability, you can gain more sawed-off shotgun charges than you started with.<br/>"
 
 [ScrapMetalTrigger_LW X2AbilityTemplate]
 LocFriendlyName="Scrap Metal: Recovered ammo"

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -649,8 +649,8 @@ LocPromotionPopUpText="<Bullet/> Activate to grant the soldier +<ABILITY:FORTIFY
 [CombatFitness X2AbilityTemplate]
 LocFriendlyName="Combat Fitness"
 LocLongDescription="Gain <ABILITY:COMBAT_FITNESS_OFFENSE_LW/> aim, <ABILITY:COMBAT_FITNESS_MOBILITY_LW/> mobility, <ABILITY:COMBAT_FITNESS_HP_LW/> HP, <ABILITY:COMBAT_FITNESS_WILL_LW/> will, and <ABILITY:COMBAT_FITNESS_DODGE_LW/> dodge."
-LocHelpText="This soldier has numerous stat bonuses."
-LocPromotionPopUpText="<Bullet/> Combat Fitness provides <ABILITY:COMBAT_FITNESS_OFFENSE_LW/> aim, <ABILITY:COMBAT_FITNESS_MOBILITY_LW/> mobility, <ABILITY:COMBAT_FITNESS_HP_LW/> HP, <ABILITY:COMBAT_FITNESS_WILL_LW/> will, and <ABILITY:COMBAT_FITNESS_DODGE_LW/> dodge."
+LocHelpText="<Bullet/> Combat Fitness provides <ABILITY:COMBAT_FITNESS_OFFENSE_LW/> aim, <ABILITY:COMBAT_FITNESS_MOBILITY_LW/> mobility, <ABILITY:COMBAT_FITNESS_HP_LW/> HP, <ABILITY:COMBAT_FITNESS_WILL_LW/> will, and <ABILITY:COMBAT_FITNESS_DODGE_LW/> dodge."
+LocPromotionPopUpText=""
 
 [Sprinter X2AbilityTemplate]
 LocFriendlyName="Sprinter"


### PR DESCRIPTION
Multiple localization edits, mostly reducing redundant text in promotion popups, but also mechanic corrections and typo fixes.

Affected perks:
* Hard Target
* Infighter
* Aggression
* Cool Under Pressure
* Scrap Metal
* Rapid Reaction
* Lock 'n Load
* Paramedic
* Executioner
* Open Fire
* Combat Fitness
* Close and Personal