### PR TITLE
Update X2Effect_Executioner_LW.uc

### DIFF
--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Executioner_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_Executioner_LW.uc
@@ -18,7 +18,7 @@ function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit 
     // if ((SourceWeapon != none) && (Target != none))
     if ((Target != none))
     {
-        if (Target.GetCurrentStat(eStat_HP) <= (Target.GetMaxStat(eStat_HP) / 2))
+        if (Target.GetCurrentStat(eStat_HP) * 2 <= Target.GetMaxStat(eStat_HP))
         {
             ShotInfo.ModType = eHit_Success;
             ShotInfo.Reason = FriendlyName;


### PR DESCRIPTION
Change the condition in the Executioner effect to not use division to prevent comparing float values directly.