### PR TITLE
Fix weapon name for Bladestorm

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -6391,15 +6391,15 @@ LocPromotionPopupText="<Bullet/> If an enemy begins their turn in an adjacent ti
 
 [Bladestorm X2AbilityTemplate]
 LocFriendlyName="Bladestorm"
-LocLongDescription="Free <Ability:WeaponName/> attacks on any enemies that enter, exit or attack from melee range on enemy turns."
-LocHelpText="Free <Ability:WeaponName/> attacks on any enemies that enter, exit or attack from melee range on enemy turns."
+LocLongDescription="Free <Ability:BOUND_WEAPON_NAME/> attacks on any enemies that enter, exit or attack from melee range on enemy turns."
+LocHelpText="Free <Ability:BOUND_WEAPON_NAME/> attacks on any enemies that enter, exit or attack from melee range on enemy turns."
 LocFlyOverText="Bladestorm"
 LocPromotionPopupText="<Bullet/> If an enemy begins their turn in an adjacent tile, Bladestorm will trigger if that enemy tries to attack the <Ability:ClassName/>.<br/><Bullet/> If an enemy does not begin their turn in an adjacent tile, then Bladestorm will trigger when that enemy moves into melee range.<br/><Bullet/> Bladestorm does not trigger on your own turn.<br/>"
 
 [TemplarBladestorm X2AbilityTemplate]
 LocFriendlyName="Bladestorm"
-LocLongDescription="Free <Ability:WeaponName/> attacks on any enemies that enter, exit or attack from melee range on enemy turns."
-LocHelpText="Free <Ability:WeaponName/> attacks on any enemies that enter, exit or attack from melee range on enemy turns."
+LocLongDescription="Free <Ability:BOUND_WEAPON_NAME/> attacks on any enemies that enter, exit or attack from melee range on enemy turns."
+LocHelpText="Free <Ability:BOUND_WEAPON_NAME/> attacks on any enemies that enter, exit or attack from melee range on enemy turns."
 LocFlyOverText="Bladestorm"
 LocPromotionPopupText="<Bullet/> If an enemy begins their turn in an adjacent tile, Bladestorm will trigger if that enemy tries to attack the <Ability:ClassName/>.<br/><Bullet/> If an enemy does not begin their turn in an adjacent tile, then Bladestorm will trigger when that enemy moves into melee range.<br/><Bullet/> Bladestorm does not trigger on your own turn.<br/>"
 ; End Translation


### PR DESCRIPTION
Change the tag to LW's one that pulls the name of the bound weapon.