### PR TITLE
Fix crash on Linux on killing a Chosen

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_ChosenLoot.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_ChosenLoot.uc
@@ -32,9 +32,15 @@ static function EventListenerReturn ScavengerAutoLoot(Object EventData, Object E
 		return ELR_NoInterrupt;
 	}
 
-    
     if(DeadUnit.IsChosen())	
     {
+		EffectState = XComGameState_Effect_EffectCounter(CallbackData);
+		if (EffectState == none)
+		{
+			`RedScreen("Chosen Loot Check: no effect game state");
+			return ELR_NoInterrupt;
+		}
+
         NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState(string(GetFuncName()));
         EffectState = XComGameState_Effect_EffectCounter(NewGameState.ModifyStateObject(EffectState.Class, EffectState.ObjectID));
         PutChosenLoot(NewGameState, EffectState, DeadUnit);


### PR DESCRIPTION
Use of an uninitialized variable. We can make guesses about why this crashes on Linux and not on Windows, but this is a code error on Windows as well.

Fixes https://github.com/long-war-2/lwotc/issues/1624