### PR TITLE
Minor localization fixes

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -6512,6 +6512,11 @@ LocPromotionPopupText=""
 [WatchThemRun_LW X2AbilityTemplate]
 LocFriendlyName="Watch Them Run"
 LocFlyOverText="Watch Them Run"
+; LWOTC Needs Translation (2)
+LocLongDescription="Once per turn, enter overwatch after throwing or launching a grenade."
+LocHelpText="Once per turn, enter overwatch after throwing or launching a grenade."
+LocPromotionPopupText="<Bullet> Watch Them Run will not activate the <Ability:ClassName> is disoriented, stunned, panicking, on fire or otherwise impaired.<br><Bullet> Watch Them Run will not activate if the <Ability:ClassName> doesn't have enough ammo for overwatch."
+; End Translation (2)
 
 [WatchThemRun_LW_Passive X2AbilityTemplate]
 LocFriendlyName="Watch Them Run"

--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_BloodTrail_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_BloodTrail_LW.uc
@@ -71,5 +71,5 @@ defaultproperties
 {
 	DuplicateResponse = eDupe_Ignore
 	EffectName = "BloodTrail"
-	bDisplayInSpecialDamageMessageUI = false
+	bDisplayInSpecialDamageMessageUI = true
 }

--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_BloodTrail_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Effect_BloodTrail_LW.uc
@@ -71,5 +71,5 @@ defaultproperties
 {
 	DuplicateResponse = eDupe_Ignore
 	EffectName = "BloodTrail"
-	bDisplayInSpecialDamageMessageUI = true
+	bDisplayInSpecialDamageMessageUI = false
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_BonusRocketDamage_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_BonusRocketDamage_LW.uc
@@ -24,5 +24,5 @@ function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGa
 defaultproperties
 {
     DuplicateResponse=eDupe_Ignore
-	bDisplayInSpecialDamageMessageUI = true
+	bDisplayInSpecialDamageMessageUI = false
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_GrenadeDamage.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_GrenadeDamage.uc
@@ -52,5 +52,5 @@ function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGa
 defaultproperties
 {
     DuplicateResponse = eDupe_Ignore
-	bDisplayInSpecialDamageMessageUI = true
+	bDisplayInSpecialDamageMessageUI = false
 }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_NeedleGrenades.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_NeedleGrenades.uc
@@ -71,5 +71,5 @@ function int GetAttackingDamageModifier(XComGameState_Effect EffectState, XComGa
 DefaultProperties
 {
 	DuplicateResponse = eDupe_Ignore
-	bDisplayInSpecialDamageMessageUI = true
+	bDisplayInSpecialDamageMessageUI = false
 }


### PR DESCRIPTION
1. Add missing `LocLongDescription`, `LocHelpText` and `LocPromotionPopupText` to `WatchThemRun_LW`.
2. Change `bDisplayInSpecialDamageMessageUI` for some effects to `false`.