### PR TITLE
Refactor psi stat display in soldier lists

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_UI.ini
+++ b/LongWarOfTheChosen/Config/XComLW_UI.ini
@@ -108,8 +108,6 @@ RECRUIT_Y_OFFSET_CTRL = -3
 RECRUIT_FONT_SIZE_MK = 20
 ; Moves the stats up/down; negative numbers move up / positive numbers move down.
 RECRUIT_Y_OFFSET_MK = -2
-; The tech required to show Recruits' Psi stat. Use "AutopsySectoid" for old behaviour.
-RECRUIT_SHOW_PSI_TECH = ""
 
 [LW_Overhaul.UIScreenListener_UIStrategyMap]
 ; When controller users cycle 'contacted' havens with the DPad, do we want the strategy map movement to be instantaneous or with acceleration/deceleration 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIPersonnel_SoldierListItem_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIPersonnel_SoldierListItem_LW.uc
@@ -251,7 +251,7 @@ function AddNameColumnIcons(XComGameState_Unit Unit)
 
 	IconXPos += IconXDeltaSmallValue;
 
-	if (!IsPsiUnit(Unit))
+	if (!Unit.IsPsiOperative())
 	{
 		if (HackIcon == none)
 		{
@@ -551,12 +551,7 @@ static function string GetWillString(XComGameState_Unit Unit)
 
 static function bool ShouldShowPsi(XComGameState_Unit Unit)
 {
-	return (IsPsiUnit(Unit) || ((Unit.GetRank() == 0) && (!Unit.CanRankUpSoldier()) && `XCOMHQ.IsTechResearched('AutopsySectoid')));
-}
-
-static function bool IsPsiUnit(XComGameState_Unit Unit)
-{
-	return (Unit.IsPsiOperative() || (Unit.GetSoldierClassTemplateName() == 'Templar'));
+	return (Unit.IsPsiOperative() || ((Unit.GetRank() == 0) && (!Unit.CanRankUpSoldier())));
 }
 
 defaultproperties

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIRecruitmentListItem_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIRecruitmentListItem_LW.uc
@@ -11,7 +11,6 @@ var config int RECRUIT_FONT_SIZE_CTRL;
 var config int RECRUIT_Y_OFFSET_CTRL;
 var config int RECRUIT_FONT_SIZE_MK;
 var config int RECRUIT_Y_OFFSET_MK;
-var config string RECRUIT_SHOW_PSI_TECH;
 
 simulated function InitRecruitItem(XComGameState_Unit Recruit)
 {
@@ -80,27 +79,12 @@ function UpdateExistingUI()
 
 function AddIcons(XComGameState_Unit Recruit)
 {
-	local bool PsiStatIsVisible;
 	local float XLoc, YLoc, XDelta;
-
-	if (RECRUIT_SHOW_PSI_TECH == "")
-	{
-		PsiStatIsVisible = true;
-	}
-	else
-	{
-		PsiStatIsVisible = `XCOMHQ.IsTechResearched(name(RECRUIT_SHOW_PSI_TECH));
-	}
 
 	// KDM : Stat icons, and their associated stat values, have to be manually placed.
 	XLoc = 97;
 	YLoc = 34.5f;
-	XDelta = 65.0f;
-
-	if (PsiStatIsVisible)
-	{
-		XDelta -= 10.0f;
-	}
+	XDelta = 55.0f;
 
 	InitIconValuePair(Recruit, eStat_Offense, "Aim", "UILibrary_LWToolbox.StatIcons.Image_Aim", XLoc, YLoc);
 	XLoc += XDelta;
@@ -115,12 +99,8 @@ function AddIcons(XComGameState_Unit Recruit)
 	InitIconValuePair(Recruit, eStat_Hacking, "Hacking", "UILibrary_LWToolbox.StatIcons.Image_Hacking", XLoc, YLoc);
 	XLoc += XDelta;
 	InitIconValuePair(Recruit, eStat_Dodge, "Dodge", "UILibrary_LWToolbox.StatIcons.Image_Dodge", XLoc, YLoc);
-	
-	if (PsiStatIsVisible)
-	{
-		XLoc += XDelta;
-		InitIconValuePair(Recruit, eStat_PsiOffense, "Psi", "gfxXComIcons.promote_psi", XLoc, YLoc);
-	}
+	XLoc += XDelta;
+	InitIconValuePair(Recruit, eStat_PsiOffense, "Psi", "gfxXComIcons.promote_psi", XLoc, YLoc);
 }
 
 function InitIconValuePair(XComGameState_Unit Recruit, ECharStatType StatType, string MCRoot, string ImagePath, float XLoc, float YLoc)

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIUtilities_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIUtilities_LW.uc
@@ -844,7 +844,7 @@ static function string GetHTMLAverageScatterText(float value, optional int place
 static function bool ShouldShowPsiOffense(XComGameState_Unit UnitState)
 {
 	return UnitState.IsPsiOperative() ||
-		(UnitState.GetRank() == 0 && !UnitState.CanRankUpSoldier() && `XCOMHQ.IsTechResearched('AutopsySectoid'));
+		(UnitState.GetRank() == 0 && !UnitState.CanRankUpSoldier());
 }
 
 // KDM : Adds a UIButton, if it exists and is visible, to a UIScreen's Navigator; furthermore, it selects this button


### PR DESCRIPTION
* Remove the previously added config variable to control showing rookie Psi in Recruit list. I don't think anyone will miss it.
* No longer require Sectoid Autopsy to show Rookie Psi in Barracks soldier list
* Don't show Psi for Templars -- they don't use it for anything
* Refactoring according to the reasons stated above

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d9ae4e0c-2443-4f28-a942-dba70e38406a" />
