### PR TITLE
Stop mission detection with < 6 hours infiltration

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWAlienActivity.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWAlienActivity.uc
@@ -269,7 +269,7 @@ function bool Update(XComGameState NewGameState)
 		// At this point, ensure the activity isn't near its expiration date, to avoid spawning missions that may result in crashes.
 		// Activity-completion Date must be beyond the DetectionWindow, otherwise just let it expire silently
 		DetectionWindowDateTime = class'XComGameState_GeoscapeEntity'.static.GetCurrentTime();
-		class'X2StrategyGameRulesetDataStructures'.static.AddHours(DetectionWindowDateTime, class'X2LWAlienActivityTemplate'.default.HOURS_BETWEEN_ALIEN_ACTIVITY_DETECTION_UPDATES);
+		class'X2StrategyGameRulesetDataStructures'.static.AddHours(DetectionWindowDateTime, class'X2LWAlienActivityTemplate'.default.HOURS_BETWEEN_ALIEN_ACTIVITY_DETECTION_UPDATES / 2);
 		if((bNeedsUpdateDiscovery || (ActivityTemplate.DetectionCalc != none && ActivityTemplate.DetectionCalc.CanBeDetected(self, NewGameState)))
 			&& !class'X2StrategyGameRulesetDataStructures'.static.LessThan(DateTimeActivityComplete, DetectionWindowDateTime))
 		{


### PR DESCRIPTION
Activities' detection updates happen every handful of hours (6, by default). if the ActivityComplete is less than 1 cycle away, stop the detection from happening and let it expire quietly.