### PR TITLE
Reuse base game covert op images

### DIFF
--- a/LongWarOfTheChosen/Config/XComGameBoard.ini
+++ b/LongWarOfTheChosen/Config/XComGameBoard.ini
@@ -928,3 +928,15 @@ ActionImage = "img:///UILibrary_XPACK_StrategyImages.CovertOp_Increase_Supply_In
 [CovertActionNarrative_RecruitRebels_Templars X2CovertActionNarrativeTemplate]
 AssociatedFaction="Faction_Templars"
 ActionImage = "img:///UILibrary_XPACK_StrategyImages.CovertOp_Increase_Supply_Income_by_X"
+
+[CovertActionNarrative_IntenseTraining_Skirmishers X2CovertActionNarrativeTemplate]
+AssociatedFaction="Faction_Skirmishers"
+ActionImage = "img:///UILibrary_XPACK_StrategyImages.CovertOp_Improve_Combat_Intelligence"
+
+[CovertActionNarrative_IntenseTraining_Reapers X2CovertActionNarrativeTemplate]
+AssociatedFaction="Faction_Reapers"
+ActionImage = "img:///UILibrary_XPACK_StrategyImages.CovertOp_Improve_Combat_Intelligence"
+
+[CovertActionNarrative_IntenseTraining_Templars X2CovertActionNarrativeTemplate]
+AssociatedFaction="Faction_Templars"
+ActionImage = "img:///UILibrary_XPACK_StrategyImages.CovertOp_Improve_Combat_Intelligence"


### PR DESCRIPTION
Increase Supply Income and Improve Combat Intelligence are disabled in LWOTC, might as well reuse their images for Recruit Rebels and Intense Training