### PR TITLE
Updating handling for smoke grenade effects

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_SoldierSkills.ini
+++ b/LongWarOfTheChosen/Config/XComLW_SoldierSkills.ini
@@ -362,8 +362,10 @@ COLLATERAL_RADIUS = 176
 COLLATERAL_ENVDMG = 30 
 
 
-;New dense smoke
-DENSESMOKEGRENADE_HITMOD = 10
+; DEPRECATED
+; DENSESMOKEGRENADE_HITMOD = 10
+
+; Now also used for Combat Stimulants and Regenerative Mist
 +SMOKE_GRENADES_FOR_DENSE_SMOKE="SmokeGrenade"
 +SMOKE_GRENADES_FOR_DENSE_SMOKE="SmokeGrenadeMk2"
 
@@ -415,6 +417,18 @@ SHOCKWAVE_TURNS = 1
 +ATTACK_GRENADES=FlashbangGrenade
 
 ChainingJolt_Cooldown=3
+
+[LW_PerkPack_Integrated.X2Effect_LWCombatStims]
+AimBonus = 10
+CritBonus = 10
+
+[LW_PerkPack_Integrated.X2Effect_LWDenseSmoke]
+DefenseBonus = 10
+
+[LW_PerkPack_Integrated.X2Effect_LWRegenSmoke]
+HealAmount = 2
+MaxHealAmount = 4
+bApplyToBleedingOutUnits = false
 
 [LW_PerkPack_Integrated.X2AbilityCharges_Repair_LW]
 ; Repair

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.chn
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.chn
@@ -34,14 +34,15 @@ m_strNoWeaponUpgradesTooltip="没有可用的武器配件"
 TrojanVirus="特洛伊病毒"
 TrojanVirusTriggered="<XGParam:StrValue0/!UnitName/>已触发特洛伊病毒。"
 
-DenseSmokeGrenadeEffectDisplayName="浓密烟雾"
-DenseSmokeGrenadeEffectDisplayDesc="浓密烟雾赋予该单位额外的防御加成。"
-
 ShellshockEffectDesc="这个单位的命中和暴击几率降低了。"
 ShellshockEffectName="被弹震"
 
 ShockwaveEffectName="被冲击"
 ShockwaveEffectDesc="这个单位的防御和闪避降低了。"
+
+[X2Effect_LWDenseSmoke]
+strEffectBonusName = "浓密烟雾"
+strEffectBonusDesc = "浓密烟雾赋予该单位额外的防御加成。"
 
 [X2Effect_Savior]
 strSavior_WorldMessage="妙手回春：已回复额外<XGParam:IntValue0/>生命值。"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.cht
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.cht
@@ -34,14 +34,15 @@ m_strNoWeaponUpgradesTooltip="沒有可用的武器配件"
 TrojanVirus="特洛伊病毒"
 TrojanVirusTriggered="<XGParam:StrValue0/!UnitName/>已觸發特洛伊病毒。"
 
-DenseSmokeGrenadeEffectDisplayName="濃密煙霧"
-DenseSmokeGrenadeEffectDisplayDesc="濃密煙霧賦予該單位額外的防禦加成。"
-
 ShellshockEffectDesc="這個單位的命中和暴擊幾率降低了。"
 ShellshockEffectName="被彈震"
 
 ShockwaveEffectName="被衝擊"
 ShockwaveEffectDesc="這個單位的防禦和閃避降低了。"
+
+[X2Effect_LWDenseSmoke]
+strEffectBonusName = "濃密煙霧"
+strEffectBonusDesc = "濃密煙霧賦予該單位額外的防禦加成。"
 
 [X2Effect_Savior]
 strSavior_WorldMessage="妙手回春：已回復額外<XGParam:IntValue0/>生命值。"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.deu
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.deu
@@ -34,14 +34,15 @@ m_strNoWeaponUpgradesTooltip="KEINE WAFFENVERBESSERUNGEN VERFÜGBAR"
 TrojanVirus="Trojaner"
 TrojanVirusTriggered="<XGParam:StrValue0/!UnitName/> hat Trojaner ausgelöst."
 
-DenseSmokeGrenadeEffectDisplayName="Dichter Rauch"
-DenseSmokeGrenadeEffectDisplayDesc="Der dichte Rauch gewährt dieser Einheit einen zusätzlichen Verteidigungsbonus."
-
 ShellshockEffectDesc="Diese Einheit hat verringerte Zielgenauigkeit und kritische Trefferchance."
 ShellshockEffectName="Schockzustand"
 
 ShockwaveEffectName="Erschüttert"
 ShockwaveEffectDesc="Diese Einheit hat verringerte Verteidigung und Ausweichchance."
+
+[X2Effect_LWDenseSmoke]
+strEffectBonusName = "Dichter Rauch"
+strEffectBonusDesc = "Der dichte Rauch gewährt dieser Einheit einen zusätzlichen Verteidigungsbonus."
 
 [X2Effect_Savior]
 strSavior_WorldMessage="Erretter: Hat zusätzliche <XGParam:IntValue0/> Trefferpunkte geheilt."

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.esn
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.esn
@@ -36,9 +36,6 @@ TrojanVirusTriggered="<XGParam:StrValue0/!UnitName/> ha activado el virus troyan
 
 ; LWOTC translated
 
-DenseSmokeGrenadeEffectDisplayName="Humo denso"
-DenseSmokeGrenadeEffectDisplayDesc="El humo denso concede una bonificación defensiva adicional a esta unidad."
-
 ShellshockEffectDesc="Esta unidad tiene reducida su puntería y probabilidad de golpe crítico."
 ShellshockEffectName="Conmocionado"
 
@@ -46,6 +43,10 @@ ShockwaveEffectName="Estremecido"
 ShockwaveEffectDesc="Esta unidad tiene defensa y esquiva reducidas."
 
 ; End translated
+
+[X2Effect_LWDenseSmoke]
+strEffectBonusName = "Humo denso"
+strEffectBonusDesc = "El humo denso concede una bonificación defensiva adicional a esta unidad."
 
 [X2Effect_Savior]
 strSavior_WorldMessage="Salvador: curación de <XGParam:IntValue0/> de salud adicional."

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.fra
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.fra
@@ -34,6 +34,10 @@ m_strNoWeaponUpgradesTooltip="AUCUNE AMÉLIORATION D'ARME DISPONIBLE"
 TrojanVirus="Cheval de Troie"
 TrojanVirusTriggered="<XGParam:StrValue0/!UnitName/> a déclenché un cheval de Troie."
 
+[X2Effect_LWDenseSmoke]
+strEffectBonusName = "Fumée dense"
+strEffectBonusDesc = "Cette épaisse fumée octroie à cette unité un bonus de défense supplémentaire."
+
 [X2Effect_Savior]
 strSavior_WorldMessage="Sauveur: +<XGParam:IntValue0/> PV régénérés en plus."
 

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.int
@@ -34,14 +34,25 @@ m_strNoWeaponUpgradesTooltip=NO WEAPON UPGRADES AVAILABLE
 TrojanVirus="Trojan Virus"
 TrojanVirusTriggered="<XGParam:StrValue0/!UnitName/> triggered Trojan Virus."
 
-DenseSmokeGrenadeEffectDisplayName="Dense Smoke"
-DenseSmokeGrenadeEffectDisplayDesc="The dense smoke grants this unit a additional defensive bonus."
-
 ShellshockEffectDesc="This unit has reduced aim and critical hit chance."
 ShellshockEffectName="Shellshocked"
 
 ShockwaveEffectName="Shocked"
 ShockwaveEffectDesc="This unit has reduced defense and dodge."
+
+; LWOTC Needs Translation
+[X2Effect_LWCombatStims]
+strEffectBonusName = "Combat Stimulants"
+strEffectBonusDesc = "This unit is affected by Combat Stimulants. Its aim and critical chance are increased."
+
+[X2Effect_LWDenseSmoke]
+strEffectBonusName = "Dense Smoke"
+strEffectBonusDesc = "This unit is in Dense Smoke. Its defense is increased."
+
+[X2Effect_LWRegenSmoke]
+strEffectBonusName = "Regenerative Mist"
+strEffectBonusDesc = "This unit is affected by Regenerative Mist. It's regenerating HP at the start of each turn."
+; End Translation
 
 [X2Effect_Savior]
 strSavior_WorldMessage="Savior: Healed extra <XGParam:IntValue0/> Health."

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.ita
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.ita
@@ -34,6 +34,10 @@ m_strNoWeaponUpgradesTooltip="NESSUN POTENZIAMENTO DISPONIBILE"
 TrojanVirus="Virus Trojan"
 TrojanVirusTriggered="<XGParam:StrValue0/!UnitName/> ha attivato un virus Trojan."
 
+[X2Effect_LWDenseSmoke]
+strEffectBonusName = "Fumo impenetrabile"
+strEffectBonusDesc = "Il fumo denso conferisce un ulteriore bonus difensivo a questa unità."
+
 [X2Effect_Savior]
 strSavior_WorldMessage="Salvatore: ha curato <XGParam:IntValue0/> punti salute in più."
 

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.jpn
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.jpn
@@ -34,6 +34,10 @@ m_strNoWeaponUpgradesTooltip="利用可能な武装アップグレードがあ�
 TrojanVirus="トロイウイルス"
 TrojanVirusTriggered="<XGParam:StrValue0/!UnitName/>がトロイウイルスを発動した。"
 
+[X2Effect_LWDenseSmoke]
+strEffectBonusName = "高密度スモーク"
+strEffectBonusDesc = "高密度の煙幕がこのユニットに追加の防御ボーナスをもたらしてくれる。"
+
 [X2Effect_Savior]
 strSavior_WorldMessage="救世主：体力回復量<XGParam:IntValue0/>増加"
 

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.pol
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.pol
@@ -34,6 +34,10 @@ m_strNoWeaponUpgradesTooltip="BRAK DOSTĘPNYCH ULEPSZEŃ BRONI"
 TrojanVirus="Wirus typu trojan"
 TrojanVirusTriggered="<XGParam:StrValue0/!UnitName/> uruchamia wirus typu trojan."
 
