### PR TITLE
Aggregate jailbreak rewards in infiltration UI panel

### DIFF
--- a/LongWarOfTheChosen/Localization/LW_Overhaul.int
+++ b/LongWarOfTheChosen/Localization/LW_Overhaul.int
@@ -290,6 +290,7 @@ strLaunchingInfiltration="CONTACT IMMINENT"
 
 [UIUtilities_Text_LW]
 m_strHelp="Help"
+m_strJailbreakAggregatedReward="<XGParam:StrValue0/!RewardType>: <XGParam:StrValue1/!RewardQuantity>"
 
 [X2Ability_LW_GearAbilities]
 strWeight="Small item weight"
@@ -509,7 +510,6 @@ m_strInsuffientInfiltrationToLaunch="Need to infiltrate to at least <XGParam:Int
 
 [UIMission_LWCustomMission]
 m_strUrgent="SECURITY BREACH"
-m_strJailbreakAggregatedReward="<XGParam:StrValue0/!RewardType>: <XGParam:StrValue1/!RewardQuantity>"
 m_strRendezvousMission="RENDEZVOUS"
 m_strRendezvousDesc="**Unauthorized signal from Resistance Haven in <XGParam:StrValue0/!WorldRegionName>** The adviser and volunteers from the Haven will intercept and eliminate a spy and their ADVENT handlers at a nearby meeting site."
 m_strInvasionMission="INVASION"

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
@@ -46,7 +46,6 @@ var EMissionUIType MissionUIType;
 var name LibraryID;
 var string GeoscapeSFX;
 
-var localized string m_strJailbreakAggregatedReward;
 var localized string m_strUrgent;
 var localized string m_strRendezvousMission;
 var localized string m_strRendezvousDesc;
