### PR TITLE
Add unit conditions to Anticipation

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.chn
+++ b/LongWarOfTheChosen/Localization/XComGame.chn
@@ -5746,8 +5746,8 @@ LocFlyOverText="精神控制"
 
 [ChosenImmuneMelee X2AbilityTemplate]
 LocFriendlyName="严阵以待"
-LocLongDescription="受到的冲刺近战伤害减少50%。"
-LocHelpText="受到的冲刺近战伤害减少50%。"
+LocLongDescription="受到的冲刺近战伤害减少<Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>%。"
+LocHelpText="受到的冲刺近战伤害减少<Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>%。"
 
 [BlastShield X2AbilityTemplate]
 LocFriendlyName="防爆护盾"

--- a/LongWarOfTheChosen/Localization/XComGame.cht
+++ b/LongWarOfTheChosen/Localization/XComGame.cht
@@ -5733,8 +5733,8 @@ LocFlyOverText="精神控制"
 
 [ChosenImmuneMelee X2AbilityTemplate]
 LocFriendlyName="嚴陣以待"
-LocLongDescription="受到的衝刺近戰傷害減少50%。"
-LocHelpText="受到的衝刺近戰傷害減少50%。"
+LocLongDescription="受到的衝刺近戰傷害減少<Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>%。"
+LocHelpText="受到的衝刺近戰傷害減少<Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>%。"
 
 [BlastShield X2AbilityTemplate]
 LocFriendlyName="防爆護盾"

--- a/LongWarOfTheChosen/Localization/XComGame.deu
+++ b/LongWarOfTheChosen/Localization/XComGame.deu
@@ -4997,8 +4997,8 @@ LocFlyOverText="Gedankenkontrolle"
 
 [ChosenImmuneMelee X2AbilityTemplate]
 LocFriendlyName="Antizipation"
-LocLongDescription="Erleidet 50 % weniger Schaden durch Springt-Nahkampfangriffe."
-LocHelpText="Erleidet 50 % weniger Schaden durch Springt-Nahkampfangriffe."
+LocLongDescription="Erleidet <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION> % weniger Schaden durch Springt-Nahkampfangriffe."
+LocHelpText="Erleidet <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION> % weniger Schaden durch Springt-Nahkampfangriffe."
 
 [BlastShield X2AbilityTemplate]
 LocFriendlyName="Explosionsschild"

--- a/LongWarOfTheChosen/Localization/XComGame.esn
+++ b/LongWarOfTheChosen/Localization/XComGame.esn
@@ -5941,8 +5941,8 @@ LocFlyOverText="Abrasar escudo mental"
 
 [ChosenImmuneMelee X2AbilityTemplate]
 LocFriendlyName="Anticipación"
-LocLongDescription="Recibe un 50% menos de daño cuerpo a cuerpo."
-LocHelpText="Recibe un 50% menos de daño cuerpo a cuerpo."
+LocLongDescription="Recibe un <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>% menos de daño cuerpo a cuerpo."
+LocHelpText="Recibe un <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>% menos de daño cuerpo a cuerpo."
 
 ; LWOTC translated
 [BlastShield X2AbilityTemplate]

--- a/LongWarOfTheChosen/Localization/XComGame.fra
+++ b/LongWarOfTheChosen/Localization/XComGame.fra
@@ -5647,8 +5647,8 @@ LocFlyOverText="Contrôle mental"
 
 [ChosenImmuneMelee X2AbilityTemplate]
 LocFriendlyName="Anticipation"
-LocLongDescription="Les attaques au corps à corps qui nécessitent de sprinter infligent 50% de dégâts en moins."
-LocHelpText="Les attaques au corps à corps qui nécessitent de sprinter infligent 50% de dégâts en moins."
+LocLongDescription="Les attaques au corps à corps qui nécessitent de sprinter infligent <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>% de dégâts en moins."
+LocHelpText="Les attaques au corps à corps qui nécessitent de sprinter infligent <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>% de dégâts en moins."
 
 [BlastShield X2AbilityTemplate]
 LocFriendlyName="Pare-explosion"

--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -5929,8 +5929,8 @@ LocFlyOverText="Mind Control"
 
 [ChosenImmuneMelee X2AbilityTemplate]
 LocFriendlyName="Anticipation"
-LocLongDescription="Takes 50% less damage from dashing melee attacks."
-LocHelpText="Takes 50% less damage from dashing melee attacks."
+LocLongDescription="Takes <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>% less damage from dashing melee attacks."
+LocHelpText="Takes <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>% less damage from dashing melee attacks."
 
 [BlastShield X2AbilityTemplate]
 LocFriendlyName="Blast Shield"

--- a/LongWarOfTheChosen/Localization/XComGame.pol
+++ b/LongWarOfTheChosen/Localization/XComGame.pol
@@ -5423,8 +5423,8 @@ LocFlyOverText="Kontrola umysłu"
 
 [ChosenImmuneMelee X2AbilityTemplate]
 LocFriendlyName="Oczekiwanie"
-LocLongDescription="Otrzymuje o 50% mniej obrażeń od gwałtownych ataków wręcz."
-LocHelpText="Otrzymuje o 50% mniej obrażeń od gwałtownych ataków wręcz."
+LocLongDescription="Otrzymuje o <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>% mniej obrażeń od gwałtownych ataków wręcz."
+LocHelpText="Otrzymuje o <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>% mniej obrażeń od gwałtownych ataków wręcz."
 
 [BlastShield X2AbilityTemplate]
 LocFriendlyName="Osłona uderzeniowa"

