### PR TITLE
Display rebel nickname in outpost management list item

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIOutpostManagement_ListItem.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIOutpostManagement_ListItem.uc
@@ -200,7 +200,7 @@ simulated function UpdateStaticData(bool ControllerActive)
 	SetMugShot(Unit.GetReference());
 
 	// KDM : Rebel name
-	strRebelName = Unit.GetFullName();
+	strRebelName = Unit.GetName(eNameType_FullNick);
 	if (OutpostUI.ShowFaceless && OutpostUI.CachedRebels[ListItemIndex].IsFaceless)
 	{
 		strRebelName = "*" @ strRebelName;


### PR DESCRIPTION
Show rebel name in outpost management list as *Firstname "Nickname" Lastname* (previously, *Firstname Lastname*).

Vanilla LWOTC never assigns nicknames to them but mods can make them generate with one.