### PR TITLE
Use the local value of MT_DEFENSE and MT_DODGE in X2Effect_MovingTarget

### DIFF
--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_MovingTarget_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_MovingTarget_LW.uc
@@ -17,12 +17,12 @@ function GetToHitAsTargetModifiers(XComGameState_Effect EffectState, XComGameSta
 
 			ShotInfo.ModType = eHit_Success;
 			ShotInfo.Reason = FriendlyName;
-			ShotInfo.Value = -default.MT_DEFENSE;
+			ShotInfo.Value = -MT_DEFENSE;
 			ShotModifiers.AddItem(ShotInfo);
 
             ShotInfo.ModType = eHit_Graze;
 			ShotInfo.Reason = FriendlyName;
-			ShotInfo.Value = default.MT_DODGE;
+			ShotInfo.Value = MT_DODGE;
 			ShotModifiers.AddItem(ShotInfo);
 		}
 	}


### PR DESCRIPTION
The recent fix to Moving Target accidentally set the defense and dodge values to 0.

MT_DEFENSE and MT_DODGE were changed from config variables to simple instance variables in 0ef85b2db, so the default property value of these variables is zero.