+[X2Effect_LWDenseSmoke]
+strEffectBonusName = "Gęsty dym"
+strEffectBonusDesc = "Gęsty dym daje tej jednostce premię do obrony."
+
 [X2Effect_Savior]
 strSavior_WorldMessage="Zbawca: leczenie dodatkowych <XGParam:IntValue0/> pkt. zdrowia."
 

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.rus
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/LW_PerkPack_Integrated.rus
@@ -34,6 +34,10 @@ m_strNoWeaponUpgradesTooltip="УЛУЧШЕНИЕ ОРУЖИЯ НЕДОСТУПН
 TrojanVirus="Троян"
 TrojanVirusTriggered="<XGParam:StrValue0/!UnitName/> активирует троян."
 
+[X2Effect_LWDenseSmoke]
+strEffectBonusName = "Густой дым"
+strEffectBonusDesc = "Густой дым дополнительно увеличивает защиту этого солдата."
+
 [X2Effect_Savior]
 strSavior_WorldMessage="Спаситель: восстанавливается дополнительно <XGParam:IntValue0/> здоровья."
 

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.chn
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.chn
@@ -534,9 +534,9 @@ LocPromotionPopupText="<Bullet/> 效果适用于小精灵治疗，急救包和�
 [DenseSmoke X2AbilityTemplate]
 LocFriendlyName="浓密烟雾"
 LocFlyOverText="浓密烟雾"
-LocLongDescription="你的烟雾榴弹提供额外10点防御。同时额外获得一颗免费的烟雾榴弹。"
-LocHelpText="你的烟雾榴弹提供额外10点防御。同时额外获得一颗免费的烟雾榴弹。"
-LocPromotionPopupText="<Bullet/> 你的烟雾榴弹对处于烟雾中的单位提供额外10点防御，最高30。同时额外获得一颗免费的烟雾榴弹。<br/>"
+LocLongDescription="你的烟雾榴弹提供额外<Ability:DenseSmoke_DefenseBonus_LW>点防御。同时额外获得一颗免费的烟雾榴弹。"
+LocHelpText="你的烟雾榴弹提供额外<Ability:DenseSmoke_DefenseBonus_LW>点防御。同时额外获得一颗免费的烟雾榴弹。"
+LocPromotionPopupText="<Bullet/> 你的烟雾榴弹对处于烟雾中的单位提供额外<Ability:DenseSmoke_DefenseBonus_LW>点防御，最高<Ability:DenseSmoke_DefenseTotal_LW>。同时额外获得一颗免费的烟雾榴弹。<br/>"
 
 
 [Collateral_LW X2AbilityTemplate]

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.cht
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.cht
@@ -534,9 +534,9 @@ LocPromotionPopupText="<Bullet/>效果適用於小精靈治療，急救包和恢
 [DenseSmoke X2AbilityTemplate]
 LocFriendlyName="濃密煙霧"
 LocFlyOverText="濃密煙霧"
-LocLongDescription="你的煙霧榴彈提供額外10點防禦。同時額外獲得一顆免費的煙霧榴彈。"
-LocHelpText="你的煙霧榴彈提供額外10點防禦。同時額外獲得一顆免費的煙霧榴彈。"
-LocPromotionPopupText="<Bullet/>你的煙霧榴彈對處於煙霧中的單位提供額外10點防禦，最高30。同時額外獲得一顆免費的煙霧榴彈。<br/>"
+LocLongDescription="你的煙霧榴彈提供額外<Ability:DenseSmoke_DefenseBonus_LW>點防禦。同時額外獲得一顆免費的煙霧榴彈。"
+LocHelpText="你的煙霧榴彈提供額外<Ability:DenseSmoke_DefenseBonus_LW>點防禦。同時額外獲得一顆免費的煙霧榴彈。"
+LocPromotionPopupText="<Bullet/>你的煙霧榴彈對處於煙霧中的單位提供額外<Ability:DenseSmoke_DefenseBonus_LW>點防禦，最高<Ability:DenseSmoke_DefenseTotal_LW>。同時額外獲得一顆免費的煙霧榴彈。<br/>"
 
 
 [Collateral_LW X2AbilityTemplate]

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.deu
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.deu
@@ -528,9 +528,9 @@ LocPromotionPopupText="<Bullet/> Gilt für GREMLIN-Heilung, Medikits und Genesun
 [DenseSmoke X2AbilityTemplate]
 LocFriendlyName="Dichter Rauch"
 LocFlyOverText="Dichter Rauch"
-LocLongDescription="Deine Rauchgranaten bieten allen im Rauch zusätzlich +10 Verteidigung. Außerdem erhältst du eine kostenlose Rauchgranate."
-LocHelpText="Deine Rauchgranaten bieten +10 Verteidigung zusätzlich. Gewährt eine kostenlose Rauchgranate."
-LocPromotionPopupText="<Bullet/> Gewährt allen Einheiten im Rauch +10 zusätzliche Verteidigung (max. 30).<br/><Bullet/> Zusätzlich erhältst du eine kostenlose Rauchgranate.<br/>"
+LocLongDescription="Deine Rauchgranaten bieten allen im Rauch zusätzlich +<Ability:DenseSmoke_DefenseBonus_LW> Verteidigung. Außerdem erhältst du eine kostenlose Rauchgranate."
+LocHelpText="Deine Rauchgranaten bieten +<Ability:DenseSmoke_DefenseBonus_LW> Verteidigung zusätzlich. Gewährt eine kostenlose Rauchgranate."
+LocPromotionPopupText="<Bullet/> Gewährt allen Einheiten im Rauch +<Ability:DenseSmoke_DefenseBonus_LW> zusätzliche Verteidigung (max. <Ability:DenseSmoke_DefenseTotal_LW>).<br/><Bullet/> Zusätzlich erhältst du eine kostenlose Rauchgranate.<br/>"
 
 [DenseSmokeGrenade X2GrenadeTemplate]
 FriendlyName="Schwere Rauchgranate"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.esn
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.esn
@@ -551,9 +551,9 @@ LocPromotionPopupText="<Bullet/> El efecto se aplica a la curación con GREMLIN,
 [DenseSmoke X2AbilityTemplate]
 LocFriendlyName="Humo denso"
 LocFlyOverText="Humo denso"
-LocLongDescription="Tus granadas de humo confieren 10 de defensa adicional. También otorga una granada de humo gratis."
-LocHelpText="Tus granadas de humo confieren 10 de defensa adicional. También otorga una granada de humo gratis."
-LocPromotionPopupText="<Bullet/> Tus granadas de humo confieren 10 de defensa adicional a aquellos dentro del humo, para un total de 30. También otorga una granada de humo gratis.<br/>"
+LocLongDescription="Tus granadas de humo confieren <Ability:DenseSmoke_DefenseBonus_LW> de defensa adicional. También otorga una granada de humo gratis."
+LocHelpText="Tus granadas de humo confieren <Ability:DenseSmoke_DefenseBonus_LW> de defensa adicional. También otorga una granada de humo gratis."
+LocPromotionPopupText="<Bullet/> Tus granadas de humo confieren <Ability:DenseSmoke_DefenseBonus_LW> de defensa adicional a aquellos dentro del humo, para un total de <Ability:DenseSmoke_DefenseTotal_LW>. También otorga una granada de humo gratis.<br/>"
 
 [Collateral_LW X2AbilityTemplate]
 LocFriendlyName="Daños colaterales"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.fra
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.fra
@@ -586,9 +586,9 @@ LocPromotionPopupText="<Bullet/> L'effet s'applique aux soins du GREMLIN, aux m�
 [DenseSmoke X2AbilityTemplate]
 LocFriendlyName="Fumée dense"
 LocFlyOverText="Fumée dense"
-LocLongDescription="Vos grenades fumigènes octroient 10 points de défense supplémentaires."
-LocHelpText="Vos grenades fumigènes octroient 10 points de défense supplémentaires."
-LocPromotionPopupText="<Bullet/> Vos grenades fumigènes octroient 10 points de défense supplémentaires aux unités se trouvant dans la fumée, pour un total de 30.<br/>"
+LocLongDescription="Vos grenades fumigènes octroient <Ability:DenseSmoke_DefenseBonus_LW> points de défense supplémentaires."
+LocHelpText="Vos grenades fumigènes octroient <Ability:DenseSmoke_DefenseBonus_LW> points de défense supplémentaires."
+LocPromotionPopupText="<Bullet/> Vos grenades fumigènes octroient <Ability:DenseSmoke_DefenseBonus_LW> points de défense supplémentaires aux unités se trouvant dans la fumée, pour un total de <Ability:DenseSmoke_DefenseTotal_LW>.<br/>"
 
 [DenseSmokeGrenade X2GrenadeTemplate]
 FriendlyName="Grenade fumigène dense"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -598,10 +598,25 @@ LocPromotionPopupText="<Bullet/> Effect applies to GREMLIN heal, Medikits and Re
 [DenseSmoke X2AbilityTemplate]
 LocFriendlyName="Dense Smoke"
 LocFlyOverText="Dense Smoke"
-LocLongDescription="Your smoke grenades confer an additional 10 defense. Also grants one free Smoke Grenade."
-LocHelpText="Your smoke grenades confer an additional 10 defense. Also grants one free Smoke Grenade."
-LocPromotionPopupText="<Bullet/> Your smoke grenades confer an additional 10 defense to those within the smoke, for a total of 30. Also grants one free Smoke Grenade.<br/>"
+LocLongDescription="Your smoke grenades confer an additional <Ability:DenseSmoke_DefenseBonus_LW> defense. Also grants one free Smoke Grenade."
+LocHelpText="Your smoke grenades confer an additional <Ability:DenseSmoke_DefenseBonus_LW> defense. Also grants one free Smoke Grenade."
+LocPromotionPopupText="<Bullet/> Your smoke grenades confer an additional <Ability:DenseSmoke_DefenseBonus_LW> defense to those within the smoke, for a total of <Ability:DenseSmoke_DefenseTotal_LW>.<br><Bullet> Grants one free Smoke Grenade.<br><Bullet> The effect will be applied if the unit enters the smoke after it's deployed.<br><Bullet> Applies to enemy units."
 
