### PR TITLE
Remove weapon check for Aggression and Executioner

### DIFF
--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Aggression.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Aggression.uc
@@ -12,28 +12,28 @@ var config bool AGG_SQUADSIGHT_ENEMIES_APPLY;
 
 function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit Attacker, XComGameState_Unit Target, XComGameState_Ability AbilityState, class<X2AbilityToHitCalc> ToHitType, bool bMelee, bool bFlanking, bool bIndirectFire, out array<ShotModifierInfo> ShotModifiers)
 {
-    local XComGameState_Item	SourceWeapon;
-    local ShotModifierInfo		ShotInfo;
-	local int					BadGuys;
-	local array<StateObjectReference> arrSSEnemies;
+    // local XComGameState_Item SourceWeapon;
+    local ShotModifierInfo      ShotInfo;
+    local int                   BadGuys;
+    local array<StateObjectReference> arrSSEnemies;
 
-    SourceWeapon = AbilityState.GetSourceWeapon();    
-    if(SourceWeapon != none)	
-	{
-		BadGuys = Attacker.GetNumVisibleEnemyUnits (true, false, false, -1, false, false);
-		if (Attacker.HasSquadsight() && default.AGG_SQUADSIGHT_ENEMIES_APPLY)
-		{
-			class'X2TacticalVisibilityHelpers'.static.GetAllSquadsightEnemiesForUnit(Attacker.ObjectID, arrSSEnemies, -1, false);
-			BadGuys += arrSSEnemies.length;
-		}
-		if (BadGuys > 0)
-		{
-			ShotInfo.ModType = eHit_Crit;
-			ShotInfo.Reason = FriendlyName;
-			ShotInfo.Value = Clamp (BadGuys * default.AGGRESSION_CRIT_BONUS_PER_ENEMY, 0, default.AGGRESSION_MAX_CRIT_BONUS);
-			ShotModifiers.AddItem(ShotInfo);
-		}
-	}
+    // SourceWeapon = AbilityState.GetSourceWeapon();
+    // if(SourceWeapon != none)
+    // {
+    BadGuys = Attacker.GetNumVisibleEnemyUnits (true, false, false, -1, false, false);
+    if (Attacker.HasSquadsight() && default.AGG_SQUADSIGHT_ENEMIES_APPLY)
+    {
+        class'X2TacticalVisibilityHelpers'.static.GetAllSquadsightEnemiesForUnit(Attacker.ObjectID, arrSSEnemies, -1, false);
+        BadGuys += arrSSEnemies.length;
+    }
+    if (BadGuys > 0)
+    {
+        ShotInfo.ModType = eHit_Crit;
+        ShotInfo.Reason = FriendlyName;
+        ShotInfo.Value = Clamp (BadGuys * default.AGGRESSION_CRIT_BONUS_PER_ENEMY, 0, default.AGGRESSION_MAX_CRIT_BONUS);
+        ShotModifiers.AddItem(ShotInfo);
+    }
+    // }
 }
 
 defaultproperties

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Executioner_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Executioner_LW.uc
@@ -11,22 +11,23 @@ var config int EXECUTIONER_CRIT_BONUS;
 
 function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit Attacker, XComGameState_Unit Target, XComGameState_Ability AbilityState, class<X2AbilityToHitCalc> ToHitType, bool bMelee, bool bFlanking, bool bIndirectFire, out array<ShotModifierInfo> ShotModifiers)
 {
-    local XComGameState_Item SourceWeapon;
+    // local XComGameState_Item SourceWeapon;
     local ShotModifierInfo ShotInfo;
 
-    SourceWeapon = AbilityState.GetSourceWeapon();    
-    if ((SourceWeapon != none) && (Target != none))
+    // SourceWeapon = AbilityState.GetSourceWeapon();
+    // if ((SourceWeapon != none) && (Target != none))
+    if ((Target != none))
     {
-		if (Target.GetCurrentStat(eStat_HP) <= (Target.GetMaxStat(eStat_HP) / 2))
-		{
-		    ShotInfo.ModType = eHit_Success;
+        if (Target.GetCurrentStat(eStat_HP) <= (Target.GetMaxStat(eStat_HP) / 2))
+        {
+            ShotInfo.ModType = eHit_Success;
             ShotInfo.Reason = FriendlyName;
-			ShotInfo.Value = default.EXECUTIONER_AIM_BONUS;
+            ShotInfo.Value = default.EXECUTIONER_AIM_BONUS;
             ShotModifiers.AddItem(ShotInfo);
 
-			ShotInfo.ModType = eHit_Crit;
+            ShotInfo.ModType = eHit_Crit;
             ShotInfo.Reason = FriendlyName;
-			ShotInfo.Value = default.EXECUTIONER_CRIT_BONUS;
+            ShotInfo.Value = default.EXECUTIONER_CRIT_BONUS;
             ShotModifiers.AddItem(ShotInfo);
         }
     }    


### PR DESCRIPTION
Allow Aggression and Executioner bonuses to apply to any ability instead of requiring the ability to be bound to any weapon. Relevant for any ability that doesn't require a weapon to work.