### PR TITLE
Update GREMLINs to affect Blinding Protocol

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -2988,6 +2988,7 @@ function ReconfigGear(X2ItemTemplate Template, int Difficulty)
 			GremlinTemplate.ScanningChargesBonus = 1;
 			GremlinTemplate.AidProtocolBonus = 5;
 			GremlinTemplate.BaseDamage.Damage = 5;
+			GremlinTemplate.Abilities.AddItem('LW_T2GremlinIndicator');
 		}
 		if (GremlinTemplate.DataName == 'Gremlin_BM')
 		{
@@ -2995,14 +2996,17 @@ function ReconfigGear(X2ItemTemplate Template, int Difficulty)
 			GremlinTemplate.ScanningChargesBonus = 2;
 			GremlinTemplate.AidProtocolBonus = 10;
 			GremlinTemplate.BaseDamage.Damage = 8;
+			GremlinTemplate.Abilities.AddItem('LW_T3GremlinIndicator');
 		}
 		if (GremlinTemplate.DataName == 'SparkBit_MG')
 		{
 			GremlinTemplate.HealingBonus = 2;
+			GremlinTemplate.Abilities.AddItem('LW_T2GremlinIndicator');
 		}
 		if (GremlinTemplate.DataName == 'SparkBit_BM')
 		{
 			GremlinTemplate.HealingBonus = 4;
+			GremlinTemplate.Abilities.AddItem('LW_T3GremlinIndicator');
 		}
 	}
 	

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_XMBPerkAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_XMBPerkAbilitySet.uc
@@ -163,6 +163,8 @@ static function array<X2DataTemplate> CreateTemplates()
 
 	Templates.AddItem(LeadTheTarget_LW());
 	Templates.AddItem(LeadTheTargetShot_LW());
+	Templates.AddItem(GremlinTierPassive('LW_T2GremlinIndicator'));
+	Templates.AddItem(GremlinTierPassive('LW_T3GremlinIndicator'));
 	Templates.AddItem(BlindingProtocol_LW());
 	Templates.AddItem(ApexPredator_LW());
 	Templates.AddItem(ApexPredatorPanic_LW());
@@ -793,6 +795,20 @@ static function EventListenerReturn LTTListener(Object EventData, Object EventSo
 	
 
 	return ELR_NoInterrupt;
+}
+
+static function X2AbilityTemplate GremlinTierPassive(name DataName)
+{
+	local X2AbilityTemplate		Template;
+
+	Template = PurePassive(DataName, "", false, 'eAbilitySource_Item', false);
+
+	Template.bHideOnClassUnlock = true;
+	Template.bDisplayInUITooltip = false;
+	Template.bDisplayInUITacticalText = false;
+	Template.bDontDisplayInAbilitySummary = true;
+
+	return Template;
 }
 
 static function X2AbilityTemplate BlindingProtocol_LW()


### PR DESCRIPTION
1. Create and add missing passives to GREMLIN templates.
    - These passives match the ability names used for bonus radii in `X2AbilityMultiTarget_Radius` of Blinding Protocol.