### PR TITLE
Fix broken ShotHUD by disabling shotwings from PI_INTEGRATED

### DIFF
--- a/LongWarOfTheChosen/Src/PI_Integrated/Classes/XCom_Perfect_Information_UIScreenListener.uc
+++ b/LongWarOfTheChosen/Src/PI_Integrated/Classes/XCom_Perfect_Information_UIScreenListener.uc
@@ -20,10 +20,13 @@ event OnInit(UIScreen Screen)
 
 	if (MyScreen.m_kShotInfoWings.Class == class'UITacticalHUD_ShotWings')
 	{
-		MyScreen.m_kShotInfoWings.Remove();
-		MyScreen.m_kShotInfoWings = MyScreen.Spawn(class'XCom_Perfect_Information_UITacticalHUD_ShotWings', MyScreen).InitShotWings();
+		// Use existing shotwings
+		MyScreen.m_kShotInfoWings.InitShotWings();
 
 		// LWOTC: These are currently disabled because they don't work properly/well
+		// MyScreen.m_kShotInfoWings.Remove();
+		// MyScreen.m_kShotInfoWings = MyScreen.Spawn(class'XCom_Perfect_Information_UITacticalHUD_ShotWings', MyScreen).InitShotWings();
+
 		// MyScreen.m_kTooltips.Remove();
 		// MyScreen.m_kTooltips = MyScreen.Spawn(class'XCom_Perfect_Information_UITacticalHUD_Tooltips', MyScreen).InitTooltips();
 		


### PR DESCRIPTION
The damage breakdown in the ShotHUD wings is missing and has been missing since WOTC.

We cannot delete the PI_Integrated mod because it contains a copy of Grimy's shot bar code that shows crit/graze breakdown, but we can at least restore the damage breakdown for the user by using the default shotwings object.

Current LWOTC shotwings with missing damage breakdown:
![lwotc-shotwings](https://github.com/user-attachments/assets/38d9cc25-7c4c-493e-9225-1fc413843077)

LWOTC with default shotwings object (this PR):
![lwotc-with-default-shotwings](https://github.com/user-attachments/assets/b72ce91c-8bb9-4cd9-82bd-abbe18cd4926)

For comparison, here is the regular shothud:
![wotc-shotwings](https://github.com/user-attachments/assets/82f96d41-8430-4f87-aa81-3b4198616640)

And LWOTC + [WOTC] Extended Information:
![lwotc-with-extended-information](https://github.com/user-attachments/assets/197a5c20-7fab-4fc2-881f-10168093d1f8)
