### PR TITLE
Add 2 Codices to Psi Gate on Rookie and Veteran

### DIFF
--- a/LongWarOfTheChosen/Config/XComSchedules.ini
+++ b/LongWarOfTheChosen/Config/XComSchedules.ini
@@ -14671,9 +14671,8 @@
 				  PrePlacedEncounters[3]=(EncounterID="ALNx8_Bucket_Standard_LW",			EncounterZoneOffsetAlongLOP=10.0,	EncounterZoneWidth=44.0), \\
 				  PrePlacedEncounters[4]=(EncounterID="GP_PsiGate_SolitaryHunter",		EncounterZoneOffsetAlongLOP=33.0,	EncounterZoneOffsetFromLOP=20.0, EncounterZoneWidth=5.0, EncounterZoneDepthOverride=5.0), \\
 				  PrePlacedEncounters[5]=(EncounterID="GP_PsiGate_SolitaryHunter",		EncounterZoneOffsetAlongLOP=33.0,	EncounterZoneOffsetFromLOP=20.0, EncounterZoneWidth=5.0, EncounterZoneDepthOverride=5.0), \\
-				  PrePlacedEncounters[6]=(EncounterID="GP_PsiGate_SolitaryHunter",		EncounterZoneOffsetAlongLOP=33.0,	EncounterZoneOffsetFromLOP=-20.0, EncounterZoneWidth=5.0, EncounterZoneDepthOverride=5.0), \\
-				  PrePlacedEncounters[7]=(EncounterID="GP_PsiGate_SolitaryHunter",		EncounterZoneOffsetAlongLOP=33.0,	EncounterZoneOffsetFromLOP=-20.0, EncounterZoneWidth=5.0, EncounterZoneDepthOverride=5.0), \\
-				  PrePlacedEncounters[8]=(EncounterID="GP_PsiGate_Chryssalids",			EncounterZoneOffsetAlongLOP=-3.0,	EncounterZoneWidth=9.0), \\
+				  PrePlacedEncounters[6]=(EncounterID="GP_PsiGate_CodexGuards",			EncounterZoneOffsetAlongLOP=0.0,	EncounterZoneOffsetFromLOP=14.0, EncounterZoneWidth=14.0, EncounterZoneDepthOverride=50.0), \\
+				  PrePlacedEncounters[7]=(EncounterID="GP_PsiGate_Chryssalids",			EncounterZoneOffsetAlongLOP=-3.0,	EncounterZoneWidth=9.0), \\
 				  MinRequiredAlertLevel=0, \\
 				  MaxRequiredAlertLevel=1)
 
@@ -14692,9 +14691,8 @@
 				  PrePlacedEncounters[6]=(EncounterID="GP_PsiGate_SolitaryHunter",		EncounterZoneOffsetAlongLOP=33.0,	EncounterZoneOffsetFromLOP=20.0, EncounterZoneWidth=5.0, EncounterZoneDepthOverride=5.0), \\
 				  PrePlacedEncounters[7]=(EncounterID="GP_PsiGate_SolitaryHunter",		EncounterZoneOffsetAlongLOP=33.0,	EncounterZoneOffsetFromLOP=-20.0, EncounterZoneWidth=5.0, EncounterZoneDepthOverride=5.0), \\
 				  PrePlacedEncounters[8]=(EncounterID="GP_PsiGate_SolitaryHunter",		EncounterZoneOffsetAlongLOP=33.0,	EncounterZoneOffsetFromLOP=-20.0, EncounterZoneWidth=5.0, EncounterZoneDepthOverride=5.0), \\
-				  PrePlacedEncounters[9]=(EncounterID="GP_PsiGate_SolitaryHunter",		EncounterZoneOffsetAlongLOP=33.0,	EncounterZoneOffsetFromLOP=-20.0, EncounterZoneWidth=5.0, EncounterZoneDepthOverride=5.0), \\
-				  PrePlacedEncounters[10]=(EncounterID="GP_PsiGate_SolitaryHunter",		EncounterZoneOffsetAlongLOP=33.0,	EncounterZoneOffsetFromLOP=20.0, EncounterZoneWidth=5.0, EncounterZoneDepthOverride=5.0), \\
-				  PrePlacedEncounters[11]=(EncounterID="GP_PsiGate_Chryssalids",		EncounterZoneOffsetAlongLOP=-3.0,	EncounterZoneWidth=9.0), \\
+				  PrePlacedEncounters[9]=(EncounterID="GP_PsiGate_CodexGuards",			EncounterZoneOffsetAlongLOP=0.0,	EncounterZoneOffsetFromLOP=14.0, EncounterZoneWidth=14.0, EncounterZoneDepthOverride=50.0), \\
+				  PrePlacedEncounters[10]=(EncounterID="GP_PsiGate_Chryssalids",		EncounterZoneOffsetAlongLOP=-3.0,	EncounterZoneWidth=9.0), \\
 				  MinRequiredAlertLevel=2, \\
 				  MaxRequiredAlertLevel=2)
 


### PR DESCRIPTION
Removed 2 chryssalids off rookie and vet psi gate schedules and replaced with codex guards (2 codices)