### PR TITLE
RewardTemplates being modified after OPTC

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
@@ -274,7 +274,6 @@ static event OnPostTemplatesCreated()
 	EditModdedRocketAbilities();
 	UpdateSkulljackAllShooterEffectExclusions();
 	class'X2Ability_PerkPackAbilitySet2'.static.AddEffectsToGrenades();
-	//moved from X2DLCI_LWToolbox as it doesn't need to run later than this -styr
 	class'XComGameState_LWToolboxOptions'.static.UpdateRewardSoldierTemplates();
 }
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
@@ -274,6 +274,8 @@ static event OnPostTemplatesCreated()
 	EditModdedRocketAbilities();
 	UpdateSkulljackAllShooterEffectExclusions();
 	class'X2Ability_PerkPackAbilitySet2'.static.AddEffectsToGrenades();
+	//moved from X2DLCI_LWToolbox as it doesn't need to run later than this -styr
+	class'XComGameState_LWToolboxOptions'.static.UpdateRewardSoldierTemplates();
 }
 
 // Borrowed from Xynamek / Prototype Armory code

--- a/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/X2DownloadableContentInfo_LWToolbox.uc
+++ b/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/X2DownloadableContentInfo_LWToolbox.uc
@@ -94,8 +94,6 @@ static event OnLoadedSavedGameToStrategy()
 
 	ToolboxOptions.RegisterListeners();
 	ToolboxOptions.UpdateWeaponTemplates_RandomizedDamage();
-	//This is a static function, it should probably run at OPTC instead of at runtime - styr
-	//ToolboxOptions.UpdateRewardSoldierTemplates();
 
 	PatchupMissingPCSStats();
 

--- a/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/X2DownloadableContentInfo_LWToolbox.uc
+++ b/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/X2DownloadableContentInfo_LWToolbox.uc
@@ -94,7 +94,8 @@ static event OnLoadedSavedGameToStrategy()
 
 	ToolboxOptions.RegisterListeners();
 	ToolboxOptions.UpdateWeaponTemplates_RandomizedDamage();
-	ToolboxOptions.UpdateRewardSoldierTemplates();
+	//This is a static function, it should probably run at OPTC instead of at runtime - styr
+	//ToolboxOptions.UpdateRewardSoldierTemplates();
 
 	PatchupMissingPCSStats();
 

--- a/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/X2DownloadableContentInfo_LWToolbox.uc
+++ b/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/X2DownloadableContentInfo_LWToolbox.uc
@@ -101,6 +101,34 @@ static event OnLoadedSavedGameToStrategy()
 		`XCOMHISTORY.RegisterOnNewGameStateDelegate(ToolboxOptions.OnNewGameState_RankWatcher);
 }
 
+//Code copied over from the UITacticalHUD UISL
+//Now that this CHL hook exists it's possible to get rid of the UISL entirely
+static event OnLoadedSavedGameToTactical()
+{
+	local XComGameState_LWToolboxOptions ToolboxOptions;
+
+	//same setup as OnLoadedSavedGameToStrategy
+	ToolboxOptions = class'XComGameState_LWToolboxOptions'.static.GetToolboxOptions();
+	if (ToolboxOptions == none) { ToolboxOptions = XComGameState_LWToolboxOptions(class'XComGameState_LWToolboxOptions'.static.CreateModSettingsState_ExistingCampaign(class'XComGameState_LWToolboxOptions')); }
+
+	if (ToolboxOptions == none)
+	{
+		`REDSCREEN("Toolbox OnLoadedSavedGameToTactical : Unable to find or create ToolboxOptions");
+		return;
+	}
+
+	ToolboxOptions.RegisterListeners();
+	ToolboxOptions.UpdateWeaponTemplates_RandomizedDamage();
+	PatchupMissingPCSStats();
+
+	if(ToolboxOptions.bRandomizedLevelupStatsEnabled)
+		`XCOMHISTORY.RegisterOnNewGameStateDelegate(ToolboxOptions.OnNewGameState_RankWatcher);
+
+	//re-register the hit point observer if necessary
+	if(ToolboxOptions.bRedFogXComActive || ToolboxOptions.bRedFogAliensActive)
+		`XCOMHISTORY.RegisterOnNewGameStateDelegate(ToolboxOptions.OnNewGameState_HealthWatcher);
+}
+
 /// <summary>
 /// Called when the player completes a mission while this DLC / Mod is installed.
 /// </summary>

--- a/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/X2DownloadableContentInfo_LWToolbox.uc
+++ b/LongWarOfTheChosen/Src/LW_Toolbox_Integrated/Classes/X2DownloadableContentInfo_LWToolbox.uc
@@ -4,9 +4,9 @@
 //  PURPOSE: Initializes Toolbox mod settings on campaign start or when loading campaign without mod previously active
 //--------------------------------------------------------------------------------------- 
 
-class X2DownloadableContentInfo_LWToolbox extends X2DownloadableContentInfo config(LW_Toolbox);	
+class X2DownloadableContentInfo_LWToolbox extends X2DownloadableContentInfo;	
 
-//
+//switched the config file to the only variable, as it left this X2DLCI without a DLCIdentifier
 
 struct DefaultBaseDamageEntry
 {
@@ -15,7 +15,7 @@ struct DefaultBaseDamageEntry
 };
 var transient array<DefaultBaseDamageEntry> arrDefaultBaseDamage;
 
-var config bool bRandomizedInitialStatsEnabledAtStart;
+var config(LW_Toolbox) bool bRandomizedInitialStatsEnabledAtStart;
 
 static function X2DownloadableContentInfo_LWToolbox GetThisDLCInfo()
 {


### PR DESCRIPTION
Some of the template modifications made by LW_Toolbox run at OnLoadedSavedGameToStrategy because it requires some settings recorded to its XGS. The modification of RewardTemplates is implemented in a static function that doesn't refer to the XGS and should probably be moved to OPTC. I'll hopefully be moving it to the proper time so other mods can overwrite it with the proper CHL run order. Fixes Issue #1807 