+; LWOTC Needs Translation
+[CombatStims_LW X2AbilityTemplate]
+LocFriendlyName="Combat Stimulants"
+LocFlyOverText="Combat Stimulants"
+LocLongDescription="Your smoke grenades confer +<Ability:CombatStims_AimBonus_LW> aim and +<Ability:CombatStims_CritBonus_LW> critical chance to units in the smoke cloud."
+LocHelpText="Your smoke grenades confer +<Ability:CombatStims_AimBonus_LW> aim and +<Ability:CombatStims_CritBonus_LW> critical chance to units in the smoke cloud."
+LocPromotionPopupText="<Bullet> The effect persists for as long as the unit remains in the smoke.<br><Bullet> The effect will be applied if the unit enters the smoke after it's deployed.<br><Bullet> Applies to both living and mechanical units.<br><Bullet> Applies to enemy units."
+
+[RegenSmoke_LW X2AbilityTemplate]
+LocFriendlyName="Regenerative Mist"
+LocFlyOverText="Regenerative Mist"
+LocLongDescription="Your smoke grenades heal units in the smoke cloud for <Ability:RegenSmoke_HealAmount_LW> HP at the start of each turn, up to a maximum of <Ability:RegenSmoke_MaxHealAmount_LW> HP per mission."
+LocHelpText="Your smoke grenades heal units in the smoke cloud at the start of each turn."
+LocPromotionPopupText="<Bullet> The effect will be applied if the unit enters the smoke after it's deployed.<br><Bullet> Doesn't apply to mechanical units.<br><Bullet> Applies to enemy units."
+; End Translation
 
 [Collateral_LW X2AbilityTemplate]
 LocFriendlyName="Collateral Damage"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.ita
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.ita
@@ -536,9 +536,9 @@ LocPromotionPopupText="<Bullet/> L'effetto si applica a Cura con GREMLIN, ai med
 [DenseSmoke X2AbilityTemplate]
 LocFriendlyName="Fumo impenetrabile"
 LocFlyOverText="Fumo impenetrabile"
-LocLongDescription="Le granate fumogene conferiscono 10 di Difesa in più."
-LocHelpText="Le granate fumogene conferiscono 10 di Difesa in più."
-LocPromotionPopupText="<Bullet/> Le granate fumogene conferiscono 10 di Difesa in più alle unità all'interno del fumo, per un totale di 30.<br/>"
+LocLongDescription="Le granate fumogene conferiscono <Ability:DenseSmoke_DefenseBonus_LW> di Difesa in più."
+LocHelpText="Le granate fumogene conferiscono <Ability:DenseSmoke_DefenseBonus_LW> di Difesa in più."
+LocPromotionPopupText="<Bullet/> Le granate fumogene conferiscono <Ability:DenseSmoke_DefenseBonus_LW> di Difesa in più alle unità all'interno del fumo, per un totale di <Ability:DenseSmoke_DefenseTotal_LW>.<br/>"
 
 [DenseSmokeGrenade X2GrenadeTemplate]
 FriendlyName="Granata fumogena impenetrabile"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.jpn
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.jpn
@@ -536,9 +536,9 @@ LocPromotionPopupText="<Bullet/>対象は、グレムリン・ヒール、治療
 [DenseSmoke X2AbilityTemplate]
 LocFriendlyName="高密度スモーク"
 LocFlyOverText="高密度スモーク"
-LocLongDescription="スモークグレネードによる防御力+10。"
-LocHelpText="スモークグレネードによる防御力+10。"
-LocPromotionPopupText="<Bullet/>スモークグレネードの煙幕の中にいるユニットが得る防御力+10。合計30。<br/>"
+LocLongDescription="スモークグレネードによる防御力+<Ability:DenseSmoke_DefenseBonus_LW>。"
+LocHelpText="スモークグレネードによる防御力+<Ability:DenseSmoke_DefenseBonus_LW>。"
+LocPromotionPopupText="<Bullet/>スモークグレネードの煙幕の中にいるユニットが得る防御力+<Ability:DenseSmoke_DefenseBonus_LW>。合計<Ability:DenseSmoke_DefenseTotal_LW>。<br/>"
 
 [DenseSmokeGrenade X2GrenadeTemplate]
 FriendlyName="高密度スモークグレネード"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.kor
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.kor
@@ -533,9 +533,9 @@ LocPromotionPopupText="<Bullet/> 이 효과는 그렘린 치료, 메디킷, 레�
 [DenseSmoke X2AbilityTemplate]
 LocFriendlyName="짙은 연막"
 LocFlyOverText="짙은 연막"
-LocLongDescription="연막 수류탄이 10의 추가 방어력을 부여합니다."
-LocHelpText="연막 수류탄이 10의 추가 방어력을 부여합니다."
-LocPromotionPopupText="<Bullet/> 연막 수류탄의 연막 내에 들어온 유닛에게 10의 추가 방어력을 부여할 수 있습니다. 최고는 30입니다.<br/>"
+LocLongDescription="연막 수류탄이 <Ability:DenseSmoke_DefenseBonus_LW>의 추가 방어력을 부여합니다."
+LocHelpText="연막 수류탄이 <Ability:DenseSmoke_DefenseBonus_LW>의 추가 방어력을 부여합니다."
+LocPromotionPopupText="<Bullet/> 연막 수류탄의 연막 내에 들어온 유닛에게 <Ability:DenseSmoke_DefenseBonus_LW>의 추가 방어력을 부여할 수 있습니다. 최고는 <Ability:DenseSmoke_DefenseTotal_LW>입니다.<br/>"
 
 [DenseSmokeGrenade X2GrenadeTemplate]
 FriendlyName="짙은 연막 수류탄"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.pol
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.pol
@@ -528,9 +528,9 @@ LocPromotionPopupText="<Bullet/> Efekt dotyczy leczenia przez gremlina, apteczki
 [DenseSmoke X2AbilityTemplate]
 LocFriendlyName="Gęsty dym"
 LocFlyOverText="Gęsty dym"
-LocLongDescription="Twoje granaty dymne zapewniają dodatkowe 10 pkt. do obrony."
-LocHelpText="Twoje granaty dymne zapewniają dodatkowe 10 pkt. do obrony."
-LocPromotionPopupText="<Bullet/> Twoje granaty dymne zapewniają dodatkowe 10 pkt. do obrony, łącznie 30, jednostkom znajdującym się w obrębie dymu.<br/>"
+LocLongDescription="Twoje granaty dymne zapewniają dodatkowe <Ability:DenseSmoke_DefenseBonus_LW> pkt. do obrony."
+LocHelpText="Twoje granaty dymne zapewniają dodatkowe <Ability:DenseSmoke_DefenseBonus_LW> pkt. do obrony."
+LocPromotionPopupText="<Bullet/> Twoje granaty dymne zapewniają dodatkowe <Ability:DenseSmoke_DefenseBonus_LW> pkt. do obrony, łącznie <Ability:DenseSmoke_DefenseTotal_LW>, jednostkom znajdującym się w obrębie dymu.<br/>"
 
 [DenseSmokeGrenade X2GrenadeTemplate]
 FriendlyName="Granat z gęstym dymem"

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.rus
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.rus
@@ -534,9 +534,9 @@ LocPromotionPopupText="<Bullet/> Эффект добавляется к лече
 [DenseSmoke X2AbilityTemplate]
 LocFriendlyName="Густой дым"
 LocFlyOverText="Густой дым"
-LocLongDescription="Ваши дымовые гранаты дают дополнительно +10 к Защите."
-LocHelpText="Ваши дымовые гранаты дают дополнительно +10 к Защите."
-LocPromotionPopupText="<Bullet/> Ваши дымовые гранаты дают дополнительно +10 ед. к Защите солдатам, находящимся в дыму (суммарно +30).<br/>"
+LocLongDescription="Ваши дымовые гранаты дают дополнительно +<Ability:DenseSmoke_DefenseBonus_LW> к Защите."
+LocHelpText="Ваши дымовые гранаты дают дополнительно +<Ability:DenseSmoke_DefenseBonus_LW> к Защите."
+LocPromotionPopupText="<Bullet/> Ваши дымовые гранаты дают дополнительно +<Ability:DenseSmoke_DefenseBonus_LW> ед. к Защите солдатам, находящимся в дыму (суммарно +<Ability:DenseSmoke_DefenseTotal_LW>).<br/>"
 
 [DenseSmokeGrenade X2GrenadeTemplate]
 FriendlyName="Граната с густым дымом"

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
@@ -8,8 +8,9 @@ class X2Ability_PerkPackAbilitySet2 extends X2Ability config (LW_SoldierSkills) 
 
 var localized string TrojanVirus;
 var localized string TrojanVirusTriggered;
-var localized string DenseSmokeGrenadeEffectDisplayName;
-var localized string DenseSmokeGrenadeEffectDisplayDesc;
+// DEPRECATED
+// var localized string DenseSmokeGrenadeEffectDisplayName;
+// var localized string DenseSmokeGrenadeEffectDisplayDesc;
 var localized string ShellshockEffectName, ShellshockEffectDesc, ShockwaveEffectName, ShockwaveEffectDesc;
 
 var config int NUM_AIRDROP_CHARGES;
@@ -25,8 +26,8 @@ var config int COLLATERAL_AMMO;
 var config int COLLATERAL_RADIUS;
 var config int COLLATERAL_ENVDMG;
 
