### PR TITLE
Update Death From Above

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_SoldierSkills.ini
+++ b/LongWarOfTheChosen/Config/XComLW_SoldierSkills.ini
@@ -1484,7 +1484,7 @@ CONCUSSION_WARHEADS_ENV_DMG_BONUS=7
 DFA_USES_PER_TURN = 1
 
 ; Range penalty negation for DFA
-; 0.8 = 80% penalty negation
+; -0.8 = 80% penalty negation
 DFA_RANGE_PENALTY_NEGATION_MODIFIER = -0.5
 
 ; Attacks against targets at this range and farther
@@ -1493,6 +1493,8 @@ DFA_RANGE_PENALTY_NEGATION_BASE_RANGE = 17
 
 ; List of abilities that never activate DFA
 +DFA_BLACKLISTED_ABILITIES = "DoubleTap2"
+
+bLog = false
 
 [LW_Overhaul.X2Effect_CancelLongRangePenalty]
 

--- a/LongWarOfTheChosen/Config/XComLW_SoldierSkills.ini
+++ b/LongWarOfTheChosen/Config/XComLW_SoldierSkills.ini
@@ -1494,6 +1494,9 @@ DFA_RANGE_PENALTY_NEGATION_BASE_RANGE = 17
 ; List of abilities that never activate DFA
 +DFA_BLACKLISTED_ABILITIES = "DoubleTap2"
 
+; If `true`, the effects will be disabled while Serial is active
+DFA_DISABLE_WITH_SERIAL = false
+
 bLog = false
 
 [LW_Overhaul.X2Effect_CancelLongRangePenalty]

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -907,11 +907,11 @@ LocFriendlyNameWhenConcealed="Kill Zone (Concealed)"
 [DeathFromAbove X2AbilityTemplate]
 LocFriendlyName="Death From Above"
 ; LWOTC Needs Translation
-LocLongDescription="Once per turn, gain a standard action after killing an enemy at a lower elevation with your <Ability:BOUND_WEAPON_NAME>. Additionally, the long range penalties of the sniper and vektor rifles are reduced by 50%."
-LocHelpText="Once per turn, gain a standard action after killing an enemy at a lower elevation with your <Ability:BOUND_WEAPON_NAME>."
+LocLongDescription="Once per turn, gain a standard action after killing an enemy at a lower elevation with your <Ability:BOUND_WEAPON_NAME>. Additionally, the long range penalties of the sniper and vektor rifles are reduced by <Ability:DFA_RANGE_PENALTY_NEGATION_MODIFIER>%."
+LocHelpText="Once per turn, gain a standard action after killing an enemy at a lower elevation with your <Ability:BOUND_WEAPON_NAME>. Additionally, the long range penalties of the sniper and vektor rifles are reduced by <Ability:DFA_RANGE_PENALTY_NEGATION_MODIFIER>%."
 ; End Translation
 LocFlyOverText="Death From Above"
-LocPromotionPopupText="<Bullet> Does not activate when killing an enemy with the first shot of Double Tap.<br><Bullet> Reduces the long range penalties of the sniper and vektor rifles by 50%."
+LocPromotionPopupText="<Bullet> Does not activate when killing an enemy with the first shot of Double Tap.<br><Bullet> Reduces the long range penalties of the sniper and vektor rifles by <Ability:DFA_RANGE_PENALTY_NEGATION_MODIFIER>%."
 
 [XComGame.Implacable X2AbilityTemplate]
 [Implacable X2AbilityTemplate]

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -1144,14 +1144,14 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		DFAEffect.BaseRange = class'X2Effect_DeathFromAbove_LW'.default.DFA_RANGE_PENALTY_NEGATION_BASE_RANGE;
 		DFAEffect.bLongRange = true;
 		DFAEffect.BuildPersistentEffect(1, true, false);
