### PR TITLE
Fixed Death Dealer's doubled crit damage not applying during Green Alert

### DIFF
--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_DeathDealer_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_DeathDealer_LW.uc
@@ -24,7 +24,9 @@ function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGa
 
 	//  only add bonus damage on a crit, flanking, while in shadow
 	if (AppliedData.AbilityResultContext.HitResult == eHit_Crit && Attacker.IsSuperConcealed() &&
-		TargetUnit != none && (class'Helpers_LW'.static.IsUnitFlankedBy(TargetUnit, Attacker) || (!TargetUnit.CanTakeCover() && Attacker.HasAbilityFromAnySource('TheBanisher_LW'))))
+		TargetUnit != none && (class'Helpers_LW'.static.IsUnitFlankedBy(TargetUnit, Attacker) 
+			|| (TargetUnit.GetMyTemplate().bCanTakeCover && TargetUnit.GetCurrentStat(eStat_AlertLevel) == 0) 
+			|| (!TargetUnit.CanTakeCover() && Attacker.HasAbilityFromAnySource('TheBanisher_LW'))))
 	{
 		SourceWeapon = AbilityState.GetSourceWeapon();
 		SourceWeapon.GetBaseWeaponDamageValue(none, DamageValue);


### PR DESCRIPTION
Based on Hit and Run and other abilities that work during Green Alert, fixed Death Dealer's doubled crit damage not applying during Green Alert.