@@ -1128,12 +1127,7 @@ simulated function XComGameState_LWAlienActivity GetAlienActivity()
 simulated function string GetModifiedRewardString()
 {
 	local XComGameState_MissionSite MissionState;
-	local XComGameState_Reward RewardState;
-	local X2RewardTemplate RewardTemplate;
-	local StateObjectReference Ref;
 	local string RewardString, OldCaptureRewardString, NewCaptureRewardString;
-	local XGParamTag kTag;
-	local int Rookies, Rebels;
 
 	MissionState = GetMission();
 	RewardString = GetRewardString();
@@ -1147,62 +1141,7 @@ simulated function string GetModifiedRewardString()
 	}
 	if (MissionState.GeneratedMission.Mission.sType == "Jailbreak_LW" && `LWOVERHAULOPTIONS.GetAggregateJailbreakRewards())
 	{
-		RewardString = "";
-
-		foreach MissionState.Rewards(Ref)
-		{
-			RewardState = XComGameState_Reward(`XCOMHISTORY.GetGameStateForObjectID(Ref.ObjectID));
-			if (RewardState == None)
-			{
-				continue;
-			}
-			if (RewardState.GetMyTemplateName() == 'Reward_Rookie')
-			{
-				Rookies++;
-			}
-			else if (RewardState.GetMyTemplateName() == 'Reward_Rebel')
-			{
-				Rebels++;
-			}
-			else
-			{
-				if (RewardString != "")
-				{
-					RewardString $= ", ";
-				}
-				RewardString $= RewardState.GetRewardString();
-			}
-		}
-
-		if (Rookies > 0)
-		{
-			RewardTemplate = X2RewardTemplate(class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager().FindStrategyElementTemplate('Reward_Rookie'));
-
-			kTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
-			kTag.StrValue0 = RewardTemplate.DisplayName;
-			kTag.StrValue1 = string(Rookies);
-
-			if (RewardString != "")
-			{
-				RewardString $= ", ";
-			}
-			RewardString $= `XEXPAND.ExpandString(default.m_strJailbreakAggregatedReward);
-		}
-
-		if (Rebels > 0)
-		{
-			RewardTemplate = X2RewardTemplate(class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager().FindStrategyElementTemplate('Reward_Rebel'));
-
-			kTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
-			kTag.StrValue0 = RewardTemplate.DisplayName;
-			kTag.StrValue1 = string(Rebels);
-
-			if (RewardString != "")
-			{
-				RewardString $= ", ";
-			}
-			RewardString $= `XEXPAND.ExpandString(default.m_strJailbreakAggregatedReward);
-		}
+		RewardString = class'UIUtilities_Text_LW'.static.GetJailbreakAggregatedRewardsString(MissionState);
 	}
 	return RewardString;
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWLaunchDelayedMission.uc
@@ -201,7 +201,14 @@ simulated function BuildMissionPanel()
 
 	if(GetRewardString() != "")
 	{
-		LibraryPanel.MC.QueueString(GetRewardString());
+		if (Mission.GeneratedMission.Mission.sType == "Jailbreak_LW" && `LWOVERHAULOPTIONS.GetAggregateJailbreakRewards())
+		{
+			LibraryPanel.MC.QueueString(class'UIUtilities_Text_LW'.static.GetJailbreakAggregatedRewardsString(Mission));
+		}
+		else
+		{
+			LibraryPanel.MC.QueueString(GetRewardString());
+		}
 	}
 	else
 	{

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIUtilities_Text_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIUtilities_Text_LW.uc
@@ -15,6 +15,7 @@ const BODY_FONT_TYPE = "$NormalFont";
 const TITLE_FONT_TYPE = "$TitleFont";
 
 var localized string m_strHelp;
+var localized string m_strJailbreakAggregatedReward;
 
 // KDM : This is equivalent to UIUtilities_Text --> AddFontInfo(); the only difference is that it allows you to modify the font's colour.
 static function string AddFontInfoWithColor(string txt, bool is3DScreen, optional bool isTitleFont, optional bool forceBodyFontSize, 
@@ -271,4 +272,73 @@ static function GetShadowChamberMissionInfo(XComGameState_MissionSite MissionSit
 		}//end character for loop
 
 	}//end encounter for loop
+}
+
+static function string GetJailbreakAggregatedRewardsString(XComGameState_MissionSite MissionState)
+{
+	local X2RewardTemplate RewardTemplate;
+	local XComGameState_Reward RewardState;
+	local StateObjectReference Ref;
+	local string RewardString;
+	local XGParamTag kTag;
+	local int Rookies, Rebels;
+
+	RewardString = "";
+
+	foreach MissionState.Rewards(Ref)
+	{
+		RewardState = XComGameState_Reward(`XCOMHISTORY.GetGameStateForObjectID(Ref.ObjectID));
+		if (RewardState == None)
+		{
+			continue;
+		}
+		if (RewardState.GetMyTemplateName() == 'Reward_Rookie')
+		{
+			Rookies++;
+		}
+		else if (RewardState.GetMyTemplateName() == 'Reward_Rebel')
+		{
+			Rebels++;
+		}
+		else
+		{
+			if (RewardString != "")
+			{
+				RewardString $= ", ";
+			}
+			RewardString $= RewardState.GetRewardString();
+		}
+	}
+
+	if (Rookies > 0)
+	{
+		RewardTemplate = X2RewardTemplate(class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager().FindStrategyElementTemplate('Reward_Rookie'));
+
+		kTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
+		kTag.StrValue0 = RewardTemplate.DisplayName;
+		kTag.StrValue1 = string(Rookies);
+
+		if (RewardString != "")
+		{
+			RewardString $= ", ";
+		}
+		RewardString $= `XEXPAND.ExpandString(default.m_strJailbreakAggregatedReward);
+	}
+
+	if (Rebels > 0)
+	{
+		RewardTemplate = X2RewardTemplate(class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager().FindStrategyElementTemplate('Reward_Rebel'));
+
+		kTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
+		kTag.StrValue0 = RewardTemplate.DisplayName;
+		kTag.StrValue1 = string(Rebels);
+
+		if (RewardString != "")
+		{
+			RewardString $= ", ";
+		}
+		RewardString $= `XEXPAND.ExpandString(default.m_strJailbreakAggregatedReward);
+	}
+
+	return RewardString;
 }


### PR DESCRIPTION
Formerly, aggregated jailbreak rewards would only show up in the mission info panel that shows up before a squad is sent:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/65c2e7be-a3ed-48bf-83dc-2f6c0e128840" />

This PR applies the aggregation also for missions being infiltrated (if option is enabled):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3dad1b17-e905-45ee-9411-a1928859158f" />

Internally, refactor the aggregation code under `UIUtilities_Text_LW` for use by both applications.