### PR TITLE
Don't fly to Rendezvous region when launching it

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
@@ -715,7 +715,7 @@ simulated function BuildRendezvousOptionsPanel()
 
 	Button1.SetText(class'UIUtilities_Text'.default.m_strGenericConfirm);
 	Button1.SetBad(true);
-	Button1.OnClickedDelegate = OnLaunchClicked;
+	Button1.OnClickedDelegate = OnLaunchClickedRendezvous;
 
 	Button2.SetText(class'UIUtilities_Text'.default.m_strGenericCancel);
 	Button2.SetBad(true);
@@ -1210,6 +1210,11 @@ simulated function string GetModifiedRewardString()
 simulated function bool CanTakeAlienFacilityMission()
 {
 	return GetRegion().HaveMadeContact();
+}
+
+simulated public function OnLaunchClickedRendezvous(UIButton button)
+{
+    GetMission().ConfirmSelection();
 }
 
 // KDM : The navigation system, set up in UIMission.RefreshNavigation, is a mess; override it here and 


### PR DESCRIPTION
When the "Launch mission" button of a Rendezvous mission info panel is clicked, don't fly to the mission region, instead just launch the mission immediately. Motivation can be found in the linked issue.