### PR TITLE
Change the order of effects in Disabling Shot

### DIFF
--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_ReaperAbilitySet_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_ReaperAbilitySet_LW.uc
@@ -497,14 +497,14 @@ static function X2AbilityTemplate AddDisablingShot()
 	VisibilityCondition.bAllowSquadsight = true;
 	Template.AbilityTargetConditions.AddItem(VisibilityCondition);
 
+	StunEffect = CreateDisablingShotStunnedEffect(default.DisablingShotBaseStunActions);
+	StunEffect.BonusStunActionsOnCrit = default.DisablingShotCritStunActions;
+	Template.AddTargetEffect(StunEffect);
+
 	Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.HoloTargetEffect());
 	Template.AssociatedPassives.AddItem('HoloTargeting');
 	Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.ShredderDamageEffect());
 	Template.bAllowAmmoEffects = true;
-
-	StunEffect = CreateDisablingShotStunnedEffect(default.DisablingShotBaseStunActions);
-	StunEffect.BonusStunActionsOnCrit = default.DisablingShotCritStunActions;
-	Template.AddTargetEffect(StunEffect);
 
 	ActionPointCost = new class 'X2AbilityCost_ActionPoints';
 	ActionPointCost.iNumPoints = 0;
@@ -592,14 +592,14 @@ static function X2AbilityTemplate AddDisablingShotSnapShot()
 	VisibilityCondition.bAllowSquadsight = true;
 	Template.AbilityTargetConditions.AddItem(VisibilityCondition);
 
+	StunEffect = CreateDisablingShotStunnedEffect(default.DisablingShotBaseStunActions);
+	StunEffect.BonusStunActionsOnCrit = default.DisablingShotCritStunActions;
+	Template.AddTargetEffect(StunEffect);
+
 	Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.HoloTargetEffect());
 	Template.AssociatedPassives.AddItem('HoloTargeting');
 	Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.ShredderDamageEffect());
 	Template.bAllowAmmoEffects = true;
-
-	StunEffect = CreateDisablingShotStunnedEffect(default.DisablingShotBaseStunActions);
-	StunEffect.BonusStunActionsOnCrit = default.DisablingShotCritStunActions;
-	Template.AddTargetEffect(StunEffect);
 
 	ActionPointCost = new class'X2AbilityCost_ActionPoints';
 	ActionPointCost.iNumPoints = 1;


### PR DESCRIPTION
Move the stun effect before the damage effect to make the stun come earlier in the visualization tree, preventing the damage flinch action.