-		DFAEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, false,, Template.AbilitySourceName);
+		DFAEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, true,, Template.AbilitySourceName);
 		Template.AddTargetEffect(DFAEffect);
 		
 		DeathEffect = new class'X2Effect_DeathFromAbove_LW';
 		DeathEffect.ActivationsPerTurn = class'X2Effect_DeathFromAbove_LW'.default.DFA_USES_PER_TURN;
 		DeathEffect.BlacklistedAbilities =  class'X2Effect_DeathFromAbove_LW'.default.DFA_BLACKLISTED_ABILITIES;
 		DeathEffect.BuildPersistentEffect(1, true, false, false);
-		DeathEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, true,, Template.AbilitySourceName);
+		DeathEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, false,, Template.AbilitySourceName);
 		Template.AddTargetEffect(DeathEffect);
 	}
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -1150,6 +1150,7 @@ function ModifyAbilitiesGeneral(X2AbilityTemplate Template, int Difficulty)
 		DeathEffect = new class'X2Effect_DeathFromAbove_LW';
 		DeathEffect.ActivationsPerTurn = class'X2Effect_DeathFromAbove_LW'.default.DFA_USES_PER_TURN;
 		DeathEffect.BlacklistedAbilities =  class'X2Effect_DeathFromAbove_LW'.default.DFA_BLACKLISTED_ABILITIES;
+		DeathEffect.bDisableWithSerial = class'X2Effect_DeathFromAbove_LW'.default.DFA_DISABLE_WITH_SERIAL
 		DeathEffect.BuildPersistentEffect(1, true, false, false);
 		DeathEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.LocLongDescription, Template.IconImage, false,, Template.AbilitySourceName);
 		Template.AddTargetEffect(DeathEffect);

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_DeathFromAbove_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_DeathFromAbove_LW.uc
@@ -6,10 +6,12 @@ var config float DFA_RANGE_PENALTY_NEGATION_MODIFIER;
 var config int DFA_RANGE_PENALTY_NEGATION_BASE_RANGE;
 
 var bool bMatchSourceWeapon;
-// If true, all abilities that have AbilityMultiTargetStyle that's not X2AbilityMultiTarget_BurstFire will be blacklisted
+// If `true`, all abilities that have AbilityMultiTargetStyle that's not X2AbilityMultiTarget_BurstFire will be blacklisted
 var bool bDisallowMultiTarget;
-// If true, the effect will be activated if any of the units in AbilityContext.InputContext.MultiTargets satisfy the conditions
-var bool bAllowMultiTarget;
+// If `false`, the effect will be activated if any of the units in AbilityContext.InputContext.MultiTargets satisfy the conditions
+var bool bOnlyPrimaryTarget;
+// If `true`, the effect will be activated only if the activated ability wasn't free
+var bool bDisallowFreeActions;
 
 var name PointType;
 var int ActivationsPerTurn;
@@ -17,127 +19,280 @@ var int ActivationsPerTurn;
 var array<name> BlacklistedAbilities;
 
 var name CounterName;
-var name EventName;
 
 var config bool bLog;
 
 function RegisterForEvents(XComGameState_Effect EffectGameState)
 {
-    local XComGameState_Unit        UnitState;
-    local Object                    EffectObj;
+    local X2EventManager        EventMgr;
+    local XComGameState_Unit    TargetUnit;
+    local Object                EffectObj;
+
+    EventMgr = `XEVENTMGR;
 
     EffectObj = EffectGameState;
-    UnitState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(EffectGameState.ApplyEffectParameters.SourceStateObjectRef.ObjectID));
-    `XEVENTMGR.RegisterForEvent(EffectObj, EventName, EffectGameState.TriggerAbilityFlyover, ELD_OnStateSubmitted, 40, UnitState);
+    TargetUnit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(EffectGameState.ApplyEffectParameters.TargetStateObjectRef.ObjectID));
+
+    EventMgr.RegisterForEvent(EffectObj, 'AbilityActivated', OnAbilityActivated, ELD_OnStateSubmitted,, TargetUnit,, EffectObj);
 }
 