--- a/LongWarOfTheChosen/Localization/XComGame.rus
+++ b/LongWarOfTheChosen/Localization/XComGame.rus
@@ -5951,8 +5951,8 @@ LocFlyOverText="Чемпион Чародея"
 
 [ChosenImmuneMelee X2AbilityTemplate]
 LocFriendlyName="Предугадывание"
-LocLongDescription="Получает на 50% меньше урона от атак оружием ближнего боя с разбега."
-LocHelpText="Получает на 50% меньше урона от атак оружием ближнего боя с разбега."
+LocLongDescription="Получает на <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>% меньше урона от атак оружием ближнего боя с разбега."
+LocHelpText="Получает на <Ability:ANTICIPATION_MELEE_DAMAGE_REDUCTION>% меньше урона от атак оружием ближнего боя с разбега."
 
 [BlastShield X2AbilityTemplate]
 LocFriendlyName="Стойкость"

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
@@ -5276,6 +5276,9 @@ static function bool AbilityTagExpandHandler(string InString, out string OutStri
 		case 'CRUSADER_RAGE_HEAL':
 			Outstring = string(class'X2Ability_XMBPerkAbilitySet'.default.CRUSADER_WOUND_HP_REDUCTTION);
 			return true;
+		case 'ANTICIPATION_MELEE_DAMAGE_REDUCTION':
+			Outstring = string(int(class'X2LWAbilitiesModTemplate'.default.MELEE_DAMAGE_REDUCTION));
+			return true;
 		default:
 			return false;
 	}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2LWAbilitiesModTemplate.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2LWAbilitiesModTemplate.uc
@@ -791,6 +791,9 @@ static function ReplaceWithDamageReductionMelee(X2AbilityTemplate Template)
 	DamageMod.PercentDR = default.MELEE_DAMAGE_REDUCTION;
 	DamageMod.bApplyToMovingMelee = true;
 	DamageMod.bApplyToStandardMelee = false;
+	DamageMod.bAllowImpaired = false;
+	DamageMod.bAllowPanicked = false;
+	DamageMod.bAllowFrozen = false;
 	DamageMod.BuildPersistentEffect(1, true, false, true);
 	DamageMod.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage,,, Template.AbilitySourceName);
 	Template.AddTargetEffect(DamageMod);

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_MeleeDamageResistance.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_MeleeDamageResistance.uc
@@ -3,6 +3,11 @@ class X2Effect_MeleeDamageResistance extends X2Effect_Persistent;
 var bool bApplyToStandardMelee;
 var bool bApplyToMovingMelee;
 
+var bool bAllowImpaired;
+var bool bAllowPanicked;
+var bool bAllowBurning;
+var bool bAllowFrozen;
+
 var float PercentDR;
 var int FlatDR;
 
@@ -23,7 +28,7 @@ function int GetDefendingDamageModifier(
         return 0;
 
     if (ValidateAttack(EffectState, Attacker, XComGameState_Unit(TargetDamageable), AbilityState, AppliedData, WeaponDamageEffect))
-        return -1 * Min(CurrentDamage-1, FlatDR);
+        return -1 * Min(CurrentDamage - 1, FlatDR);
     
     return 0;
 }
@@ -39,7 +44,7 @@ function float GetPostDefaultDefendingDamageModifier_CH(
     XComGameState NewGameState)
 {
     if (ValidateAttack(EffectState, SourceUnit, TargetUnit, AbilityState, ApplyEffectParameters, WeaponDamageEffect))
-        return -1 * Min(WeaponDamage-1, WeaponDamage * PercentDR / 100);
+        return -1 * Min(WeaponDamage - 1, WeaponDamage * PercentDR / 100);
 
     return 0;
 }
@@ -56,6 +61,12 @@ private function bool ValidateAttack(
     local bool bIsMovingMelee;
 
     if (EffectState.ApplyEffectParameters.EffectRef.ApplyOnTickIndex != INDEX_NONE)
+        return false;
+
+    if (!bAllowImpaired && TargetUnit.IsImpaired()
+        || !bAllowPanicked && TargetUnit.IsPanicked()
+        || !bAllowBurning && TargetUnit.IsBurning()
+        || !bAllowFrozen && TargetUnit.AffectedByEffectNames.Find('Frozen') != INDEX_NONE)
         return false;
 
     if (WhitelistedAbilities.Find(AbilityState.GetMyTemplateName()) != INDEX_NONE)
@@ -82,6 +93,11 @@ defaultproperties
 {
     bApplyToStandardMelee = true
     bApplyToMovingMelee = true
+
+    bAllowImpaired = true
+    bAllowPanicked = true
+    bAllowBurning = true
+    bAllowFrozen = true
 
     WhitelistedAbilities[0] = PartingSilk
     WhitelistedAbilities[1] = AssassinSlash_LW


### PR DESCRIPTION
1. Add flags to enable / disable the melee DR effect from applying while burning, panicked, impaired, or frozen.
2. Disable Anticipation while the unit is panicked, frozen, or impaired.
3. Add localization tag for Anticipation DR.