### PR TITLE
Update Russian description of Anatomy

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.rus
+++ b/LongWarOfTheChosen/Localization/XComGame.rus
@@ -7146,6 +7146,7 @@ LocPromotionPopupText="<Bullet/> Боевые сканеры у это спос�
 ;End Translated
 
 ;LWOTC Translated
+[Anatomy_LW X2AbilityTemplate]
 LocFriendlyName="Анатом"
 LocFlyOverText="Анатом"
 LocLongDescription="Получает +<Ability:ANATOMY_CRIT_TAG> крит шанс и +<Ability:ANATOMY_PIERCE_TAG> пробивания брони."


### PR DESCRIPTION
Previously the localization section for anatomy was missing a line with the name of the perk, which caused its description to appear on Reconnoiter instead, with Anatomy missing a description as a result. This adds the missing line.