-function bool PostAbilityCostPaid(XComGameState_Effect EffectState, XComGameStateContext_Ability AbilityContext, XComGameState_Ability kAbility, XComGameState_Unit SourceUnit, XComGameState_Item AffectWeapon, XComGameState NewGameState, const array<name> PreCostActionPoints, const array<name> PreCostReservePoints)
+static function EventListenerReturn OnAbilityActivated(Object EventData, Object EventSource, XComGameState GameState, Name EventID, Object CallbackData)
 {
-    local XComGameStateHistory      History;
-    local XComGameState_Ability     AbilityState;
-    local XComGameState_Unit        TargetUnit, PrevTargetUnit;
-    local UnitValue                 UnitValue;
-    local int                       iCounter;
-    local int                       Index;
-    local bool                      bIsMultiTarget;
-    local bool                      bShouldApply;
+    local XComGameStateContext_Ability  AbilityContext;
+    local XComGameState_Unit            SourceUnit;
+    local XComGameState_Ability         AbilityState;
+    local XComGameState_Effect          EffectState;
+    local X2Effect_DeathFromAbove_LW    Effect;
+    local XComGameState                 NewGameState;
+    local UnitValue                     CountUnitValue;
 
-    if (SourceUnit.IsUnitAffectedByEffectName(class'X2Effect_Serial'.default.EffectName))
-        return false;
+    AbilityContext = XComGameStateContext_Ability(GameState.GetContext());
 
-    if (class'Helpers_LW'.static.IsUnitInterruptingEnemyTurn(SourceUnit))
-        return false;
-
-    SourceUnit.GetUnitValue(CounterName, UnitValue);
-    iCounter = int(UnitValue.fValue);
-
-    if (ActivationsPerTurn > 0 && iCounter >= ActivationsPerTurn)
-        return false;
-
-    History = `XCOMHISTORY;
-
-    AbilityState = XComGameState_Ability(History.GetGameStateForObjectID(EffectState.ApplyEffectParameters.AbilityStateObjectRef.ObjectID));
-
-    if (AbilityState != none)
+    if (AbilityContext != none && AbilityContext.InterruptionStatus != eInterruptionStatus_Interrupt)
     {
-        if (!bMatchSourceWeapon || kAbility.SourceWeapon.ObjectID == EffectState.ApplyEffectParameters.ItemStateObjectRef.ObjectID)
+        SourceUnit = XComGameState_Unit(EventSource);
+        AbilityState = XComGameState_Ability(EventData);
+        EffectState = XComGameState_Effect(CallbackData);
+
+        if (SourceUnit != none && AbilityState != none && EffectState != none)
         {
-            `LOG(kAbility.GetMyTemplateName(), default.bLog, self.Class.Name);
-            if (kAbility.IsAbilityInputTriggered() && ValidateAbilityCost(kAbility, SourceUnit))
+            Effect = X2Effect_DeathFromAbove_LW(EffectState.GetX2Effect());
+
+            if (Effect != none)
             {
-                `LOG("+", default.bLog, self.Class.Name);
-                bIsMultiTarget = IsMultiTarget(kAbility);
-                if (BlacklistedAbilities.Find(kAbility.GetMyTemplateName()) == INDEX_NONE
-                    && (!bDisallowMultiTarget || !bIsMultiTarget))
+                if (Effect.IsEffectCurrentlyRelevant(EffectState, SourceUnit))
                 {
-                    TargetUnit = XComGameState_Unit(NewGameState.GetGameStateForObjectID(AbilityContext.InputContext.PrimaryTarget.ObjectID));
-
-                    if (TargetUnit != none)
+                    if (Effect.IsAbilityRelevant(AbilityState, SourceUnit, EffectState, GameState))
                     {
-                        PrevTargetUnit = XComGameState_Unit(History.GetGameStateForObjectID(TargetUnit.ObjectID));
-                        if (TargetUnit.IsDead() && SourceUnit.HasHeightAdvantageOver(PrevTargetUnit, true))
+                        if (Effect.IsTargetRelevant(AbilityContext, GameState, SourceUnit, EffectState))
                         {
-                            bShouldApply = true;
-                        }
-                    }
+                            NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState(string(default.Class.Name));
+                            SourceUnit = XComGameState_Unit(NewGameState.ModifyStateObject(SourceUnit.Class, SourceUnit.ObjectID));
 
-                    `LOG(bShouldApply $ " " $ bAllowMultiTarget $ " " $ bIsMultiTarget, default.bLog, self.Class.Name);
-                    
-                    if (!bShouldApply && bAllowMultiTarget && bIsMultiTarget)
-                    {
-                        `LOG("AbilityContext.InputContext.MultiTargets.Length = " $ AbilityContext.InputContext.MultiTargets.Length, default.bLog, self.Class.Name);
-                        for (Index = 0; Index < AbilityContext.InputContext.MultiTargets.Length; Index++)
-                        {
-                            TargetUnit = XComGameState_Unit(NewGameState.GetGameStateForObjectID(AbilityContext.InputContext.MultiTargets[Index].ObjectID));
-
-                            if (TargetUnit != none)
+                            if (Effect.CounterName != '')
                             {
-                                PrevTargetUnit = XComGameState_Unit(History.GetGameStateForObjectID(TargetUnit.ObjectID));
-                                `LOG("TargetUnit = " $ TargetUnit.GetMyTemplateName(), default.bLog, self.Class.Name);
-                                `LOG(TargetUnit.IsDead() $ " " $ SourceUnit.HasHeightAdvantageOver(PrevTargetUnit, true), default.bLog, self.Class.Name);
-                                if (TargetUnit.IsDead() && SourceUnit.HasHeightAdvantageOver(PrevTargetUnit, true))
-                                {
-                                    bShouldApply = true;
-                                    break;
-                                }
+                                SourceUnit.GetUnitValue(Effect.CounterName, CountUnitValue);
+                                SourceUnit.SetUnitFloatValue(Effect.CounterName, CountUnitValue.fValue + 1, eCleanup_BeginTurn);
                             }
+
+                            NewGameState.ModifyStateObject(class'XComGameState_Ability', EffectState.ApplyEffectParameters.AbilityStateObjectRef.ObjectID);
+                            XComGameStateContext_ChangeContainer(NewGameState.GetContext()).BuildVisualizationFn = EffectState.TriggerAbilityFlyoverVisualizationFn;
+
+                            SourceUnit.ActionPoints.AddItem(Effect.GetActionPointType());
+
+                            `TACTICALRULES.SubmitGameState(NewGameState);
                         }
-                    }
-                    
-                    if (bShouldApply)
-                    {
-                        SourceUnit.SetUnitFloatValue(CounterName, iCounter + 1.0, eCleanup_BeginTurn);
-                        if (PointType != '')
-                            SourceUnit.ActionPoints.AddItem(PointType);
-                        else
-                            SourceUnit.ActionPoints.AddItem(class'X2CharacterTemplateManager'.default.StandardActionPoint);
-                        
-                        `XEVENTMGR.TriggerEvent(EventName, AbilityState, SourceUnit, NewGameState);
                     }
                 }
             }
         }
     }
-    
+
+    return ELR_NoInterrupt;
+}
+
+function bool PostAbilityCostPaid(XComGameState_Effect EffectState, XComGameStateContext_Ability AbilityContext, XComGameState_Ability kAbility, XComGameState_Unit SourceUnit, XComGameState_Item AffectWeapon, XComGameState NewGameState, const array<name> PreCostActionPoints, const array<name> PreCostReservePoints)
+{
     return false;
 }
 
-// Helper function that returns false if the ability is free
-static function bool ValidateAbilityCost(XComGameState_Ability AbilityState, XComGameState_Unit AbilityOwner)
+function bool IsAbilityRelevant(XComGameState_Ability AbilityState, XComGameState_Unit SourceUnit, XComGameState_Effect EffectState, XComGameState GameState)
 {
-    local X2AbilityTemplate Template;
-    local X2AbilityCost Cost;
+    local XComGameStateHistory          History;
+    local XComGameState                 ChainStartGameState;
+    local XComGameStateContext_Ability  ChainStartAbilityContext;
+    local XComGameState_Ability         ChainStartAbilityState;
+
+    `LOG(GetFuncName() @ AbilityState.GetMyTemplateName(), default.bLog, default.Class.Name);
+
+    History = `XCOMHISTORY;
+
+    if (AbilityState.IsAbilityInputTriggered())
+    {
+        if (bDisallowFreeActions && WasAbilityFree(AbilityState, SourceUnit, GameState.HistoryIndex - 1))
+        {
+            return false;
+        }
+    }
+    else
+    {
+        `LOG(AbilityState.GetMyTemplateName() $ " is not input-activated", default.bLog, default.Class.Name);
+        ChainStartGameState = GameState.GetContext().GetFirstStateInEventChain();
+        if (GameState != ChainStartGameState)
+        {
+            ChainStartAbilityContext = XComGameStateContext_Ability(ChainStartGameState.GetContext());
+            if (ChainStartAbilityContext == none)
+            {
+                `LOG("AbilityContext not found", default.bLog, default.Class.Name);
+                return false;
+            }
+            else
+            {
+                if (ChainStartAbilityContext.InputContext.SourceObject.ObjectID != SourceUnit.ObjectID)
+                {
+                    `LOG("First ability in chain has a different source", default.bLog, default.Class.Name);
+                    return false;
+                }
+
+                ChainStartAbilityState = XComGameState_Ability(History.GetGameStateForObjectID(ChainStartAbilityContext.InputContext.AbilityRef.ObjectID));
+                if (!IsAbilityRelevant(ChainStartAbilityState, SourceUnit, EffectState, ChainStartGameState))
+                {
+                    return false;
+                }
+            }
+        }
+    }
+
+    if (bDisallowMultiTarget && IsMultiTarget(AbilityState))
+    {
+        `LOG("MultiTarget abilities are not allowed", default.bLog, default.Class.Name);
+        return false;
+    }
+
+    if (BlacklistedAbilities.Find(AbilityState.GetMyTemplateName()) != INDEX_NONE)
+    {
+        `LOG(AbilityState.GetMyTemplateName() $ " is blacklisted", default.bLog, default.Class.Name);
+        return false;
+    }
+
+    if (bMatchSourceWeapon)
+    {
+        if (AbilityState.SourceWeapon.ObjectID > 0)
+        {
+            if (AbilityState.SourceWeapon != EffectState.ApplyEffectParameters.ItemStateObjectRef)
+            {
+                `LOG("Source weapon doesn't match", default.bLog, default.Class.Name);
+                return false;
+            }
+        }
+        else
+        {
+            `LOG("No source weapon", default.bLog, default.Class.Name);
+            return false;
+        }
+    }
+
+    `LOG("Ability is relevant", default.bLog, default.Class.Name);
+
+    return true;
+}
+
+function bool IsTargetRelevant(XComGameStateContext_Ability AbilityContext, XComGameState GameState, XComGameState_Unit SourceUnit, XComGameState_Effect EffectState)
+{
+    local XComGameStateHistory  History;
+    local XComGameState_Unit    TargetUnit, OldTargetState;
+    local int                   Index;
+
+    `LOG(GetFuncName(), default.bLog, default.Class.Name);
+
+    History = `XCOMHISTORY;
+
+    TargetUnit = XComGameState_Unit(History.GetGameStateForObjectID(AbilityContext.InputContext.PrimaryTarget.ObjectID));
+
+    if (TargetUnit != none)
+    {
+        OldTargetState = XComGameState_Unit(History.GetGameStateForObjectID(TargetUnit.ObjectID,, GameState.HistoryIndex - 1));
+        if (OldTargetState.IsAlive() && TargetUnit.IsDead() && SourceUnit.HasHeightAdvantageOver(OldTargetState, true))
+        {
+            `LOG("Primary target is valid", default.bLog, default.Class.Name);
+            return true;
+        }
+        `LOG("Primary target is not valid", default.bLog, default.Class.Name);
+    }
+
+    if (!bOnlyPrimaryTarget && AbilityContext.InputContext.MultiTargets.Length > 0)
+    {
+        `LOG("MultiTargets.Length = " $ AbilityContext.InputContext.MultiTargets.Length, default.bLog, default.Class.Name);
+        for (Index = 0; Index < AbilityContext.InputContext.MultiTargets.Length; Index++)
+        {
+            TargetUnit = XComGameState_Unit(History.GetGameStateForObjectID(AbilityContext.InputContext.MultiTargets[Index].ObjectID));
+
+            if (TargetUnit != none)
+            {
+                OldTargetState = XComGameState_Unit(History.GetGameStateForObjectID(TargetUnit.ObjectID,, GameState.HistoryIndex - 1));
+                if (OldTargetState.IsAlive() && TargetUnit.IsDead() && SourceUnit.HasHeightAdvantageOver(OldTargetState, true))
+                {
+                    `LOG("MultiTarget #" $ Index $ " is valid", default.bLog, default.Class.Name);
+                    return true;
+                }
+            }
+        }
+    }
+
+    `LOG("No valid targets", default.bLog, default.Class.Name);
+
+    return false;
+}
+
+function bool IsEffectCurrentlyRelevant(XComGameState_Effect EffectGameState, XComGameState_Unit TargetUnit)
+{
+    local UnitValue CountUnitValue;
+
+    if (class'Helpers_LW'.static.IsUnitInterruptingEnemyTurn(TargetUnit))
+    {
+        return false;
+    }
+
+    if (CounterName != '')
+    {
+        TargetUnit.GetUnitValue(CounterName, CountUnitValue);
+        if (ActivationsPerTurn > 0 && CountUnitValue.fValue >= ActivationsPerTurn)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function name GetActionPointType()
+{
+    return PointType != '' ? PointType : class'X2CharacterTemplateManager'.default.StandardActionPoint;
+}
+
+static function bool WasAbilityFree(XComGameState_Ability AbilityState, XComGameState_Unit AbilityOwner, optional int HistoryIndex = -1)
+{
+    local XComGameStateHistory      History;
+    local XComGameState_Ability     OldAbilityState;
+    local XComGameState_Unit        OldAbilityOwner;
+    local X2AbilityTemplate         Template;
+    local X2AbilityCost             Cost;
     local X2AbilityCost_ActionPoints ActionPointCost;
 
+    `LOG(GetFuncName() @ AbilityState.GetMyTemplateName(), default.bLog, default.Class.Name);
+    `LOG("HistoryIndex = " $ HistoryIndex, default.bLog, default.Class.Name);
+
+    History = `XCOMHISTORY;
+
     Template = AbilityState.GetMyTemplate();
+
+    if (HistoryIndex != -1)
+    {
+        OldAbilityState = XComGameState_Ability(History.GetGameStateForObjectID(AbilityState.ObjectID,, HistoryIndex));
+        OldAbilityOwner = XComGameState_Unit(History.GetGameStateForObjectID(AbilityOwner.ObjectID,, HistoryIndex));
+    }
+    else
+    {
+        OldAbilityState = XComGameState_Ability(History.GetGameStateForObjectID(AbilityState.ObjectID));
+        OldAbilityOwner = XComGameState_Unit(History.GetGameStateForObjectID(AbilityOwner.ObjectID));
+    }
 
     foreach Template.AbilityCosts(Cost)
     {
         ActionPointCost = X2AbilityCost_ActionPoints(Cost);
-        if (ActionPointCost != none && !ActionPointCost.bFreeCost && ActionPointCost.GetPointCost(AbilityState, AbilityOwner) > 0)
-            return true;
+        if (ActionPointCost != none)
+        {
+            if (!ActionPointCost.bFreeCost && ActionPointCost.GetPointCost(OldAbilityState, OldAbilityOwner) > 0)
+            {
+                `LOG(AbilityState.GetMyTemplateName() $ " wasn't free", default.bLog, default.Class.Name);
+                return false;
+            }
+        }
     }
-    return false;
+
+    `LOG(AbilityState.GetMyTemplateName() $ " was free", default.bLog, default.Class.Name);
+
+    return true;
 }
 
 static function bool IsMultiTarget(XComGameState_Ability AbilityState)
@@ -145,21 +300,25 @@ static function bool IsMultiTarget(XComGameState_Ability AbilityState)
     local X2AbilityTemplate Template;
     local bool bIsMultiTarget;
 
+    `LOG(GetFuncName() @ AbilityState.GetMyTemplateName(), default.bLog, default.Class.Name);
+
     Template = AbilityState.GetMyTemplate();
     bIsMultiTarget = Template.AbilityMultiTargetStyle != none && X2AbilityMultiTarget_BurstFire(Template.AbilityMultiTargetStyle) == none;
 
-    `LOG(AbilityState.GetMyTemplateName() $ ": " $ bIsMultiTarget, default.bLog, GetFuncName());
+    `LOG(bIsMultiTarget, default.bLog, default.Class.Name);
 
     return bIsMultiTarget;
 }
 
 defaultproperties
 {
-    DuplicateResponse = eDupe_Ignore
     EffectName = DeathFromAbove_LW
+    DuplicateResponse = eDupe_Ignore
+
     CounterName = LW_DeathFromAboveUses
-    EventName = DeathFromAbove
+
     bMatchSourceWeapon = true
-    bAllowMultiTarget = true
     bDisallowMultiTarget = false
+    bOnlyPrimaryTarget = false
+    bDisallowFreeActions = true
 }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_DeathFromAbove_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_DeathFromAbove_LW.uc
@@ -4,6 +4,7 @@ var config int DFA_USES_PER_TURN;
 var config array<name> DFA_BLACKLISTED_ABILITIES;
 var config float DFA_RANGE_PENALTY_NEGATION_MODIFIER;
 var config int DFA_RANGE_PENALTY_NEGATION_BASE_RANGE;
+var config bool DFA_DISABLE_WITH_SERIAL;
 
 var bool bMatchSourceWeapon;
 // If `true`, all abilities that have AbilityMultiTargetStyle that's not X2AbilityMultiTarget_BurstFire will be blacklisted
@@ -12,6 +13,8 @@ var bool bDisallowMultiTarget;
 var bool bOnlyPrimaryTarget;
 // If `true`, the effect will be activated only if the activated ability wasn't free
 var bool bDisallowFreeActions;
+// If `true`, the effects will be disabled while Serial is active
+var bool bDisableWithSerial;
 
 var name PointType;
 var int ActivationsPerTurn;
@@ -229,6 +232,11 @@ function bool IsEffectCurrentlyRelevant(XComGameState_Effect EffectGameState, XC
     local UnitValue CountUnitValue;
 
     if (class'Helpers_LW'.static.IsUnitInterruptingEnemyTurn(TargetUnit))
+    {
+        return false;
+    }
+
+    if (bDisableWithSerial && TargetUnit.IsUnitAffectedByEffectName(class'X2Effect_Serial'.default.EffectName))
     {
         return false;
     }

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2DownloadableContentInfo_LWPerkPack.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2DownloadableContentInfo_LWPerkPack.uc
@@ -649,6 +649,9 @@ static function bool AbilityTagExpandHandler_CH(string InString, out string OutS
 		case 'RegenSmoke_MaxHealAmount_LW':
 			OutString = string(class'X2Effect_LWRegenSmoke'.default.MaxHealAmount);
 			return true;
+		case 'DFA_RANGE_PENALTY_NEGATION_MODIFIER':
+			OutString = string(int(-1 * class'X2Effect_DeathFromAbove_LW'.default.DFA_RANGE_PENALTY_NEGATION_MODIFIER * 100));
+			return true;
 		default:
 			return false;
 	}


### PR DESCRIPTION
1. Move handling to an event listener.
2. Use more complicated logic to validate the ability.

Fixes [Issue #1695](https://github.com/long-war-2/lwotc/issues/1695).