-
-var config int DENSESMOKEGRENADE_HITMOD;
+// DEPRECATED
+// var config int DENSESMOKEGRENADE_HITMOD;
 var config array<name> SMOKE_GRENADES_FOR_DENSE_SMOKE;
 
 var config int STING_GRENADE_STUN_CHANCE;
@@ -85,6 +86,8 @@ static function array<X2DataTemplate> CreateTemplates()
 	Templates.AddItem(AddSmokeGrenade());
 	Templates.AddItem(AddSavior());
 	Templates.AddItem(AddDenseSmoke());
+	Templates.AddItem(AddCombatStims());
+	Templates.AddItem(AddRegenSmoke());
 	Templates.AddItem(AddRapidDeployment());
 	Templates.AddItem(AddAirdrop());
 	Templates.AddItem(AddSwordSlice_LWAbility());
@@ -631,61 +634,13 @@ static function X2AbilityTemplate AddSavior()
 	return Template;
 }
 
-//this increases the defense bonus of smoke grenades and smoke bombs used by the unit
-// accomplished by swapping out existing smoke grenade/bomb for a dense smoke version
-//ALTERATION: Just going to make this a passive and just apply the effect to traditional smoke grenades
-//MANY DEPERECATIONS INBOUND LOL
 static function X2AbilityTemplate AddDenseSmoke()
 {
 	local X2AbilityTemplate						Template;
 	local X2Effect_TemporaryItem				TemporaryItemEffect;
 	local ResearchConditional					Conditional;
-	//local X2AbilityTrigger_UnitPostBeginPlay	Trigger;
 
 	Template = PurePassive('DenseSmoke', "img:///UILibrary_LW_PerkPack.LW_AbilityDenseSmoke");
-	//`CREATE_X2ABILITY_TEMPLATE(Template, 'DenseSmoke');
-
-	//MEGA DELETE. We don't need any of this. Also got rid of a duplicate return.
-	/*Template.IconImage = "img:///UILibrary_LW_PerkPack.LW_AbilityDenseSmoke";
-	Template.AbilitySourceName = 'eAbilitySource_Perk';
-	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
-	Template.Hostility = eHostility_Neutral;
-	Template.AbilityToHitCalc = default.DeadEye;
-	Template.AbilityTargetStyle = default.SelfTarget;
-	Template.bIsPassive = true;
-	Template.bCrossClassEligible = true;
-
-	Trigger = new class'X2AbilityTrigger_UnitPostBeginPlay';
-	Trigger.Priority -= 40; // delayed so that any other abilities that add items happen first
-	Template.AbilityTriggers.AddItem(Trigger);
-
-	TemporaryItemEffect = new class'X2Effect_TemporaryItem';
-	TemporaryItemEffect.EffectName = 'DenseSmokeGrenadeEffect';
-	TemporaryItemEffect.ItemName = 'DenseSmokeGrenade';
-	TemporaryItemEffect.bReplaceExistingItemOnly = true;
-	TemporaryItemEffect.ExistingItemName = 'SmokeGrenade';
-	TemporaryItemEffect.ForceCheckAbilities.AddItem('LaunchGrenade');
-	TemporaryItemEffect.bIgnoreItemEquipRestrictions = true;
-	TemporaryItemEffect.BuildPersistentEffect(1, true, false);
-	TemporaryItemEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true,,Template.AbilitySourceName);
-	TemporaryItemEffect.DuplicateResponse = eDupe_Ignore;
-	Template.AddTargetEffect(TemporaryItemEffect);
-
-	TemporaryItemEffect = new class'X2Effect_TemporaryItem';
-	TemporaryItemEffect.EffectName = 'DenseSmokeBombEffect';
-	TemporaryItemEffect.ItemName = 'DenseSmokeGrenadeMk2';
-	TemporaryItemEffect.bReplaceExistingItemOnly = true;
-	TemporaryItemEffect.ExistingItemName = 'SmokeGrenadeMk2';
-	TemporaryItemEffect.ForceCheckAbilities.AddItem('LaunchGrenade');
-	TemporaryItemEffect.bIgnoreItemEquipRestrictions = true;
-	TemporaryItemEffect.BuildPersistentEffect(1, true, false);
-	//TemporaryItemEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true,,Template.AbilitySourceName);
-	TemporaryItemEffect.DuplicateResponse = eDupe_Ignore;
-	Template.AddTargetEffect(TemporaryItemEffect);
-
-	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
-
-	return Template;*/
 
 	Conditional.ResearchProjectName = 'AdvancedGrenades';
 	Conditional.ItemName = 'SmokeGrenadeMk2';
@@ -695,7 +650,7 @@ static function X2AbilityTemplate AddDenseSmoke()
 	TemporaryItemEffect.ItemName = 'SmokeGrenade';
 	TemporaryItemEffect.ResearchOptionalItems.AddItem(Conditional);
 
-	//POTENTIALLY DEPERECATED
+	// POTENTIALLY DEPERECATED
 	TemporaryItemEffect.AlternativeItemNames.AddItem('DenseSmokeGrenade');
 	TemporaryItemEffect.AlternativeItemNames.AddItem('DenseSmokeGrenadeMk2');
 
@@ -712,21 +667,37 @@ static function X2AbilityTemplate AddDenseSmoke()
 	return Template;
 }
 
-static function X2Effect DenseSmokeEffect()
+// DEPRECATED
+// static function X2Effect DenseSmokeEffect()
+// {
+	// local X2Effect_DenseSmokeEffect		Effect;
+	// local X2Condition_AbilityProperty	AbilityCondition;
+
+	// Effect = new class'X2Effect_DenseSmokeEffect';
+	// Effect.BuildPersistentEffect(class'X2Effect_ApplySmokeGrenadeToWorld'.default.Duration + 1, false, false, false, eGameRule_PlayerTurnBegin);
+	// Effect.SetDisplayInfo(ePerkBuff_Bonus, default.DenseSmokeGrenadeEffectDisplayName, default.DenseSmokeGrenadeEffectDisplayDesc, "img:///UILibrary_LW_PerkPack.LW_AbilityDenseSmoke", true,,'eAbilitySource_Perk');
+	// Effect.Defense = default.DENSESMOKEGRENADE_HITMOD;
+
+	// AbilityCondition = new class'X2Condition_AbilityProperty';
+	// AbilityCondition.OwnerHasSoldierAbilities.AddItem('DenseSmoke');
+	// Effect.TargetConditions.AddItem(AbilityCondition);
+	
+	// return Effect;
+// }
+
+static function X2AbilityTemplate AddCombatStims()
 {
-	local X2Effect_DenseSmokeEffect Effect;
-	local X2Condition_AbilityProperty	AbilityCondition;
+	return PurePassive('CombatStims_LW', "img:///UILibrary_XPerkIconPack.UIPerk_smoke_shot_2");
+}
 
-	Effect = new class'X2Effect_DenseSmokeEffect';
-	Effect.BuildPersistentEffect(class'X2Effect_ApplySmokeGrenadeToWorld'.default.Duration + 1, false, false, false, eGameRule_PlayerTurnBegin);
-	Effect.SetDisplayInfo(ePerkBuff_Bonus, default.DenseSmokeGrenadeEffectDisplayName, default.DenseSmokeGrenadeEffectDisplayDesc, "img:///UILibrary_LW_PerkPack.LW_AbilityDenseSmoke", true,,'eAbilitySource_Perk');
-	Effect.Defense = default.DENSESMOKEGRENADE_HITMOD;
+static function X2AbilityTemplate AddRegenSmoke()
+{
+	return PurePassive('RegenSmoke_LW', "img:///UILibrary_XPerkIconPack.UIPerk_smoke_medkit");
+}
 
-	AbilityCondition = new class'X2Condition_AbilityProperty';
-    AbilityCondition.OwnerHasSoldierAbilities.AddItem('DenseSmoke');
-    Effect.TargetConditions.AddItem(AbilityCondition);
-
-	return Effect;
+static function X2AbilityTemplate AddBastionPassive()
+{
+	return PurePassive('BastionPassive', "img:///UILibrary_LW_PerkPack.LW_AbilityBastion", , 'eAbilitySource_Psionic');
 }
 
 //this ability allows the next use (this turn) of smoke grenade or flashbang to be free
@@ -2726,7 +2697,6 @@ static function AddEffectsToGrenades()
 
 	ItemManager.GetTemplateNames(TemplateNames);
 
