### PR TITLE
Remake the Cutthroat effect

### DIFF
--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -379,8 +379,8 @@ LocPromotionPopupText="<Bullet/> Reaction fire shots against you have a signific
 LocFriendlyName="Cutthroat"
 LocFlyOverText="Cutthroat"
 ; LWOTC Needs Translation
-LocLongDescription="Your melee attacks against biological enemies ignore their armor, have a +<Ability:CUTTHROAT_BONUS_CRIT_CHANCE/> critical chance, and do +<Ability:CUTTHROAT_BONUS_CRIT_DAMAGE/> critical damage."
-LocHelpText="Your melee attacks against biological enemies ignore their armor, have a +<Ability:CUTTHROAT_BONUS_CRIT_CHANCE/> critical chance, and do +<Ability:CUTTHROAT_BONUS_CRIT_DAMAGE/> critical damage."
+LocLongDescription="Your melee attacks against biological enemies ignore their armor, have +<Ability:CUTTHROAT_BONUS_CRIT_CHANCE/> critical chance, and do +<Ability:CUTTHROAT_BONUS_CRIT_DAMAGE/> critical damage."
+LocHelpText="Your melee attacks against biological enemies ignore their armor, have +<Ability:CUTTHROAT_BONUS_CRIT_CHANCE/> critical chance, and do +<Ability:CUTTHROAT_BONUS_CRIT_DAMAGE/> critical damage."
 LocPromotionPopupText=""
 ; End translation
 

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Cutthroat.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Cutthroat.uc
@@ -4,86 +4,66 @@
 //  PURPOSE: Sets up crit and Armor piercing bonus
 //--------------------------------------------------------------------------------------- 
 
-class X2Effect_Cutthroat extends X2Effect_Persistent config (LW_SoldierSkills);
+class X2Effect_Cutthroat extends X2Effect_Persistent config(LW_SoldierSkills);
 
 var int BONUS_CRIT_CHANCE;
 var int BONUS_CRIT_DAMAGE;
 
 function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit Attacker, XComGameState_Unit Target, XComGameState_Ability AbilityState, class<X2AbilityToHitCalc> ToHitType, bool bMelee, bool bFlanking, bool bIndirectFire, out array<ShotModifierInfo> ShotModifiers)
 {
-    local XComGameState_Item	SourceWeapon;
-    local ShotModifierInfo		ShotInfo;
+    local ShotModifierInfo      CritInfo;
 
-	//`LOG ("Cutthroat 1");
-    if(AbilityState.GetMyTemplate().IsMelee())
-	{
-		//`LOG ("Cutthroat 2");
-		if (Target != none && !Target.IsRobotic())
-		{
-			//`LOG ("Cutthroat 3");
-			SourceWeapon = AbilityState.GetSourceWeapon();
-			if (SourceWeapon != none || Attacker.IsRobotic())
-			{
-				//`LOG ("Cutthroat 4");
-				ShotInfo.ModType = eHit_Crit;
-				ShotInfo.Reason = FriendlyName;
-				ShotInfo.Value = BONUS_CRIT_CHANCE;
-				ShotModifiers.AddItem(ShotInfo);
-			}
-		}
-	}
+    if (AbilityState.IsMeleeAbility())
+    {
+        if (Target != none && !Target.IsRobotic())
+        {
+            CritInfo.ModType = eHit_Crit;
+            CritInfo.Reason = FriendlyName;
+            CritInfo.Value = BONUS_CRIT_CHANCE;
+            ShotModifiers.AddItem(CritInfo);
+        }
+    }
 }
 
 function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData, const int CurrentDamage, optional XComGameState NewGameState)
 {
-	local XComGameState_Unit		Target;
-	local X2Effect_ApplyWeaponDamage WeaponDamageEffect;
+    local XComGameState_Unit Target;
 
-	if(AbilityState.GetMyTemplate().IsMelee())
-	{
-	    if(AppliedData.AbilityResultContext.HitResult == eHit_Crit)
-		{
-			Target = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(AppliedData.TargetStateObjectRef.ObjectID));
-			if (Target != none && !Target.IsRobotic())
-			{
-				if (CurrentDamage > 0)
-				{
-					// remove from DOT effects
-					WeaponDamageEffect = X2Effect_ApplyWeaponDamage(class'X2Effect'.static.GetX2Effect(AppliedData.EffectRef));
-					if (WeaponDamageEffect != none)
-					{			
-						if (WeaponDamageEffect.bIgnoreBaseDamage)
-						{	
-							return 0;		
-						}
-					}
-					return BONUS_CRIT_DAMAGE;
-				}
-			}
+    if (AbilityState.IsMeleeAbility())
+    {
+        if (AppliedData.AbilityResultContext.HitResult == eHit_Crit)
+        {
+            Target = XComGameState_Unit(TargetDamageable);
+            if (Target != none && !Target.IsRobotic())
+            {
+                if (CurrentDamage > 0)
+                {
+                    // remove from DOT effects
+                    if (EffectState.ApplyEffectParameters.EffectRef.ApplyOnTickIndex != INDEX_NONE)
+                        return 0;
+                    
+                    return BONUS_CRIT_DAMAGE;
+                }
+            }
         }
     }
-	return 0;
+    return 0;
 }
 
 function int GetExtraArmorPiercing(XComGameState_Effect EffectState, XComGameState_Unit Attacker, Damageable TargetDamageable, XComGameState_Ability AbilityState, const out EffectAppliedData AppliedData)
 {
-	local XComGameState_Item		SourceWeapon;
-	local XComGameState_Unit		Target, Source;
+    local XComGameState_Unit Target;
 
-	if(AbilityState.GetMyTemplate().IsMelee())
-	{
-		Target = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(AppliedData.TargetStateObjectRef.ObjectID));
-		Source = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(AppliedData.SourceStateObjectRef.ObjectID));
-		if (Target != none && !Target.IsRobotic())
-		{		
-			SourceWeapon = AbilityState.GetSourceWeapon();
-			if (SourceWeapon != none || Source.IsRobotic())
-			{				
-				return 9999;
-			}
-		}
-	}	
-	return 0;
+    if (AbilityState.IsMeleeAbility())
+    {
+        Target = XComGameState_Unit(TargetDamageable);
+        if (Target != none && !Target.IsRobotic())
+        {
+            return 9999;
+        }
+    }
+
+    return 0;
 }
 
 defaultproperties


### PR DESCRIPTION
- Simplify the implementation.
- Allow the effect to apply to abilities that ignore base weapon damage. Use a different method to check for DoT damage.
- Allow the effect to apply to abilities without a source weapon.
- Fix a critical localization issue.