### PR TITLE
Update Snap Shots

### DIFF
--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_ReaperAbilitySet_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_ReaperAbilitySet_LW.uc
@@ -553,17 +553,17 @@ static function X2AbilityTemplate AddDisablingShot()
 
 static function X2AbilityTemplate AddDisablingShotSnapShot()
 {
-	local X2AbilityTemplate					Template;
-	local X2AbilityCost_Ammo				AmmoCost;
-	local X2AbilityCost_ActionPoints		ActionPointCost;
-	local X2AbilityCooldown_Shared			Cooldown;
-	local X2AbilityToHitCalc_StandardAim	ToHitCalc;
-	local X2Condition_Visibility			VisibilityCondition;
-	local X2Effect_DisablingShotStunned		StunEffect;
-	local X2Condition_UnitEffects			SuppressedCondition;
-	local X2Condition_UnitProperty			UnitPropertyCondition;
-	local X2Condition_AbilityProperty		AbilityCondition;
-	local X2Condition_UnitActionPoints		ActionPointCondition;
+	local X2AbilityTemplate                 Template;
+	local X2AbilityCost_Ammo                AmmoCost;
+	local X2AbilityCost_ActionPoints        ActionPointCost;
+	local X2AbilityCooldown_Shared          Cooldown;
+	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
+	local X2Condition_Visibility            VisibilityCondition;
+	local X2Effect_DisablingShotStunned     StunEffect;
+	local X2Condition_UnitEffects           SuppressedCondition;
+	local X2Condition_UnitProperty          UnitPropertyCondition;
+	local X2Condition_AbilityProperty       AbilityCondition;
+	local X2Condition_SnapShotAction        SnapShotActionCondition;
 
 	`CREATE_X2ABILITY_TEMPLATE (Template, 'DisablingShotSnapShot');
 	Template.IconImage = "img:///UILibrary_LWOTC.LW_AbilityElectroshock";
@@ -641,12 +641,9 @@ static function X2AbilityTemplate AddDisablingShotSnapShot()
 	AbilityCondition.OwnerHasSoldierAbilities.AddItem('SnapShot');
 	Template.AbilityShooterConditions.Additem(AbilityCondition);
 
-	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1, class'X2CharacterTemplateManager'.default.StandardActionPoint, false, eCheck_LessThanOrEqual);
-	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
-	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1, class'X2CharacterTemplateManager'.default.RunAndGunActionPoint, false, eCheck_LessThanOrEqual);
-	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
+	SnapShotActionCondition = new class'X2Condition_SnapShotAction';
+	SnapShotActionCondition.StandardAbilityName = 'DisablingShot';
+	Template.AbilityShooterConditions.Additem(SnapShotActionCondition);
 
 	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
 	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet.uc
@@ -1349,10 +1349,10 @@ static function X2AbilityTemplate AddPrecisionShotAbility()
 	local X2AbilityTemplate					Template;
 	local X2AbilityCost_ActionPoints		ActionPointCost;
 	local X2AbilityCost_Ammo				AmmoCost;
-	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
-	local X2AbilityCooldown_Shared			Cooldown;	
+	local X2AbilityToHitCalc_StandardAim	ToHitCalc;
+	local X2AbilityCooldown_Shared			Cooldown;
 	local X2Effect_Knockback				KnockbackEffect;
-	local X2Condition_Visibility            VisibilityCondition;
+	local X2Condition_Visibility			VisibilityCondition;
 	local X2Condition_UnitEffects			SuppressedCondition;
 
 	`CREATE_X2ABILITY_TEMPLATE (Template, 'PrecisionShot');
@@ -1384,9 +1384,9 @@ static function X2AbilityTemplate AddPrecisionShotAbility()
 	Template.AbilityToHitOwnerOnMissCalc = ToHitCalc;
 
 	Cooldown = new class'X2AbilityCooldown_Shared';
-    Cooldown.iNumTurns = default.PRECISION_SHOT_COOLDOWN;
+	Cooldown.iNumTurns = default.PRECISION_SHOT_COOLDOWN;
 	Cooldown.SharingCooldownsWith.AddItem('PrecisionShotSnapShot');
-    Template.AbilityCooldown = Cooldown;
+	Template.AbilityCooldown = Cooldown;
 
 	AmmoCost = new class'X2AbilityCost_Ammo';
 	AmmoCost.iAmmo = default.PRECISION_SHOT_AMMO_COST;
@@ -1417,8 +1417,8 @@ static function X2AbilityTemplate AddPrecisionShotAbility()
 	Template.AddTargetEffect(KnockbackEffect);
 
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
-    Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
-    Template.BuildInterruptGameStateFn = TypicalAbility_BuildInterruptGameState;
+	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
+	Template.BuildInterruptGameStateFn = TypicalAbility_BuildInterruptGameState;
 	
 	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
 	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
@@ -1432,16 +1432,16 @@ static function X2AbilityTemplate AddPrecisionShotAbility()
 
 static function X2AbilityTemplate AddPrecisionShotSnapShotAbility()
 {
-	local X2AbilityTemplate					Template;
-	local X2AbilityCost_ActionPoints		ActionPointCost;
-	local X2AbilityCost_Ammo				AmmoCost;
+	local X2AbilityTemplate                 Template;
+	local X2AbilityCost_ActionPoints        ActionPointCost;
+	local X2AbilityCost_Ammo                AmmoCost;
 	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
-	local X2AbilityCooldown_Shared					Cooldown;	
-	local X2Effect_Knockback				KnockbackEffect;
+	local X2AbilityCooldown_Shared          Cooldown;
+	local X2Effect_Knockback                KnockbackEffect;
 	local X2Condition_Visibility            VisibilityCondition;
-	local X2Condition_UnitEffects			SuppressedCondition;
-	local X2Condition_AbilityProperty   	AbilityCondition;
-	local X2Condition_UnitActionPoints		ActionPointCondition;
+	local X2Condition_UnitEffects           SuppressedCondition;
+	local X2Condition_AbilityProperty       AbilityCondition;
+	local X2Condition_SnapShotAction        SnapShotActionCondition;
 
 	`CREATE_X2ABILITY_TEMPLATE (Template, 'PrecisionShotSnapShot');
 	Template.IconImage = "img:///UILibrary_LW_PerkPack.LW_AbilityPrecisionShot";
@@ -1470,9 +1470,9 @@ static function X2AbilityTemplate AddPrecisionShotSnapShotAbility()
 	Template.AbilityToHitOwnerOnMissCalc = ToHitCalc;
 
 	Cooldown = new class'X2AbilityCooldown_Shared';
-    Cooldown.iNumTurns = default.PRECISION_SHOT_COOLDOWN;
+	Cooldown.iNumTurns = default.PRECISION_SHOT_COOLDOWN;
 	Cooldown.SharingCooldownsWith.AddItem('PrecisionShot');
-    Template.AbilityCooldown = Cooldown;
+	Template.AbilityCooldown = Cooldown;
 
 	AmmoCost = new class'X2AbilityCost_Ammo';
 	AmmoCost.iAmmo = default.PRECISION_SHOT_AMMO_COST;
@@ -1505,47 +1505,42 @@ static function X2AbilityTemplate AddPrecisionShotSnapShotAbility()
 	AbilityCondition = new class'X2Condition_AbilityProperty';
 	AbilityCondition.OwnerHasSoldierAbilities.AddItem('SnapShot');
 	Template.AbilityShooterConditions.Additem(AbilityCondition);
+	
+	SnapShotActionCondition = new class'X2Condition_SnapShotAction';
+	SnapShotActionCondition.StandardAbilityName = 'PrecisionShot';
+	Template.AbilityShooterConditions.Additem(SnapShotActionCondition);
 
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
-    Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
-    Template.BuildInterruptGameStateFn = TypicalAbility_BuildInterruptGameState;
+	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
+	Template.BuildInterruptGameStateFn = TypicalAbility_BuildInterruptGameState;
 	
 	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
 	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
 	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotLostSpawnIncreasePerUse;
-
-	//Template.AdditionalAbilities.AddItem('PrecisionShotCritDamage');
-
-	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1,class'X2CharacterTemplateManager'.default.StandardActionPoint,false,eCheck_LessThanOrEqual);
-	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
-	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1,class'X2CharacterTemplateManager'.default.RunAndGunActionPoint,false,eCheck_LessThanOrEqual);
-	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
 
 	return Template;
 }
 
 static function X2AbilityTemplate PrecisionShotCritDamage()
 {
-    local X2AbilityTemplate Template;
-    local X2Effect_PrecisionShotCritDamage CritEffect;
+	local X2AbilityTemplate Template;
+	local X2Effect_PrecisionShotCritDamage CritEffect;
 
-    `CREATE_X2ABILITY_TEMPLATE (Template, 'PrecisionShotCritDamage');
-    Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_momentum";
-    Template.AbilitySourceName = 'eAbilitySource_Perk';
-    Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
-    Template.Hostility = eHostility_Neutral;
-    Template.AbilityToHitCalc = default.DeadEye;
-    Template.AbilityTargetStyle = default.SelfTarget;
-    Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
-    CritEffect = new class'X2Effect_PrecisionShotCritDamage';
-    CritEffect.BuildPersistentEffect(1, true, false, false);
+	`CREATE_X2ABILITY_TEMPLATE (Template, 'PrecisionShotCritDamage');
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_momentum";
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.AbilityToHitCalc = default.DeadEye;
+	Template.AbilityTargetStyle = default.SelfTarget;
+	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
+	CritEffect = new class'X2Effect_PrecisionShotCritDamage';
+	CritEffect.BuildPersistentEffect(1, true, false, false);
 	CritEffect.DuplicateResponse = eDupe_Refresh;
-    CritEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false,, Template.AbilitySourceName);
-    Template.AddTargetEffect(CritEffect);
-    Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
-    return Template;
+	CritEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false,, Template.AbilitySourceName);
+	Template.AddTargetEffect(CritEffect);
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	return Template;
 }
 
 static function X2AbilityTemplate AddCyclicFireAbility()

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet2.uc
@@ -131,110 +131,103 @@ static function array<X2DataTemplate> CreateTemplates()
 	return Templates;
 }
 
-// - Generic : Standard Shot -
 static function X2AbilityTemplate AddSnapShot()
 {
-	local X2AbilityTemplate                 Template;	
-	local X2AbilityCost_Ammo                AmmoCost;
-	local X2AbilityCost_ActionPoints        ActionPointCost;
-	local array<name>                       SkipExclusions;
-	local X2Effect_Knockback				KnockbackEffect;
-	local X2Condition_Visibility            VisibilityCondition;
+    local X2AbilityTemplate                 Template;
+    local X2AbilityCost_Ammo                AmmoCost;
+    local X2AbilityCost_ActionPoints        ActionPointCost;
+    local array<name>                       SkipExclusions;
+    local X2Effect_Knockback                KnockbackEffect;
+    local X2Condition_Visibility            VisibilityCondition;
+    local X2Condition_SnapShotAction        SnapShotActionCondition;
 
-	// Macro to do localisation and stuffs
-	`CREATE_X2ABILITY_TEMPLATE(Template, 'SnapShot');
+    `CREATE_X2ABILITY_TEMPLATE(Template, 'SnapShot');
 
-	// Icon Properties
-	//Template.bDontDisplayInAbilitySummary = true;
-	Template.IconImage = "img:///UILibrary_LW_PerkPack.LW_AbilitySnapShot";
-	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.STANDARD_SHOT_PRIORITY;
-	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_HideIfOtherAvailable;
-	Template.HideIfAvailable.AddItem('SniperStandardFire');
-	Template.DisplayTargetHitChance = true;
-	Template.AbilitySourceName = 'eAbilitySource_Perk';                                       // color of the icon
-	Template.bCrossClassEligible = false;
-	Template.Hostility = eHostility_Offensive;
-	// Activated by a button press; additionally, tells the AI this is an activatable
-	Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
+    Template.IconImage = "img:///UILibrary_LW_PerkPack.LW_AbilitySnapShot";
+    Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.STANDARD_SHOT_PRIORITY;
+    Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_ShowIfAvailable;
+    Template.DisplayTargetHitChance = true;
+    Template.AbilitySourceName = 'eAbilitySource_Perk';
+    Template.Hostility = eHostility_Offensive;
 
-	if (!class'X2Ability_PerkPackAbilitySet'.default.NO_STANDARD_ATTACKS_WHEN_ON_FIRE)
-	{
-		SkipExclusions.AddItem(class'X2StatusEffects'.default.BurningName);
-	}
+    Template.bCrossClassEligible = false;
 
-	SkipExclusions.AddItem(class'X2AbilityTemplateManager'.default.DisorientedName);
-	Template.AddShooterEffectExclusions(SkipExclusions);
+    Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
 
-	// Targeting Details
-	// Can only shoot visible enemies
-	VisibilityCondition = new class'X2Condition_Visibility';
-	VisibilityCondition.bRequireGameplayVisible = true;
-	VisibilityCondition.bAllowSquadsight = true;
-	Template.AbilityTargetConditions.AddItem(VisibilityCondition);
-	// Can't target dead; Can't target friendlies
-	Template.AbilityTargetConditions.AddItem(default.LivingHostileTargetProperty);
-	// Can't shoot while dead
-	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
-	// Only at single targets that are in range.
-	Template.AbilityTargetStyle = default.SimpleSingleTarget;
+    SkipExclusions.AddItem(class'X2AbilityTemplateManager'.default.DisorientedName);
+    if (!class'X2Ability_PerkPackAbilitySet'.default.NO_STANDARD_ATTACKS_WHEN_ON_FIRE)
+        SkipExclusions.AddItem(class'X2StatusEffects'.default.BurningName);
+    Template.AddShooterEffectExclusions(SkipExclusions);
 
-	// Action Point
-	ActionPointCost = new class'X2AbilityCost_ActionPoints';
-	ActionPointCost.iNumPoints = 1;
-	ActionPointCost.bConsumeAllPoints = true;
-	Template.AbilityCosts.AddItem(ActionPointCost);	
+    VisibilityCondition = new class'X2Condition_Visibility';
+    VisibilityCondition.bRequireGameplayVisible = true;
+    VisibilityCondition.bAllowSquadsight = true;
+    Template.AbilityTargetConditions.AddItem(VisibilityCondition);
 
-	// Ammo
-	AmmoCost = new class'X2AbilityCost_Ammo';	
-	AmmoCost.iAmmo = 1;
-	Template.AbilityCosts.AddItem(AmmoCost);
-	Template.bAllowAmmoEffects = true; // 	
+    Template.AbilityTargetConditions.AddItem(default.LivingHostileTargetProperty);
+    Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
 
-	// Weapon Upgrade Compatibility
-	Template.bAllowFreeFireWeaponUpgrade = true;                        // Flag that permits action to become 'free action' via 'Hair Trigger' or similar upgrade / effects
+    SnapShotActionCondition = new class'X2Condition_SnapShotAction';
+    SnapShotActionCondition.StandardAbilityName = 'SniperStandardFire';
+    Template.AbilityShooterConditions.Additem(SnapShotActionCondition);
 
-	//  Put holo target effect first because if the target dies from this shot, it will be too late to notify the effect.
-	Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.HoloTargetEffect());
-	//  Various Soldier ability specific effects - effects check for the ability before applying	
-	Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.ShredderDamageEffect());
-	
-	// Damage Effect
-	Template.AddTargetEffect(default.WeaponUpgradeMissDamage);
+    Template.AbilityTargetStyle = default.SimpleSingleTarget;
 
-	// Hit Calculation (Different weapons now have different calculations for range)
-	Template.AbilityToHitCalc = default.SimpleStandardAim;
-	Template.AbilityToHitOwnerOnMissCalc = default.SimpleStandardAim;
-		
-	// Targeting Method
-	Template.TargetingMethod = class'X2TargetingMethod_OverTheShoulder';
-	Template.bUsesFiringCamera = true;
-	Template.CinescriptCameraType = "StandardGunFiring";	
+    ActionPointCost = new class'X2AbilityCost_ActionPoints';
+    ActionPointCost.iNumPoints = 1;
+    ActionPointCost.bConsumeAllPoints = true;
+    Template.AbilityCosts.AddItem(ActionPointCost);
 
-	Template.AssociatedPassives.AddItem('HoloTargeting');
+    AmmoCost = new class'X2AbilityCost_Ammo';
+    AmmoCost.iAmmo = 1;
+    Template.AbilityCosts.AddItem(AmmoCost);
 
-	// MAKE IT LIVE!
-	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
-	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
-	Template.BuildInterruptGameStateFn = TypicalAbility_BuildInterruptGameState;
+    Template.bAllowAmmoEffects = true;
+    Template.bAllowBonusWeaponEffects = true;
 
-	//Template.bDisplayInUITooltip = false;
-	//Template.bDisplayInUITacticalText = false;
+    Template.bAllowFreeFireWeaponUpgrade = true;
 
-	KnockbackEffect = new class'X2Effect_Knockback';
-	KnockbackEffect.KnockbackDistance = 2;
-	Template.AddTargetEffect(KnockbackEffect);
-	
-	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
-	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
-	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotLostSpawnIncreasePerUse;
+    Template.AddTargetEffect(class'X2Ability_Chosen'.static.HoloTargetEffect());
+    Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.HoloTargetEffect());
+    Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.ShredderDamageEffect());
+    
+    Template.AddTargetEffect(default.WeaponUpgradeMissDamage);
 
-	//Template.OverrideAbilities.AddItem('SniperStandardFire');
+    Template.AbilityToHitCalc = default.SimpleStandardAim;
+    Template.AbilityToHitOwnerOnMissCalc = default.SimpleStandardAim;
+        
+    Template.TargetingMethod = class'X2TargetingMethod_OverTheShoulder';
+    Template.bUsesFiringCamera = true;
+    Template.CinescriptCameraType = "StandardGunFiring";
 
-	Template.AdditionalAbilities.AddItem('SnapShotAimModifier');
-	Template.AdditionalAbilities.AddItem('WeaponHandling_LW');
-	//Template.AdditionalAbilities.AddItem('SnapShotOverwatch');
+    Template.AssociatedPassives.AddItem('HoloTargeting');
 
-	return Template;	
+    Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+    Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
+    Template.BuildInterruptGameStateFn = TypicalAbility_BuildInterruptGameState;
+
+    Template.bDisplayInUITooltip = false;
+    Template.bDisplayInUITacticalText = false;
+
+    KnockbackEffect = new class'X2Effect_Knockback';
+    KnockbackEffect.KnockbackDistance = 2;
+    Template.AddTargetEffect(KnockbackEffect);
+
+    class'X2StrategyElement_XpackDarkEvents'.static.AddStilettoRoundsEffect(Template);
+
+    Template.PostActivationEvents.AddItem('StandardShotActivated');
+
+    Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
+    Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
+    Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotLostSpawnIncreasePerUse;
+
+    Template.bFrameEvenWhenUnitIsHidden = true;
+
+    Template.AdditionalAbilities.AddItem('SnapShotAimModifier');
+    Template.AdditionalAbilities.AddItem('WeaponHandling_LW');
+    //Template.AdditionalAbilities.AddItem('SnapShotOverwatch');
+
+    return Template;
 }
 
 static function X2AbilityTemplate SnapShotOverwatch()

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_XMBPerkAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_XMBPerkAbilitySet.uc
@@ -3140,8 +3140,8 @@ static function X2AbilityTemplate DeadeyeSnapshotAbility()
 	local X2Condition_Visibility            TargetVisibilityCondition;
 	local X2AbilityCost_Ammo                AmmoCost;
 	local X2AbilityCost_ActionPoints        ActionPointCost;
-	local X2Condition_AbilityProperty   	AbilityCondition;
-	local X2Condition_UnitActionPoints		ActionPointCondition;
+	local X2Condition_AbilityProperty       AbilityCondition;
+	local X2Condition_SnapShotAction        SnapShotActionCondition;
 
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'DeadeyeSnapShot');
 
@@ -3211,21 +3211,17 @@ static function X2AbilityTemplate DeadeyeSnapshotAbility()
 	AbilityCondition.OwnerHasSoldierAbilities.AddItem('SnapShot');
 	Template.AbilityShooterConditions.Additem(AbilityCondition);
 
-	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1,class'X2CharacterTemplateManager'.default.StandardActionPoint,false,eCheck_LessThanOrEqual);
-	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
-	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1,class'X2CharacterTemplateManager'.default.RunAndGunActionPoint,false,eCheck_LessThanOrEqual);
-	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
-
+	SnapShotActionCondition = new class'X2Condition_SnapShotAction';
+	SnapShotActionCondition.StandardAbilityName = 'Deadeye';
+	Template.AbilityShooterConditions.Additem(SnapShotActionCondition);
 
 	return Template;
 }	
 
 static function X2AbilityTemplate DeadeyeSnapShotDamage()
 {
-	local X2AbilityTemplate						Template;
-	local X2Effect_DeadeyeDamage_SnapShot                DamageEffect;
+	local X2AbilityTemplate                 Template;
+	local X2Effect_DeadeyeDamage_SnapShot   DamageEffect;
 
 	// Icon Properties
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'DeadeyeDamage_SnapShot');
@@ -3252,13 +3248,13 @@ static function X2AbilityTemplate DeadeyeSnapShotDamage()
 
 static function X2AbilityTemplate RapidFireSnapshotAbility()
 {
-	local X2AbilityTemplate					Template;
-	local X2AbilityCost_ActionPoints		ActionPointCost;
-	local X2AbilityCost_Ammo				AmmoCost;
+	local X2AbilityTemplate                 Template;
+	local X2AbilityCost_ActionPoints        ActionPointCost;
+	local X2AbilityCost_Ammo                AmmoCost;
 	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
-	local X2AbilityCooldown_Shared			Cooldown;
-	local X2Condition_AbilityProperty   	AbilityCondition;
-	local X2Condition_UnitActionPoints		ActionPointCondition;
+	local X2AbilityCooldown_Shared          Cooldown;
+	local X2Condition_AbilityProperty       AbilityCondition;
+	local X2Condition_SnapShotAction        SnapShotActionCondition;
 
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'RapidFireSnapShot');
 
@@ -3330,20 +3326,17 @@ static function X2AbilityTemplate RapidFireSnapshotAbility()
 	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotLostSpawnIncreasePerUse;
 	Template.bFrameEvenWhenUnitIsHidden = true;
 
-	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1,class'X2CharacterTemplateManager'.default.StandardActionPoint,false,eCheck_LessThanOrEqual);
-	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
-	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1,class'X2CharacterTemplateManager'.default.RunAndGunActionPoint,false,eCheck_LessThanOrEqual);
-	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
+	SnapShotActionCondition = new class'X2Condition_SnapShotAction';
+	SnapShotActionCondition.StandardAbilityName = 'RapidFire';
+	Template.AbilityShooterConditions.Additem(SnapShotActionCondition);
 
 	return Template;
 }
 
 static function X2AbilityTemplate RapidFireSnapShot2()
 {
-	local X2AbilityTemplate					Template;
-	local X2AbilityCost_Ammo				AmmoCost;
+	local X2AbilityTemplate                 Template;
+	local X2AbilityCost_Ammo                AmmoCost;
 	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
 	local X2AbilityTrigger_EventListener    Trigger;
 
@@ -3401,13 +3394,13 @@ static function X2AbilityTemplate RapidFireSnapShot2()
 
 static function X2AbilityTemplate ChainShotSnapShot()
 {
-	local X2AbilityTemplate					Template;
-	local X2AbilityCost_Ammo				AmmoCost;
+	local X2AbilityTemplate                 Template;
+	local X2AbilityCost_Ammo                AmmoCost;
 	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
-	local X2AbilityCooldown_Shared                 Cooldown;
-	local X2Condition_AbilityProperty   	AbilityCondition;
-	local X2AbilityCost_ActionPoints		ActionPointCost;
-	local X2Condition_UnitActionPoints		ActionPointCondition;
+	local X2AbilityCooldown_Shared          Cooldown;
+	local X2Condition_AbilityProperty       AbilityCondition;
+	local X2AbilityCost_ActionPoints        ActionPointCost;
+	local X2Condition_SnapShotAction        SnapShotActionCondition;
 
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'ChainShotSnapShot');
 
@@ -3471,13 +3464,10 @@ static function X2AbilityTemplate ChainShotSnapShot()
 	AbilityCondition = new class'X2Condition_AbilityProperty';
 	AbilityCondition.OwnerHasSoldierAbilities.AddItem('SnapShot');
 	Template.AbilityShooterConditions.Additem(AbilityCondition);
-
-	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1,class'X2CharacterTemplateManager'.default.StandardActionPoint,false,eCheck_LessThanOrEqual);
-	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
-	ActionPointCondition = new class'X2Condition_UnitActionPoints';
-	ActionPointCondition.AddActionPointCheck(1,class'X2CharacterTemplateManager'.default.RunAndGunActionPoint,false,eCheck_LessThanOrEqual);
-	Template.AbilityShooterConditions.AddItem(ActionPointCondition);
+	
+	SnapShotActionCondition = new class'X2Condition_SnapShotAction';
+	SnapShotActionCondition.StandardAbilityName = 'ChainShot';
+	Template.AbilityShooterConditions.Additem(SnapShotActionCondition);
 
 	Template.DamagePreviewFn = ChainShotSnapShotDamagePreview;
 	Template.bCrossClassEligible = true;
@@ -3496,8 +3486,8 @@ static function X2AbilityTemplate ChainShotSnapShot()
 
 static function X2AbilityTemplate ChainShotSnapShot2()
 {
-	local X2AbilityTemplate					Template;
-	local X2AbilityCost_Ammo				AmmoCost;
+	local X2AbilityTemplate                 Template;
+	local X2AbilityCost_Ammo                AmmoCost;
 	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
 	local X2AbilityTrigger_EventListener    Trigger;
 

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Condition_SnapShotAction.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Condition_SnapShotAction.uc
@@ -1,0 +1,50 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Condition_SnapShotAction.uc
+//  AUTHOR:  Merist
+//  PURPOSE: Condition for Snap Shot abilities that fails if the soldier has enough
+//           action points to use the normal one.
+//---------------------------------------------------------------------------------------
+class X2Condition_SnapShotAction extends X2Condition;
+
+var name StandardAbilityName;
+var bool bRequireStandardAbility;
+
+event name CallMeetsCondition(XComGameState_BaseObject kTarget)
+{
+    local XComGameState_Unit        TargetState;
+    local XComGameState_Ability     AbilityState;
+    local X2AbilityTemplate         AbilityTemplate;
+    local X2AbilityCost             Cost;
+    local name AvailableCode;
+
+    TargetState = XComGameState_Unit(kTarget);
+    if (TargetState == none)
+        return 'AA_NotAUnit';
+
+    AbilityState = XComGameState_Ability(
+        `XCOMHISTORY.GetGameStateForObjectID(TargetState.FindAbility(StandardAbilityName).ObjectID));
+
+    if (AbilityState == none)
+        return (bRequireStandardAbility ? 'AA_AbilityUnavailable' : 'AA_Success');
+
+    AbilityTemplate = AbilityState.GetMyTemplate();
+
+    foreach AbilityTemplate.AbilityCosts(Cost)
+    {
+        if (X2AbilityCost_ActionPoints(Cost) != none)
+        {
+            AvailableCode = Cost.CanAfford(AbilityState, TargetState);
+            if (AvailableCode != 'AA_Success')
+            {
+                return 'AA_Success';
+            }
+        }
+    }
+
+    return 'AA_AbilityUnavailable';
+}
+
+defaultproperties
+{
+    bRequireStandardAbility = true
+}


### PR DESCRIPTION
1. Add `X2Condition_SnapShotAction`.
2. Replace `X2Condition_UnitActionPoints` with `X2Condition_SnapShotAction` on all Snap Shot abilities.
3. Update Snap Shot to not be available if the soldier has no sniper fire.