-	// All grenades
 	foreach TemplateNames(TemplateName)
 	{
 		ItemManager.FindDataTemplateAllDifficulties(TemplateName, TemplateAllDifficulties);
@@ -2737,37 +2707,47 @@ static function AddEffectsToGrenades()
 			GrenadeTemplate = X2GrenadeTemplate(Template);
 			if (GrenadeTemplate != none)
 			{
+				// Damaging Grenades + Flashbang
 				if ( (GrenadeTemplate.BaseDamage.Damage > 0  && (GrenadeTemplate.ThrownGrenadeEffects.Length > 0 || GrenadeTemplate.LaunchedGrenadeEffects.Length > 0)) || default.ATTACK_GRENADES.find(TemplateName) != INDEX_NONE)
 				{
 					GrenadeTemplate.ThrownGrenadeEffects.AddItem(ShellShockEffect);
 					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(ShellShockEffect);
 				}
-			}
-		}
-	}
-	
-	// Damaging Grenades
-
-	ItemManager.GetTemplateNames(TemplateNames);
-	foreach TemplateNames(TemplateName)
-	{
-		ItemManager.FindDataTemplateAllDifficulties(TemplateName, TemplateAllDifficulties);
-		// Iterate over all variants
-		
-		foreach TemplateAllDifficulties(Template)
-		{
-			GrenadeTemplate = X2GrenadeTemplate(Template);
-			if (GrenadeTemplate != none)
-			{
+				// Damaging Grenades
 				if ( (GrenadeTemplate.BaseDamage.Damage > 0  && (GrenadeTemplate.ThrownGrenadeEffects.Length > 0 || GrenadeTemplate.LaunchedGrenadeEffects.Length > 0)))
 				{
 					GrenadeTemplate.ThrownGrenadeEffects.AddItem(ShockwaveEffect);
 					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(ShockwaveEffect);
 				}
+				// Flashbangs Grenades
+				if (default.FLASHBANGS_FOR_STING_GRENADES.Find(GrenadeTemplate.DataName) != INDEX_NONE)
+				{
+					// Sting Grenades
+					GrenadeTemplate.ThrownGrenadeEffects.AddItem(StingGrenadeEffect());
+					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(StingGrenadeEffect());
+				}
+				// Smoke Grenades
+				if (default.SMOKE_GRENADES_FOR_DENSE_SMOKE.Find(GrenadeTemplate.DataName) != INDEX_NONE)
+				{
+					// Combat Stimulants
+					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWApplyCombatStimsToWorld'.static.CombatStimsWorldEffect());
+					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWCombatStims'.static.CombatStimsEffect());
+					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWApplyCombatStimsToWorld'.static.CombatStimsWorldEffect());
+					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWCombatStims'.static.CombatStimsEffect());
+					// Dense Smoke
+					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWApplyDenseSmokeToWorld'.static.DenseSmokeWorldEffect());
+					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWDenseSmoke'.static.DenseSmokeEffect());
+					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWApplyDenseSmokeToWorld'.static.DenseSmokeWorldEffect());
+					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWDenseSmoke'.static.DenseSmokeEffect());
+					// Regenerative Mist
+					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWApplyRegenSmokeToWorld'.static.RegenSmokeWorldEffect());
+					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWRegenSmoke'.static.RegenSmokeEffect());
+					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWApplyRegenSmokeToWorld'.static.RegenSmokeWorldEffect());
+					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWRegenSmoke'.static.RegenSmokeEffect());
+				}
 			}
 		}
 	}
-
 }
 
 

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
@@ -2730,19 +2730,19 @@ static function AddEffectsToGrenades()
 				if (default.SMOKE_GRENADES_FOR_DENSE_SMOKE.Find(GrenadeTemplate.DataName) != INDEX_NONE)
 				{
 					// Combat Stimulants
-					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWApplyCombatStimsToWorld'.static.CombatStimsWorldEffect());
+					GrenadeTemplate.ThrownGrenadeEffects.AddItem(new class'X2Effect_LWApplyCombatStimsToWorld');
 					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWCombatStims'.static.CombatStimsEffect());
-					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWApplyCombatStimsToWorld'.static.CombatStimsWorldEffect());
+					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(new class'X2Effect_LWApplyCombatStimsToWorld');
 					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWCombatStims'.static.CombatStimsEffect());
 					// Dense Smoke
-					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWApplyDenseSmokeToWorld'.static.DenseSmokeWorldEffect());
+					GrenadeTemplate.ThrownGrenadeEffects.AddItem(new class'X2Effect_LWApplyDenseSmokeToWorld');
 					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWDenseSmoke'.static.DenseSmokeEffect());
-					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWApplyDenseSmokeToWorld'.static.DenseSmokeWorldEffect());
+					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(new class'X2Effect_LWApplyDenseSmokeToWorld');
 					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWDenseSmoke'.static.DenseSmokeEffect());
 					// Regenerative Mist
-					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWApplyRegenSmokeToWorld'.static.RegenSmokeWorldEffect());
+					GrenadeTemplate.ThrownGrenadeEffects.AddItem(new class'X2Effect_LWApplyRegenSmokeToWorld');
 					GrenadeTemplate.ThrownGrenadeEffects.AddItem(class'X2Effect_LWRegenSmoke'.static.RegenSmokeEffect());
-					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWApplyRegenSmokeToWorld'.static.RegenSmokeWorldEffect());
+					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(new class'X2Effect_LWApplyRegenSmokeToWorld');
 					GrenadeTemplate.LaunchedGrenadeEffects.AddItem(class'X2Effect_LWRegenSmoke'.static.RegenSmokeEffect());
 				}
 			}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2DownloadableContentInfo_LWPerkPack.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2DownloadableContentInfo_LWPerkPack.uc
@@ -47,55 +47,7 @@ static event OnPostTemplatesCreated()
 
 	UpdateBaseGameOverwatchShot();
 	UpdateBaseGameThrowGrenade();
-	/*
-		Might not be the right place to be adding this. I recall that lwotc does something unique in place
-		of a lot of OPTC shenanigans.
-	*/
-	PatchItemsForDenseSmoke(ItemManager);
-	PatchItemsForStingGrenades(ItemManager);
 	//UpdateBaseGameAidProtocol();
-}
-
-static function PatchItemsForStingGrenades(X2ItemTemplateManager ItemManager)
-{
-	local X2GrenadeTemplate					Template;
-	local name								ItemName;
-
-	foreach class'LW_PerkPack_Integrated.X2Ability_PerkPackAbilitySet2'.default.FLASHBANGS_FOR_STING_GRENADES(ItemName)
-	{
-		Template = X2GrenadeTemplate(ItemManager.FindItemTemplate(ItemName));
-		if(Template != none)
-		{
-			UpdateForStingGrenades(Template);
-		}
-	}
-}
-
-static function UpdateForStingGrenades(X2GrenadeTemplate Template)
-{
-	Template.ThrownGrenadeEffects.AddItem(class'LW_PerkPack_Integrated.X2Ability_PerkPackAbilitySet2'.static.StingGrenadeEffect());
-	Template.LaunchedGrenadeEffects.AddItem(class'LW_PerkPack_Integrated.X2Ability_PerkPackAbilitySet2'.static.StingGrenadeEffect());
-}
-
-static function PatchItemsForDenseSmoke(X2ItemTemplateManager ItemManager)
-{
-	local X2GrenadeTemplate					Template;
-	local name								ItemName;
-
-	foreach class'LW_PerkPack_Integrated.X2Ability_PerkPackAbilitySet2'.default.SMOKE_GRENADES_FOR_DENSE_SMOKE(ItemName)
-	{
-		Template = X2GrenadeTemplate(ItemManager.FindItemTemplate(ItemName));
-		if(Template != none)
-		{
-			UpdateForDenseSmoke(Template);
-		}
-	}
-}
-
-static function UpdateForDenseSmoke(X2GrenadeTemplate Template)
-{
-	Template.ThrownGrenadeEffects.AddItem(class'LW_PerkPack_Integrated.X2Ability_PerkPackAbilitySet2'.static.DenseSmokeEffect());
-	Template.LaunchedGrenadeEffects.AddItem(class'LW_PerkPack_Integrated.X2Ability_PerkPackAbilitySet2'.static.DenseSmokeEffect());
 }
 
 //Restores VM's ability to modify radius
@@ -667,11 +619,28 @@ static function bool AbilityTagExpandHandler_CH(string InString, out string OutS
 		case 'HT_MAX_DODGE_BONUS':
 			Outstring = string(class'X2Effect_HardTarget'.default.HT_MAX_DODGE_BONUS);
 			return true;
-				
-        default:
-            return false;
-    }
-    return false;
+		case 'CombatStims_AimBonus_LW':
+			OutString = string(class'X2Effect_LWCombatStims'.default.AimBonus);
+			return true;
+		case 'CombatStims_CritBonus_LW':
+			OutString = string(class'X2Effect_LWCombatStims'.default.CritBonus);
+			return true;
+		case 'DenseSmoke_DefenseBonus_LW':
+			OutString = string(class'X2Effect_LWDenseSmoke'.default.DefenseBonus);
+			return true;
+		case 'DenseSmoke_DefenseTotal_LW':
+			OutString = string(class'X2Effect_LWDenseSmoke'.default.DefenseBonus + class'X2Item_DefaultGrenades'.default.SMOKEGRENADE_HITMOD);
+			return true;
+		case 'RegenSmoke_HealAmount_LW':
+			OutString = string(class'X2Effect_LWRegenSmoke'.default.HealAmount);
+			return true;
+		case 'RegenSmoke_MaxHealAmount_LW':
+			OutString = string(class'X2Effect_LWRegenSmoke'.default.MaxHealAmount);
+			return true;
+		default:
+			return false;
+	}
+	return false;
 }
 
 static function X2ItemTemplate GetItemBoundToAbilityFromUnit(XComGameState_Unit UnitState, name AbilityName, XComGameState GameState)

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWAdditionalSmokeEffect.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWAdditionalSmokeEffect.uc
@@ -1,0 +1,36 @@
+//---------------------------------------------------------------------------------------
+//  FILE:   X2Effect_LWAdditionalSmokeEffect.uc
+//  AUTHOR:  Merist
+//  PURPOSE: Pseudo-interface for effects that should apply to units in the area of the smoke grenades.
+//           Expects effect-specific X2Effect_LWApplyAdditionalSmokeEffectToWorld classes to be present.
+//---------------------------------------------------------------------------------------
+class X2Effect_LWAdditionalSmokeEffect extends X2Effect_Persistent config(LW_SoldierSkills) abstract;
+
+var protectedwrite name RelevantAbilityName;
+var class<X2Effect_LWApplyAdditionalSmokeEffectToWorld> WorldEffectClass;
+
+var localized string strEffectBonusName;
+var localized string strEffectBonusDesc;
+
+function bool IsEffectCurrentlyRelevant(XComGameState_Effect EffectGameState, XComGameState_Unit TargetUnit)
+{
+    return TargetUnit.IsInWorldEffectTile(default.WorldEffectClass.Name);
+}
+
+static function SmokeGrenadeVisualizationTickedOrRemoved(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, const name EffectApplyResult)
+{
+    local X2Action_UpdateUI UpdateUIAction;
+
+    UpdateUIAction = X2Action_UpdateUI(class'X2Action_UpdateUI'.static.AddToVisualizationTree(ActionMetadata, VisualizeGameState.GetContext(), false, ActionMetadata.LastActionAdded));
+    UpdateUIAction.SpecificID = ActionMetadata.StateObject_NewState.ObjectID;
+    UpdateUIAction.UpdateType = EUIUT_UnitFlag_Buffs;
+}
+
+defaultproperties
+{
+    DuplicateResponse = eDupe_Refresh
+    // EffectTickedVisualizationFn = SmokeGrenadeVisualizationTickedOrRemoved;
+    // EffectRemovedVisualizationFn = SmokeGrenadeVisualizationTickedOrRemoved;
+
+    WorldEffectClass = class'X2Effect_LWApplyAdditionalSmokeEffectToWorld'
+}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWAdditionalSmokeEffect.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWAdditionalSmokeEffect.uc
@@ -6,7 +6,6 @@
 //---------------------------------------------------------------------------------------
 class X2Effect_LWAdditionalSmokeEffect extends X2Effect_Persistent config(LW_SoldierSkills) abstract;
 
