### PR TITLE
Added fix for reinforcement spawning freeze

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/SeqAct_LWCallReinforcements.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/SeqAct_LWCallReinforcements.uc
@@ -228,7 +228,7 @@ function SpawnReinforcements(int ReinforceIndex, XComGameState NewGameState)
 				// LWOTC: Since the reinforcement spawner doesn't seem to do a good job of
 				// randomisation spawn locations, we manually randomise the spawn location
 				// and use a smaller tile offset for InitiateReinforcements().
-				Location = GenerateRandomSpawnLocation(`SPAWNMGR.GetCurrentXComLocation(), IdealSpawnTilesOffset);
+				Location = GenerateRandomSpawnLocation(GetXComLocation(), IdealSpawnTilesOffset);
 		
 				class'XComGameState_AIReinforcementSpawner'.static.InitiateReinforcements(
 					EncounterID,
@@ -252,8 +252,8 @@ function SpawnReinforcements(int ReinforceIndex, XComGameState NewGameState)
 			// LWOTC: Since the reinforcement spawner doesn't seem to do a good job of
 			// randomisation spawn locations, we manually randomise the spawn location
 			// and use a smaller tile offset for InitiateReinforcements().
-			Location = GenerateRandomSpawnLocation(`SPAWNMGR.GetCurrentXComLocation(), IdealSpawnTilesOffset);
-	
+			Location = GenerateRandomSpawnLocation(GetXComLocation(), IdealSpawnTilesOffset);
+	 
 			// LWOTC: It appears that the second argument to InitiateReinforcements should
 			// be -1, not 0, in order to use the reinforcement countdown of the encounter.
 			class'XComGameState_AIReinforcementSpawner'.static.InitiateReinforcements(
@@ -301,6 +301,44 @@ static function Vector GenerateRandomSpawnLocation(Vector AnchorPoint, int TileO
 	}
 
 	return TrySpawnLocation;
+}
+// LWOTC: For some reason(Native code), the usual "`SPAWNMGR.GetCurrentXComLocation" can return a location that is out of bounds.
+// This can cause the GenerateRandomSpawnLocation function to loop infinitely, which appears as a freeze to players. This function solves that issue.
+//
+// Returns the average position of every living XCom soldier.
+static function Vector GetXComLocation() 
+{
+	local XComGameStateHistory History;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_Unit UnitState;
+	local int idx, LivingCount;
+	local Vector CombinedLivingPositions;
+
+	History = `XCOMHISTORY;
+	XComHQ = `XCOMHQ;
+
+	LivingCount = 0;
+
+	for(idx = 0; idx < XComHQ.Squad.Length; idx++)
+	{
+		UnitState = XComGameState_Unit(History.GetGameStateForObjectID(XComHQ.Squad[idx].ObjectID));
+
+		if(UnitState != none)
+		{
+			if(!UnitState.IsDead())
+			{
+				LivingCount++;
+				CombinedLivingPositions += `XWORLD.GetPositionFromTileCoordinates(UnitState.TileLocation);
+			}
+		}
+	}
+
+	// LWOTC: Do not divide by zero.
+	if (LivingCount == 0) {
+		return CombinedLivingPositions;
+	} else {
+		return CombinedLivingPositions / LivingCount;
+	}
 }
 
 defaultproperties


### PR DESCRIPTION
# The Issue
There is an issue that I encountered with reinforcement spawning sometimes causing the game to freeze, this is due to the while loop for finding a reinforcement spawn location iterating infinitely, which is caused because `SPAWNMGR.GetCurrentXComLocation()` can return a position that is out of bounds.

I have had this issue happen on several different missions, seemingly at random. Bear in mind I am also running well over 100 mods, so it's certainly possible this issue has nothing to do with LWOTC and is really only my problem. But in that case this should still be considered as at least a compatibility fix.

Here is the game save that was having this issue, feel free to use it for testing but again there are quite a few mods used in it: [game_save.zip](https://github.com/user-attachments/files/30601607/game_save.zip)
# The Fix
My solution was just to calculate XCom's average position manually rather than relying on `SPAWNMGR.GetCurrentXComLocation()`. This is done with a fittingly named function called `GetXComLocation()` added to `SeqAct_LWCallReinforcements.uc`.
# Additional Notes
The function `GetPositionForCivilian` in `LWTacticalMissionUnitSpawner.uc` also uses `GetCurrentXComLocation()` from the `SPAWNMGR`, which means it could potentially have a similar problem. I have not touched this file since I never pay attention to civilians in my games and have never noticed an issue.

No AI was used in the creation of this pull request or any of its commits because I am not a fan of AI.