### PR TITLE
Reduce hardcoding in rebel/VIP scaling techs

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -302,6 +302,18 @@ bTacticalLootCleanup = false
 				  EncounterIDs[6]=(EncounterID="GP_Fortress_AvatarTeam_G_LW"), \\
 				  )		
 
+AdvancedLasersTechName="AdvancedLasers"
+MagnetizedWeaponsTechName="MagnetizedWeapons"
+GaussWeaponsTechName="GaussWeapons"
+CoilgunsTechName="Coilguns"
+AdvancedCoilgunsTechName="AdvancedCoilguns"
+PlasmaRifleTechName="PlasmaRifle"
+AlloyCannonTechName="AlloyCannon"
+HeavyPlasmaTechName="HeavyPlasma"
+PlasmaSniperTechName="PlasmaSniper"
+PlatedArmorTechName="PlatedArmor"
+PoweredArmorTechName="PoweredArmor"
+AdvancedGrenadesTechName="AdvancedGrenades"
 
 [LW_Overhaul.UIScreenListener_ShellDifficulty]
 +IntegratedMods="LW_SMGPack"

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/Utilities_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/Utilities_LW.uc
@@ -461,76 +461,96 @@ static function array<X2EquipmentTemplate> GetCompleteDefaultLoadout(XComGameSta
 // provided game state.
 function static XComGameState_Unit CreateRebelSoldier(StateObjectReference RebelRef, StateObjectReference OutpostRef, XComGameState NewGameState, optional name Loadout)
 {
-    local XComGameState_LWOutpost Outpost;
-    local XComGameState_Unit Proxy;
-    local Name TemplateName;
+	local XComGameState_LWOutpost Outpost;
+	local XComGameState_Unit Proxy;
+	local name TemplateName;
 	local int LaserChance, MagChance, CoilChance, iRand;
 	local string LoadoutStr;
 
-    Outpost = XComGameState_LWOutpost(`XCOMHISTORY.GetGameStateForObjectID(OutpostRef.ObjectID));
-    switch(Outpost.GetRebelLevel(RebelRef))
-    {
-        case 0:
-            TemplateName = 'RebelSoldierProxy';
-            break;
-        case 1:
-            TemplateName = 'RebelSoldierProxyM2';
-            break;
-        case 2:
-            TemplateName = 'RebelSoldierProxyM3';
-            break;
-        default:
-            `Redscreen("CreateRebelSoldier: Unsupported rebel level " $ Outpost.GetRebelLevel(RebelRef));
-            TemplateName = 'RebelSoldierProxy';
-    }
+	local bool AdvancedLasersResearched;
+	local bool MagnetizedWeaponsResearched;
+	local bool GaussWeaponsResearched;
+	local bool CoilgunsResearched;
+	local bool AdvancedCoilgunsResearched;
+	local bool PlasmaRifleResearched;
+	local bool AlloyCannonResearched;
+	local bool HeavyPlasmaResearched;
+	local bool PlasmaSniperResearched;
 
-    Proxy = CreateRebelProxy(RebelRef, OutpostRef, TemplateName, true, NewGameState);
-    Proxy.SetSoldierClassTemplate('LWS_RebelSoldier');
+	Outpost = XComGameState_LWOutpost(`XCOMHISTORY.GetGameStateForObjectID(OutpostRef.ObjectID));
+	switch(Outpost.GetRebelLevel(RebelRef))
+	{
+		case 0:
+			TemplateName = 'RebelSoldierProxy';
+			break;
+		case 1:
+			TemplateName = 'RebelSoldierProxyM2';
+			break;
+		case 2:
+			TemplateName = 'RebelSoldierProxyM3';
+			break;
+		default:
+			`Redscreen("CreateRebelSoldier: Unsupported rebel level " $ Outpost.GetRebelLevel(RebelRef));
+			TemplateName = 'RebelSoldierProxy';
+	}
+
+	Proxy = CreateRebelProxy(RebelRef, OutpostRef, TemplateName, true, NewGameState);
+	Proxy.SetSoldierClassTemplate('LWS_RebelSoldier');
 
 	LaserChance = 0;
 	MagChance = 0;
 	CoilChance = 0;
 
-    if (Loadout == '')
+	if (Loadout == '')
 	{
-        LoadoutStr = "RebelSoldier";
-		if (class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('MagnetizedWeapons') && class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('AdvancedLasers'))
+		AdvancedLasersResearched = class'X2DownloadableContentInfo_LongWarOfTheChosen'.static.TechResearchedOrHasHQInventoryItem(class'X2DownloadableContentInfo_LongWarOfTheChosen'.default.AdvancedLasersTechName);
+		MagnetizedWeaponsResearched = class'X2DownloadableContentInfo_LongWarOfTheChosen'.static.TechResearchedOrHasHQInventoryItem(class'X2DownloadableContentInfo_LongWarOfTheChosen'.default.MagnetizedWeaponsTechName);
+		GaussWeaponsResearched = class'X2DownloadableContentInfo_LongWarOfTheChosen'.static.TechResearchedOrHasHQInventoryItem(class'X2DownloadableContentInfo_LongWarOfTheChosen'.default.GaussWeaponsTechName);
+		CoilgunsResearched = class'X2DownloadableContentInfo_LongWarOfTheChosen'.static.TechResearchedOrHasHQInventoryItem(class'X2DownloadableContentInfo_LongWarOfTheChosen'.default.CoilgunsTechName);
+		AdvancedCoilgunsResearched = class'X2DownloadableContentInfo_LongWarOfTheChosen'.static.TechResearchedOrHasHQInventoryItem(class'X2DownloadableContentInfo_LongWarOfTheChosen'.default.AdvancedCoilgunsTechName);
+		PlasmaRifleResearched = class'X2DownloadableContentInfo_LongWarOfTheChosen'.static.TechResearchedOrHasHQInventoryItem(class'X2DownloadableContentInfo_LongWarOfTheChosen'.default.PlasmaRifleTechName);
+		AlloyCannonResearched = class'X2DownloadableContentInfo_LongWarOfTheChosen'.static.TechResearchedOrHasHQInventoryItem(class'X2DownloadableContentInfo_LongWarOfTheChosen'.default.AlloyCannonTechName);
+		HeavyPlasmaResearched = class'X2DownloadableContentInfo_LongWarOfTheChosen'.static.TechResearchedOrHasHQInventoryItem(class'X2DownloadableContentInfo_LongWarOfTheChosen'.default.HeavyPlasmaTechName);
+		PlasmaSniperResearched = class'X2DownloadableContentInfo_LongWarOfTheChosen'.static.TechResearchedOrHasHQInventoryItem(class'X2DownloadableContentInfo_LongWarOfTheChosen'.default.PlasmaSniperTechName);
+
+		LoadoutStr = "RebelSoldier";
+		if (MagnetizedWeaponsResearched && AdvancedLasersResearched)
 		{
 			LaserChance += (20 + 10 * (Outpost.GetRebelLevel(RebelRef) + 1)); // 30/40/50
 		}
-		if (class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('GaussWeapons') && class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('AdvancedLasers'))
+		if (GaussWeaponsResearched && AdvancedLasersResearched)
 		{
 			LaserChance += (20 + 10 * (Outpost.GetRebelLevel(RebelRef) + 1)); // 60/80/100
 		}
-		if (class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('Coilguns') && class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('GaussWeapons'))
+		if (CoilgunsResearched && GaussWeaponsResearched)
 		{
-			if (class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('AdvancedLasers'))
+			if (AdvancedLasersResearched)
 			{
 				LaserChance = 100;
 			}
-			MagChance += (20 + 10 * (Outpost.GetRebelLevel(RebelRef) + 1)); //30/40/50
+			MagChance += (20 + 10 * (Outpost.GetRebelLevel(RebelRef) + 1)); // 30/40/50
 		}
-		if (class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('AdvancedCoilguns') && class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('GaussWeapons'))
+		if (AdvancedCoilgunsResearched && GaussWeaponsResearched)
 		{
-			MagChance += (20 + 10 * (Outpost.GetRebelLevel(RebelRef) + 1)); //60/80/100
+			MagChance += (20 + 10 * (Outpost.GetRebelLevel(RebelRef) + 1)); // 60/80/100
 		}
-		if (class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('PlasmaRifle'))
+		if (PlasmaRifleResearched)
 		{
-			if (class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('GaussWeapons'))
-			{	
+			if (GaussWeaponsResearched)
+			{
 				MagChance = 100;
 			}
-			CoilChance += (20 + 10 * (Outpost.GetRebelLevel(RebelRef) + 1)); //30/40/50
+			CoilChance += (20 + 10 * (Outpost.GetRebelLevel(RebelRef) + 1)); // 30/40/50
 		}
 		// All plasma weapon related research
-		if (class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('HeavyPlasma') && 
-			class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('AlloyCannon') && 
-			class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('PlasmaSniper') && 
-			class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('AdvancedCoilguns'))
+		if (HeavyPlasmaResearched &&
+			AlloyCannonResearched &&
+			PlasmaSniperResearched &&
+			AdvancedCoilgunsResearched)
 		{
-			CoilChance += (20 + 10 * (Outpost.GetRebelLevel(RebelRef) + 1)); //60/80/100
+			CoilChance += (20 + 10 * (Outpost.GetRebelLevel(RebelRef) + 1)); // 60/80/100
 		}
-		
+
 		if (`SYNC_RAND_STATIC(100) < CoilChance)
 		{
 			LoadoutStr $= "4";
@@ -555,14 +575,14 @@ function static XComGameState_Unit CreateRebelSoldier(StateObjectReference Rebel
 		{
 			LoadoutStr $= "Shotgun";
 		}
-			
+
 		//`LWTRACE ("Rebel Loadout" @ LoadoutStr);
 		Loadout = name(LoadOutStr);
 	}
-		
-    ApplyLoadout(Proxy, Loadout, NewGameState);
 
-    return Proxy;
+	ApplyLoadout(Proxy, Loadout, NewGameState);
+
+	return Proxy;
 }
 
 // Create a rebel proxy for the given unit and set them on mission in the given

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
@@ -161,6 +161,20 @@ var config bool bUpdateWaterworldLW;
 
 var config bool bTacticalLootCleanup;
 
+// Reduce hardcoding of rebel/VIP scaling techs, in case a particularly invasive mod (e.g. WOTCArchipelago) wants to handle them
+var config name AdvancedLasersTechName;
+var config name MagnetizedWeaponsTechName;
+var config name GaussWeaponsTechName;
+var config name CoilgunsTechName;
+var config name AdvancedCoilgunsTechName;
+var config name PlasmaRifleTechName;
+var config name AlloyCannonTechName;
+var config name HeavyPlasmaTechName;
+var config name PlasmaSniperTechName;
+var config name PlatedArmorTechName;
+var config name PoweredArmorTechName;
+var config name AdvancedGrenadesTechName;
+
 // End data and data structures
 //-----------------------------
 
@@ -3048,7 +3062,7 @@ static function FinalizeUnitAbilitiesForInit(XComGameState_Unit UnitState, out a
 		case 'RebelSoldierProxyM2':
 		case 'RebelSoldierProxyM3':
 
-			if (class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('PoweredArmor'))
+			if (static.TechResearchedOrHasHQInventoryItem(default.PoweredArmorTechName))
 			{
 				AbilityTemplate = AbilityTemplateMan.FindAbilityTemplate('RebelHPUpgrade_T2');
 
@@ -3057,7 +3071,7 @@ static function FinalizeUnitAbilitiesForInit(XComGameState_Unit UnitState, out a
 				Data.Template = AbilityTemplate;
 				SetupData.AddItem(Data);
 			}
-			else if (class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('PlatedArmor'))
+			else if (static.TechResearchedOrHasHQInventoryItem(default.PlatedArmorTechName))
 			{
 				AbilityTemplate = AbilityTemplateMan.FindAbilityTemplate('RebelHPUpgrade_T1');
 				Data = EmptyData;
@@ -3065,8 +3079,7 @@ static function FinalizeUnitAbilitiesForInit(XComGameState_Unit UnitState, out a
 				Data.Template = AbilityTemplate;
 				SetupData.AddItem(Data);
 			}
-			
-			if (class'UIUtilities_Strategy'.static.GetXComHQ().IsTechResearched('AdvancedGrenades'))
+			if (static.TechResearchedOrHasHQInventoryItem(default.AdvancedGrenadesTechName))
 			{
 				AbilityTemplate = AbilityTemplateMan.FindAbilityTemplate('RebelGrenadeUpgrade');
 				Data = EmptyData;
@@ -4954,6 +4967,19 @@ static function XComGameState_WorldRegion ChooseRetributionRegion(XComGameState_
 	RegionState = XComGameState_WorldRegion(History.GetGameStateForObjectID(RegionRef.ObjectID));
 
 	return RegionState;
+}
+
+static function bool TechResearchedOrHasHQInventoryItem(name TechOrItem)
+{
+	local XComGameState_HeadquartersXCom HQ;
+
+	HQ = class'UIUtilities_Strategy'.static.GetXComHQ();
+
+	if (HQ.IsTechResearched(TechOrItem))
+	{
+		return true;
+	}
+	return HQ.GetNumItemInInventory(TechOrItem) > 0;
 }
 
 //=========================================================================================


### PR DESCRIPTION
Reduce hardcoding of tech names, in particular where OPTCing is not a viable alternative:
* Introduce config variables in the format `name <techname>TechName`.
* Look up whether the tech by that name is researched, or failing that, look up if there is an item in XCOM HQ's inventory by that name. The convenience function `TechResearchedOrHasHQInventoryItem` is provided.

This was done especially with WOTCArchipelago in mind. It is a particularly invasive mod but has no access to the aforementioned functionality otherwise.

Additionally, refactor rebel loadout generator for ease of reading and fix whitespace.