-var protectedwrite name RelevantAbilityName;
 var class<X2Effect_LWApplyAdditionalSmokeEffectToWorld> WorldEffectClass;
 
 var localized string strEffectBonusName;
@@ -17,14 +16,14 @@ function bool IsEffectCurrentlyRelevant(XComGameState_Effect EffectGameState, XC
     return TargetUnit.IsInWorldEffectTile(default.WorldEffectClass.Name);
 }
 
-static function SmokeGrenadeVisualizationTickedOrRemoved(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, const name EffectApplyResult)
-{
-    local X2Action_UpdateUI UpdateUIAction;
+// static function SmokeGrenadeVisualizationTickedOrRemoved(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, const name EffectApplyResult)
+// {
+//     local X2Action_UpdateUI UpdateUIAction;
 
-    UpdateUIAction = X2Action_UpdateUI(class'X2Action_UpdateUI'.static.AddToVisualizationTree(ActionMetadata, VisualizeGameState.GetContext(), false, ActionMetadata.LastActionAdded));
-    UpdateUIAction.SpecificID = ActionMetadata.StateObject_NewState.ObjectID;
-    UpdateUIAction.UpdateType = EUIUT_UnitFlag_Buffs;
-}
+//     UpdateUIAction = X2Action_UpdateUI(class'X2Action_UpdateUI'.static.AddToVisualizationTree(ActionMetadata, VisualizeGameState.GetContext(), false, ActionMetadata.LastActionAdded));
+//     UpdateUIAction.SpecificID = ActionMetadata.StateObject_NewState.ObjectID;
+//     UpdateUIAction.UpdateType = EUIUT_UnitFlag_Buffs;
+// }
 
 defaultproperties
 {

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyAdditionalSmokeEffectToWorld.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyAdditionalSmokeEffectToWorld.uc
@@ -6,6 +6,20 @@
 //---------------------------------------------------------------------------------------
 class X2Effect_LWApplyAdditionalSmokeEffectToWorld extends X2Effect_World abstract;
 
+var privatewrite name RelevantAbilityName;
+
+simulated function ApplyEffectToWorld(const out EffectAppliedData ApplyEffectParameters, XComGameState NewGameState)
+{
+    local XComGameState_Unit SourceStateObject;
+
+    SourceStateObject = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(ApplyEffectParameters.SourceStateObjectRef.ObjectID));
+
+    if (SourceStateObject != none && SourceStateObject.HasSoldierAbility(default.RelevantAbilityName, true))
+    {
+        super.ApplyEffectToWorld(ApplyEffectParameters, NewGameState);
+    }
+}
+
 simulated protected function OnEffectAdded(const out EffectAppliedData ApplyEffectParameters, XComGameState_BaseObject kNewTargetState, XComGameState NewGameState, XComGameState_Effect NewEffectState)
 {
 }
