### PR TITLE
Aggregate rookies and rebels in jailbreak reward listing

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -2809,6 +2809,7 @@ REGIONS_TO_BLACKSITE=3
 [LW_Overhaul.XComGameState_LWOverhaulOptions]
 EnablePauseOnRecruit=true
 InitialGrazeBandWidth=10
+InitialAggregateJailbreakRewards=true
 
 [LW_Overhaul.X2StrategyElement_DefaultStaffSLots_LW]
 LIMIT_INTENSE_TRAINING_OPS=true

--- a/LongWarOfTheChosen/Localization/LW_Overhaul.int
+++ b/LongWarOfTheChosen/Localization/LW_Overhaul.int
@@ -5,6 +5,8 @@ GrazeBandWidthModTooltip="This determines how close a shot has to be to the exac
 GrazeBandValue="Value: <XGParam:IntValue0>"
 PauseOnRecruitMod="Pause on Recruit"
 PauseOnRecruitModTooltip="Pause the geoscape when a Haven recruits a new soldier or rebel"
+EnableAggregateJailbreakRewards="Aggregate Jailbreak Rewards"
+EnableAggregateJailbreakRewardsTooltip="Avoid long scrolling text in mission UI by only showing Rookie and Resistance Personnel totals."
 
 [UIScreenListener_ShellDifficulty]
 strIncompatibleModsTitle="DUPLICATE MODS PRESENT"
@@ -506,10 +508,10 @@ m_strInsuffientInfiltrationToLaunch="Need to infiltrate to at least <XGParam:Int
 +m_strAlertnessModifierDescriptions[15]="Vulnerable"
 
 [UIMission_LWCustomMission]
-+m_strUrgent="SECURITY BREACH"
-+m_strRendezvousMission="RENDEZVOUS"
-+m_strRendezvousDesc="**Unauthorized signal from Resistance Haven in <XGParam:StrValue0/!WorldRegionName>** The adviser and volunteers from the Haven will intercept and eliminate a spy and their ADVENT handlers at a nearby meeting site."
-
+m_strUrgent="SECURITY BREACH"
+m_strJailbreakAggregatedReward="<XGParam:StrValue0/!RewardType>: <XGParam:StrValue1/!RewardQuantity>"
+m_strRendezvousMission="RENDEZVOUS"
+m_strRendezvousDesc="**Unauthorized signal from Resistance Haven in <XGParam:StrValue0/!WorldRegionName>** The adviser and volunteers from the Haven will intercept and eliminate a spy and their ADVENT handlers at a nearby meeting site."
 m_strInvasionMission="INVASION"
 m_strInvasionWarning="ALERT"
 m_strInvasionDesc="ADVENT forces have launched an invasion of <XGParam:StrValue0/!WorldRegionName/>! We must respond immediately or this region will fall back under ADVENT control."

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOverhaulOptions.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/XComGameState_LWOverhaulOptions.uc
@@ -9,6 +9,7 @@ class XComGameState_LWOverhaulOptions extends XComGameState_LWModOptions
 
 var config bool EnablePauseOnRecruit;
 var config int InitialGrazeBandWidth;
+var config bool InitialAggregateJailbreakRewards;
 
 var localized string LWOverhaulTabName;
 
@@ -25,6 +26,11 @@ var bool PauseOnRecruit_Cached;
 var localized string PauseOnRecruitMod;
 var localized string PauseOnRecruitModTooltip;
 
+// ***** AGGREGATED JAILBREAK REWARDS CONFIGURATION ***** //
+var bool AggregateJailbreakRewards;
+var bool AggregateJailbreakRewards_Cached;
+var localized string EnableAggregateJailbreakRewards;
+var localized string EnableAggregateJailbreakRewardsTooltip;
 
 // ***** CHosen Knowledge ***** //
 
@@ -43,6 +49,7 @@ function XComGameState_LWModOptions InitComponent(class NewClassType)
 	super.InitComponent(NewClassType);
 	PauseOnRecruit=EnablePauseOnRecruit;
 	GrazeBandWidth=InitialGrazeBandWidth;
+	AggregateJailbreakRewards=InitialAggregateJailbreakRewards;
 	//InitChosenKnowledge();
 	
 	return self;
@@ -57,6 +64,7 @@ function InitModOptions()
 {
 	GrazeBandWidth_Cached = GrazeBandWidth;
     PauseOnRecruit_Cached = PauseOnRecruit;
+    AggregateJailbreakRewards_Cached = AggregateJailbreakRewards;
 }
 
 function InitChosenKnowledge()
