### PR TITLE
Remove CHL submodule and corresponding line in `build.ps1`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "X2WOTCCommunityHighlander"]
-	path = X2WOTCCommunityHighlander
-	url = https://github.com/long-war-2/X2WOTCCommunityHighlander.git
-	branch = lwotc-dev

--- a/.scripts/build.ps1
+++ b/.scripts/build.ps1
@@ -24,7 +24,7 @@ switch ($config)
     default { ThrowFailure "Unknown build configuration $config" }
 }
 
-$builder.IncludeSrc("$srcDirectory\X2WOTCCommunityHighlander\X2WOTCCommunityHighlander\Src")
+# $builder.IncludeSrc("$srcDirectory\X2WOTCCommunityHighlander\X2WOTCCommunityHighlander\Src")
 $builder.IncludeSrc("$srcDirectory\BetterSecondWaveSupport\Src")
 $builder.AddToClean("BetterSecondWaveSupport")
 $builder.SetContentOptionsJsonFilename("ContentOptions.json")


### PR DESCRIPTION
⚠️ Mostly untested change, test PR locally before merging ⚠️ 

The PR removes the very outdated CHL submodule, which shouldn't have any part in the build process - yet it did build for me, interfering with the up-to-date CHL in SDK's `SrcOrig`. Also removes the line in `build.ps1` that refers to the now nonexistent directory.

Consider also updating the steps referring to CHL in README's build instructions.