@@ -22,7 +36,7 @@ simulated function AddX2ActionsForVisualization_Tick(XComGameState VisualizeGame
 {
 }
 
-static simulated function bool FillRequiresLOSToTargetLocation( )
+static simulated function bool FillRequiresLOSToTargetLocation()
 {
     return !class'CHHelpers'.default.DisableExtraLOSCheckForSmoke; 
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyAdditionalSmokeEffectToWorld.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyAdditionalSmokeEffectToWorld.uc
@@ -1,0 +1,38 @@
+//---------------------------------------------------------------------------------------
+//  FILE:   X2Effect_LWApplyAdditionalSmokeEffectToWorld.uc
+//  AUTHOR:  Merist
+//  PURPOSE: A mirror of the smoke world effect. Has no visualization or particales.
+//           Used to add and validate additional effects on movement.
+//---------------------------------------------------------------------------------------
+class X2Effect_LWApplyAdditionalSmokeEffectToWorld extends X2Effect_World abstract;
+
+simulated protected function OnEffectAdded(const out EffectAppliedData ApplyEffectParameters, XComGameState_BaseObject kNewTargetState, XComGameState NewGameState, XComGameState_Effect NewEffectState)
+{
+}
+
+event array<ParticleSystem> GetParticleSystem_Fill()
+{
+}
+
+simulated function AddX2ActionsForVisualization(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, name EffectApplyResult)
+{
+}
+
+simulated function AddX2ActionsForVisualization_Tick(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, const int TickIndex, XComGameState_Effect EffectState)
+{
+}
+
+static simulated function bool FillRequiresLOSToTargetLocation( )
+{
+    return !class'CHHelpers'.default.DisableExtraLOSCheckForSmoke; 
+}
+
+static simulated function int GetTileDataNumTurns() 
+{ 
+    return class'X2Effect_ApplySmokeGrenadeToWorld'.default.Duration;
+}
+
+defaultproperties
+{
+    bCenterTile = true;
+}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyCombatStimsToWorld.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyCombatStimsToWorld.uc
@@ -1,0 +1,23 @@
+class X2Effect_LWApplyCombatStimsToWorld extends X2Effect_LWApplyAdditionalSmokeEffectToWorld;
+
+event array<X2Effect> GetTileEnteredEffects()
+{
+    local array<X2Effect> TileEnteredEffects;
+
+    TileEnteredEffects.AddItem(class'X2Effect_LWCombatStims'.static.CombatStimsEffect(true));
+
+    return TileEnteredEffects;
+}
+
+static function X2Effect_LWApplyAdditionalSmokeEffectToWorld CombatStimsWorldEffect()
+{
+    local X2Effect_LWApplyAdditionalSmokeEffectToWorld  Effect;
+    local X2Condition_AbilityProperty                   AbilityCondition;
+
+    Effect = new class'X2Effect_LWApplyCombatStimsToWorld';
+    AbilityCondition = new class'X2Condition_AbilityProperty';
+    AbilityCondition.OwnerHasSoldierAbilities.AddItem(class'X2Effect_LWCombatStims'.default.RelevantAbilityName);
+    Effect.TargetConditions.AddItem(AbilityCondition);
+
+    return Effect;
+}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyCombatStimsToWorld.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyCombatStimsToWorld.uc
@@ -9,15 +9,7 @@ event array<X2Effect> GetTileEnteredEffects()
     return TileEnteredEffects;
 }
 
-static function X2Effect_LWApplyAdditionalSmokeEffectToWorld CombatStimsWorldEffect()
+defaultproperties
 {
-    local X2Effect_LWApplyAdditionalSmokeEffectToWorld  Effect;
-    local X2Condition_AbilityProperty                   AbilityCondition;
-
-    Effect = new class'X2Effect_LWApplyCombatStimsToWorld';
-    AbilityCondition = new class'X2Condition_AbilityProperty';
-    AbilityCondition.OwnerHasSoldierAbilities.AddItem(class'X2Effect_LWCombatStims'.default.RelevantAbilityName);
-    Effect.TargetConditions.AddItem(AbilityCondition);
-
-    return Effect;
+    RelevantAbilityName = CombatStims_LW
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyDenseSmokeToWorld.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyDenseSmokeToWorld.uc
@@ -1,0 +1,23 @@
+class X2Effect_LWApplyDenseSmokeToWorld extends X2Effect_LWApplyAdditionalSmokeEffectToWorld;
+
+event array<X2Effect> GetTileEnteredEffects()
+{
+    local array<X2Effect> TileEnteredEffects;
+
+    TileEnteredEffects.AddItem(class'X2Effect_LWDenseSmoke'.static.DenseSmokeEffect(true));
+
+    return TileEnteredEffects;
+}
+
+static function X2Effect_LWApplyAdditionalSmokeEffectToWorld DenseSmokeWorldEffect()
+{
+    local X2Effect_LWApplyAdditionalSmokeEffectToWorld  Effect;
+    local X2Condition_AbilityProperty                   AbilityCondition;
+
+    Effect = new class'X2Effect_LWApplyDenseSmokeToWorld';
+    AbilityCondition = new class'X2Condition_AbilityProperty';
+    AbilityCondition.OwnerHasSoldierAbilities.AddItem(class'X2Effect_LWDenseSmoke'.default.RelevantAbilityName);
+    Effect.TargetConditions.AddItem(AbilityCondition);
+
+    return Effect;
+}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyDenseSmokeToWorld.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyDenseSmokeToWorld.uc
@@ -9,15 +9,7 @@ event array<X2Effect> GetTileEnteredEffects()
     return TileEnteredEffects;
 }
 
-static function X2Effect_LWApplyAdditionalSmokeEffectToWorld DenseSmokeWorldEffect()
+defaultproperties
 {
-    local X2Effect_LWApplyAdditionalSmokeEffectToWorld  Effect;
-    local X2Condition_AbilityProperty                   AbilityCondition;
-
-    Effect = new class'X2Effect_LWApplyDenseSmokeToWorld';
-    AbilityCondition = new class'X2Condition_AbilityProperty';
-    AbilityCondition.OwnerHasSoldierAbilities.AddItem(class'X2Effect_LWDenseSmoke'.default.RelevantAbilityName);
-    Effect.TargetConditions.AddItem(AbilityCondition);
-
-    return Effect;
+    RelevantAbilityName = DenseSmoke
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyRegenSmokeToWorld.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyRegenSmokeToWorld.uc
@@ -9,15 +9,7 @@ event array<X2Effect> GetTileEnteredEffects()
     return TileEnteredEffects;
 }
 
-static function X2Effect_LWApplyAdditionalSmokeEffectToWorld RegenSmokeWorldEffect()
+defaultproperties
 {
-    local X2Effect_LWApplyAdditionalSmokeEffectToWorld  Effect;
-    local X2Condition_AbilityProperty                   AbilityCondition;
-
-    Effect = new class'X2Effect_LWApplyRegenSmokeToWorld';
-    AbilityCondition = new class'X2Condition_AbilityProperty';
-    AbilityCondition.OwnerHasSoldierAbilities.AddItem(class'X2Effect_LWRegenSmoke'.default.RelevantAbilityName);
-    Effect.TargetConditions.AddItem(AbilityCondition);
-
-    return Effect;
+    RelevantAbilityName = RegenSmoke_LW
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyRegenSmokeToWorld.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWApplyRegenSmokeToWorld.uc
@@ -1,0 +1,23 @@
+class X2Effect_LWApplyRegenSmokeToWorld extends X2Effect_LWApplyAdditionalSmokeEffectToWorld;
+
+event array<X2Effect> GetTileEnteredEffects()
+{
+    local array<X2Effect> TileEnteredEffects;
+
+    TileEnteredEffects.AddItem(class'X2Effect_LWRegenSmoke'.static.RegenSmokeEffect(true));
+
+    return TileEnteredEffects;
+}
+
+static function X2Effect_LWApplyAdditionalSmokeEffectToWorld RegenSmokeWorldEffect()
+{
+    local X2Effect_LWApplyAdditionalSmokeEffectToWorld  Effect;
+    local X2Condition_AbilityProperty                   AbilityCondition;
+
+    Effect = new class'X2Effect_LWApplyRegenSmokeToWorld';
+    AbilityCondition = new class'X2Condition_AbilityProperty';
+    AbilityCondition.OwnerHasSoldierAbilities.AddItem(class'X2Effect_LWRegenSmoke'.default.RelevantAbilityName);
+    Effect.TargetConditions.AddItem(AbilityCondition);
+
+    return Effect;
+}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWCombatStims.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWCombatStims.uc
@@ -26,6 +26,7 @@ static function X2Effect CombatStimsEffect(optional bool bSkipAbilityCheck)
 {
     local X2Effect_LWCombatStims        Effect;
     local X2Condition_AbilityProperty   AbilityCondition;
+    local X2Condition_UnitProperty      UnitPropertyCondition;
 
     Effect = new class'X2Effect_LWCombatStims';
     Effect.BuildPersistentEffect(class'X2Effect_ApplySmokeGrenadeToWorld'.default.Duration + 1, false, false, false, eGameRule_PlayerTurnBegin);
@@ -35,10 +36,17 @@ static function X2Effect CombatStimsEffect(optional bool bSkipAbilityCheck)
         "img:///UILibrary_XPerkIconPack.UIPerk_smoke_shot_2",
         true,,'eAbilitySource_Perk');
 
+    UnitPropertyCondition = new class'X2Condition_UnitProperty';
+    UnitPropertyCondition.ExcludeDead = false;
+    UnitPropertyCondition.ExcludeHostileToSource = false;
+    UnitPropertyCondition.ExcludeFriendlyToSource = false;
+    UnitPropertyCondition.FailOnNonUnits = true;
+    Effect.TargetConditions.AddItem(UnitPropertyCondition);
+
     if (!bSkipAbilityCheck)
     {
         AbilityCondition = new class'X2Condition_AbilityProperty';
-        AbilityCondition.OwnerHasSoldierAbilities.AddItem(default.RelevantAbilityName);
+        AbilityCondition.OwnerHasSoldierAbilities.AddItem(class'X2Effect_LWApplyCombatStimsToWorld'.default.RelevantAbilityName);
         Effect.TargetConditions.AddItem(AbilityCondition);
     }
 
@@ -48,6 +56,5 @@ static function X2Effect CombatStimsEffect(optional bool bSkipAbilityCheck)
 defaultproperties
 {
     EffectName = CombatStims_LW
-    RelevantAbilityName = CombatStims_LW
     WorldEffectClass = class'X2Effect_LWApplyCombatStimsToWorld'
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWCombatStims.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWCombatStims.uc
@@ -1,0 +1,53 @@
+class X2Effect_LWCombatStims extends X2Effect_LWAdditionalSmokeEffect;
+
+var config int AimBonus;
+var config int CritBonus;
+
+function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit Attacker, XComGameState_Unit Target, XComGameState_Ability AbilityState, class<X2AbilityToHitCalc> ToHitType, bool bMelee, bool bFlanking, bool bIndirectFire, out array<ShotModifierInfo> ShotModifiers)
+{
+    local ShotModifierInfo AimShotModifier;
+    local ShotModifierInfo CritShotModifier;
+
+    if (Attacker.IsInWorldEffectTile(default.WorldEffectClass.Name))
+    {
+        AimShotModifier.ModType = eHit_Success;
+        AimShotModifier.Value = default.AimBonus;
+        AimShotModifier.Reason = FriendlyName;
+        ShotModifiers.AddItem(AimShotModifier);
+
+        CritShotModifier.ModType = eHit_Crit;
+        CritShotModifier.Value = default.CritBonus;
+        CritShotModifier.Reason = FriendlyName;
+        ShotModifiers.AddItem(CritShotModifier);
+    }
+}
+
+static function X2Effect CombatStimsEffect(optional bool bSkipAbilityCheck)
+{
+    local X2Effect_LWCombatStims        Effect;
+    local X2Condition_AbilityProperty   AbilityCondition;
+
+    Effect = new class'X2Effect_LWCombatStims';
+    Effect.BuildPersistentEffect(class'X2Effect_ApplySmokeGrenadeToWorld'.default.Duration + 1, false, false, false, eGameRule_PlayerTurnBegin);
+    Effect.SetDisplayInfo(ePerkBuff_Bonus,
+        default.strEffectBonusName,
+        default.strEffectBonusDesc,
+        "img:///UILibrary_XPerkIconPack.UIPerk_smoke_shot_2",
+        true,,'eAbilitySource_Perk');
+
+    if (!bSkipAbilityCheck)
+    {
+        AbilityCondition = new class'X2Condition_AbilityProperty';
+        AbilityCondition.OwnerHasSoldierAbilities.AddItem(default.RelevantAbilityName);
+        Effect.TargetConditions.AddItem(AbilityCondition);
+    }
+
+    return Effect;
+}
+
+defaultproperties
+{
+    EffectName = CombatStims_LW
+    RelevantAbilityName = CombatStims_LW
+    WorldEffectClass = class'X2Effect_LWApplyCombatStimsToWorld'
+}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWDenseSmoke.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWDenseSmoke.uc
@@ -19,6 +19,7 @@ static function X2Effect DenseSmokeEffect(optional bool bSkipAbilityCheck)
 {
     local X2Effect_LWDenseSmoke         Effect;
     local X2Condition_AbilityProperty   AbilityCondition;
+    local X2Condition_UnitProperty      UnitPropertyCondition;
 
     Effect = new class'X2Effect_LWDenseSmoke';
     Effect.BuildPersistentEffect(class'X2Effect_ApplySmokeGrenadeToWorld'.default.Duration + 1, false, false, false, eGameRule_PlayerTurnBegin);
@@ -28,10 +29,17 @@ static function X2Effect DenseSmokeEffect(optional bool bSkipAbilityCheck)
         "img:///UILibrary_LW_PerkPack.LW_AbilityDenseSmoke",
         true,,'eAbilitySource_Perk');
 
+    UnitPropertyCondition = new class'X2Condition_UnitProperty';
+    UnitPropertyCondition.ExcludeDead = false;
+    UnitPropertyCondition.ExcludeHostileToSource = false;
+    UnitPropertyCondition.ExcludeFriendlyToSource = false;
+    UnitPropertyCondition.FailOnNonUnits = true;
+    Effect.TargetConditions.AddItem(UnitPropertyCondition);
+
     if (!bSkipAbilityCheck)
     {
         AbilityCondition = new class'X2Condition_AbilityProperty';
-        AbilityCondition.OwnerHasSoldierAbilities.AddItem(default.RelevantAbilityName);
+        AbilityCondition.OwnerHasSoldierAbilities.AddItem(class'X2Effect_LWApplyDenseSmokeToWorld'.default.RelevantAbilityName);
         Effect.TargetConditions.AddItem(AbilityCondition);
     }
 
@@ -41,6 +49,5 @@ static function X2Effect DenseSmokeEffect(optional bool bSkipAbilityCheck)
 defaultproperties
 {
     EffectName = DenseSmoke
-    RelevantAbilityName = DenseSmoke
     WorldEffectClass = class'X2Effect_LWApplyDenseSmokeToWorld'
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWDenseSmoke.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWDenseSmoke.uc
@@ -1,0 +1,46 @@
+class X2Effect_LWDenseSmoke extends X2Effect_LWAdditionalSmokeEffect;
+
+var config int DefenseBonus;
+
+function GetToHitAsTargetModifiers(XComGameState_Effect EffectState, XComGameState_Unit Attacker, XComGameState_Unit Target, XComGameState_Ability AbilityState, class<X2AbilityToHitCalc> ToHitType, bool bMelee, bool bFlanking, bool bIndirectFire, out array<ShotModifierInfo> ShotModifiers)
+{
+    local ShotModifierInfo ShotMod;
+
+    if (Target.IsInWorldEffectTile(default.WorldEffectClass.Name))
+    {
+        ShotMod.ModType = eHit_Success;
+        ShotMod.Value = default.DefenseBonus;
+        ShotMod.Reason = FriendlyName;
+        ShotModifiers.AddItem(ShotMod);
+    }
+}
+
+static function X2Effect DenseSmokeEffect(optional bool bSkipAbilityCheck)
+{
+    local X2Effect_LWDenseSmoke         Effect;
+    local X2Condition_AbilityProperty   AbilityCondition;
+
+    Effect = new class'X2Effect_LWDenseSmoke';
+    Effect.BuildPersistentEffect(class'X2Effect_ApplySmokeGrenadeToWorld'.default.Duration + 1, false, false, false, eGameRule_PlayerTurnBegin);
+    Effect.SetDisplayInfo(ePerkBuff_Bonus,
+        default.strEffectBonusName,
+        default.strEffectBonusDesc,
+        "img:///UILibrary_LW_PerkPack.LW_AbilityDenseSmoke",
+        true,,'eAbilitySource_Perk');
+
+    if (!bSkipAbilityCheck)
+    {
+        AbilityCondition = new class'X2Condition_AbilityProperty';
+        AbilityCondition.OwnerHasSoldierAbilities.AddItem(default.RelevantAbilityName);
+        Effect.TargetConditions.AddItem(AbilityCondition);
+    }
+
+    return Effect;
+}
+
+defaultproperties
+{
+    EffectName = DenseSmoke
+    RelevantAbilityName = DenseSmoke
+    WorldEffectClass = class'X2Effect_LWApplyDenseSmokeToWorld'
+}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWRegenSmoke.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWRegenSmoke.uc
@@ -1,0 +1,133 @@
+class X2Effect_LWRegenSmoke extends X2Effect_LWAdditionalSmokeEffect;
+
+var config int HealAmount;
+var config int MaxHealAmount;
+var config bool bApplyToBleedingOutUnits;
+var name HealthRegeneratedName;
+var name EventToTriggerOnHeal;
+
+function bool RegenerationTicked(X2Effect_Persistent PersistentEffect, const out EffectAppliedData ApplyEffectParameters, XComGameState_Effect kNewEffectState, XComGameState NewGameState, bool FirstApplication)
+{
+    local XComGameState_Unit OldTargetState, NewTargetState;
+    local UnitValue HealthRegenerated;
+    local int AmountToHeal, Healed;
+    
+    OldTargetState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(ApplyEffectParameters.TargetStateObjectRef.ObjectID));
+
+    if (OldTargetState != none && OldTargetState.IsInWorldEffectTile(default.WorldEffectClass.Name))
+    {
+        if (!bApplyToBleedingOutUnits && OldTargetState.IsBleedingOut() || OldTargetState.IsDead())
+            return false;
+
+        if (HealthRegeneratedName != '' && MaxHealAmount > 0)
+        {
+            OldTargetState.GetUnitValue(HealthRegeneratedName, HealthRegenerated);
+
+            // If the unit has already been healed the maximum number of times, do not regen
+            if (HealthRegenerated.fValue >= MaxHealAmount)
+            {
+                return false;
+            }
+            else
+            {
+                // Ensure the unit is not healed for more than the maximum allowed amount
+                AmountToHeal = min(HealAmount, (MaxHealAmount - HealthRegenerated.fValue));
+            }
+        }
+        else
+        {
+            // If no value tracking for health regenerated is set, heal for the default amount
+            AmountToHeal = HealAmount;
+        }
+
+        // Perform the heal
+        NewTargetState = XComGameState_Unit(NewGameState.ModifyStateObject(OldTargetState.Class, OldTargetState.ObjectID));
+        NewTargetState.ModifyCurrentStat(estat_HP, AmountToHeal);
+
+        if (EventToTriggerOnHeal != '')
+        {
+            `XEVENTMGR.TriggerEvent(EventToTriggerOnHeal, NewTargetState, NewTargetState, NewGameState);
+        }
+
+        // If this health regen is being tracked, save how much the unit was healed
+        if (HealthRegeneratedName != '')
+        {
+            Healed = NewTargetState.GetCurrentStat(eStat_HP) - OldTargetState.GetCurrentStat(eStat_HP);
+            if (Healed > 0)
+            {
+                NewTargetState.SetUnitFloatValue(HealthRegeneratedName, HealthRegenerated.fValue + Healed, eCleanup_BeginTactical);
+                
+            }
+        }
+    }
+
+    return false;
+}
+
+simulated function AddX2ActionsForVisualization_Tick(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, const int TickIndex, XComGameState_Effect EffectState)
+{
+    local XComGameState_Unit OldUnit, NewUnit;
+    local X2Action_PlaySoundAndFlyOver SoundAndFlyOver;
+    local int Healed;
+    local string Msg;
+
+    OldUnit = XComGameState_Unit(ActionMetadata.StateObject_OldState);
+    NewUnit = XComGameState_Unit(ActionMetadata.StateObject_NewState);
+
+    Healed = NewUnit.GetCurrentStat(eStat_HP) - OldUnit.GetCurrentStat(eStat_HP);
+    
+    if (Healed > 0)
+    {
+        SoundAndFlyOver = X2Action_PlaySoundAndFlyOver(class'X2Action_PlaySoundAndFlyOver'.static.AddToVisualizationTree(ActionMetadata, VisualizeGameState.GetContext(), false, ActionMetadata.LastActionAdded));
+        Msg = Repl(class'X2Effect_Regeneration'.default.HealedMessage, "<Heal/>", Healed);
+        SoundAndFlyOver.SetSoundAndFlyOverParameters(none, Msg, '', eColor_Good);
+    }
+}
+
+static function X2Effect RegenSmokeEffect(optional bool bSkipAbilityCheck)
+{
+    local X2Effect_LWRegenSmoke         Effect;
+    local X2Condition_AbilityProperty   AbilityCondition;
+    local X2Condition_UnitProperty      UnitPropertyCondition;
+    local X2Condition_UnitStatCheck     UnitStatCheckCondition;
+
+    Effect = new class'X2Effect_LWRegenSmoke';
+    Effect.BuildPersistentEffect(class'X2Effect_ApplySmokeGrenadeToWorld'.default.Duration + 1, false, false, false, eGameRule_PlayerTurnBegin);
+    Effect.SetDisplayInfo(ePerkBuff_Bonus,
+        default.strEffectBonusName,
+        default.strEffectBonusDesc,
+        "img:///UILibrary_XPerkIconPack.UIPerk_smoke_medkit",
+        true,,'eAbilitySource_Perk');
+
+    UnitPropertyCondition = new class'X2Condition_UnitProperty';
+    UnitPropertyCondition.ExcludeDead = false;
+    UnitPropertyCondition.ExcludeHostileToSource = true;
+    UnitPropertyCondition.ExcludeFriendlyToSource = false;
+    UnitPropertyCondition.ExcludeRobotic = true;
+    UnitPropertyCondition.ExcludeTurret = true;
+    UnitPropertyCondition.FailOnNonUnits = true;
+    Effect.TargetConditions.AddItem(UnitPropertyCondition);
+
+    UnitStatCheckCondition = new class'X2Condition_UnitStatCheck';
+    UnitStatCheckCondition.AddCheckStat(eStat_HP, 0, eCheck_GreaterThan);
+    Effect.TargetConditions.AddItem(UnitStatCheckCondition);
+
+    if (!bSkipAbilityCheck)
+    {
+        AbilityCondition = new class'X2Condition_AbilityProperty';
+        AbilityCondition.OwnerHasSoldierAbilities.AddItem(default.RelevantAbilityName);
+        Effect.TargetConditions.AddItem(AbilityCondition);
+    }
+
+    return Effect;
+}
+
+defaultproperties
+{
+    HealthRegeneratedName = RegenSmoke_LW_HealthRegenerated
+    EffectTickedFn = RegenerationTicked
+
+    EffectName = RegenSmoke_LW
+    RelevantAbilityName = RegenSmoke_LW
+    WorldEffectClass = class'X2Effect_LWApplyRegenSmokeToWorld'
+}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWRegenSmoke.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_LWRegenSmoke.uc
@@ -101,7 +101,7 @@ static function X2Effect RegenSmokeEffect(optional bool bSkipAbilityCheck)
 
     UnitPropertyCondition = new class'X2Condition_UnitProperty';
     UnitPropertyCondition.ExcludeDead = false;
-    UnitPropertyCondition.ExcludeHostileToSource = true;
+    UnitPropertyCondition.ExcludeHostileToSource = false;
     UnitPropertyCondition.ExcludeFriendlyToSource = false;
     UnitPropertyCondition.ExcludeRobotic = true;
     UnitPropertyCondition.ExcludeTurret = true;
@@ -115,7 +115,7 @@ static function X2Effect RegenSmokeEffect(optional bool bSkipAbilityCheck)
     if (!bSkipAbilityCheck)
     {
         AbilityCondition = new class'X2Condition_AbilityProperty';
-        AbilityCondition.OwnerHasSoldierAbilities.AddItem(default.RelevantAbilityName);
+        AbilityCondition.OwnerHasSoldierAbilities.AddItem(class'X2Effect_LWApplyRegenSmokeToWorld'.default.RelevantAbilityName);
         Effect.TargetConditions.AddItem(AbilityCondition);
     }
 
@@ -128,6 +128,5 @@ defaultproperties
     EffectTickedFn = RegenerationTicked
 
     EffectName = RegenSmoke_LW
-    RelevantAbilityName = RegenSmoke_LW
     WorldEffectClass = class'X2Effect_LWApplyRegenSmokeToWorld'
 }


### PR DESCRIPTION
1. Add world effects that would handle application of the effects for the units entering smoke.
2. Integrate Combat Drugs and Regenerative Mist from Extended Perk Pack.
3. Improve handling for Dense Smoke.
4. Add localization tags for Dense Smoke.
5. Move Dense Smoke and Sting Grenades OPTC changes to `X2Ability_PerkPackAbilitySet2::AddEffectsToGrenades()`.