@@ -85,6 +93,11 @@ function int SetModOptionsEnabled(out array<UIMechaListItem> m_arrMechaItems)
 	m_arrMechaItems[ButtonIdx].BG.SetTooltipText(GrazeBandWidthModTooltip, , , 10, , , , 0.0f);
 	ButtonIdx++;
 
+    // Pause on recruit
+    m_arrMechaItems[ButtonIdx].UpdateDataCheckbox(EnableAggregateJailbreakRewards, "", AggregateJailbreakRewards_Cached, UpdateAggregateJailbreakRewards);
+    m_arrMechaItems[ButtonIdx].BG.SetTooltipText(EnableAggregateJailbreakRewardsTooltip, , , 10, , , , 0.0f);
+    ButtonIdx++;
+
 	return ButtonIdx;
 }
 
@@ -95,6 +108,9 @@ function bool HasAnyValueChanged()
         return true;
 
     if (PauseOnRecruit != PauseOnRecruit_Cached)
+        return true;
+
+    if (AggregateJailbreakRewards != AggregateJailbreakRewards_Cached)
         return true;
 
 	return false; 
@@ -115,6 +131,7 @@ function ApplyModSettings()
 
 	UpdatedOptions.GrazeBandWidth = GrazeBandWidth_Cached;
     UpdatedOptions.PauseOnRecruit = PauseOnRecruit_Cached;
+    UpdatedOptions.AggregateJailbreakRewards = AggregateJailbreakRewards_Cached;
 
 	if  (`TACTICALRULES != none && `TACTICALRULES.TacticalGameIsInPlay())
 		`TACTICALRULES.SubmitGameState(NewGameState);
@@ -127,6 +144,7 @@ function RestorePreviousModSettings()
 {
 	GrazeBandWidth_Cached = GrazeBandWidth;
     PauseOnRecruit_Cached = PauseOnRecruit;
+    AggregateJailbreakRewards_Cached = AggregateJailbreakRewards;
 }
 
 function bool CanResetModSettings() { return true; }
@@ -136,6 +154,7 @@ function ResetModSettings()
 {
 	GrazeBandWidth_Cached = default.GrazeBandWidth;
     PauseOnRecruit_Cached = default.PauseOnRecruit;
+    AggregateJailbreakRewards_Cached = default.AggregateJailbreakRewards;
 }
 
 // ========================================================
@@ -185,6 +204,11 @@ function bool GetPauseOnRecruit()
     return PauseOnRecruit;
 }
 
+function bool GetAggregateJailbreakRewards()
+{
+    return AggregateJailbreakRewards;
+}
+
 function array<int> GetChosenKnowledgeGains_Randomized()
 {
 	return ChosenKnowledgeGains_Randomized;
@@ -209,6 +233,13 @@ public function UpdateGrazeBand(UISlider SliderControl)
 function UpdatePauseOnRecruit(UICheckbox Checkbox)
 {
     PauseOnRecruit_Cached = Checkbox.bChecked;
+    `SOUNDMGR.PlaySoundEvent("Play_MenuSelect");
+}
+
+// Aggregate Jailbreak rewards
+function UpdateAggregateJailbreakRewards(UICheckbox Checkbox)
+{
+    AggregateJailbreakRewards_Cached = Checkbox.bChecked;
     `SOUNDMGR.PlaySoundEvent("Play_MenuSelect");
 }
 


### PR DESCRIPTION
Modify Jailbreak reward listing:
* From: *Rk John Doe, Jane Doe - Resistance Personnel, ...*
* To: *Rookies: 1, Resistance Personnel: 2*
<img width="509" height="896" alt="image" src="https://github.com/user-attachments/assets/6f106aea-8ade-4728-ad06-2cfb6c8a3b4b" />

If the mission has zero rookies as a reward, only *Resistance Personnel: N* is shown. Vice versa for zero rebels.

If the mission has any captured soldiers as rewards, those are displayed as usual with their full name and rank:
<img width="507" height="899" alt="image" src="https://github.com/user-attachments/assets/bab7dc18-9613-4e0e-8cb4-e6f7a8664d0a" />
Note that any captured rookies are not aggregated with other rookies because they have a different reward type. It also works fluff-wise because captured rookies are ones you already know, the anonymous rookies are strangers.

Translators can control the format with localization files. Non-INT localizations pick up the INT format by default:
<img width="508" height="905" alt="image" src="https://github.com/user-attachments/assets/7a3fba38-e4a7-4687-9d85-0b3b1a2963a6" />

For end users, there is a MCM option under the LWOTC tab that controls this behaviour.
<img width="853" height="824" alt="image" src="https://github.com/user-attachments/assets/5c3b3712-ef9a-44d5-9e57-e54a8e5f2e45" />


Also minor housekeeping in `LW_Overhaul.int`.