### PR TITLE
Update item weight ability

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
+++ b/LongWarOfTheChosen/Config/XComLW_Overhaul.ini
@@ -2872,3 +2872,7 @@ bLeftSquadButton = false
 +AlienRulerTags = "Ruler_ViperKingActive"
 +AlienRulerTags = "Ruler_BerserkerQueenActive"
 +AlienRulerTags = "Ruler_ArchonKingActive"
+
+[LW_Overhaul.X2Effect_ItemWeight2]
+; Item weight mobility penalty will be skipped for items in these slots
+; +SlotsToSkip = eInvSlot_

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -3464,7 +3464,8 @@ function ReconfigGear(X2ItemTemplate Template, int Difficulty)
 				{
 					if (ItemTable[i].Weight > 0)
 					{
-						EquipmentTemplate.Abilities.AddItem ('SmallItemWeight');
+						EquipmentTemplate.Abilities.AddItem('SmallItemWeight');
+						// TODO: Move mobility penalty display from item weight to AddArmoryUIStatMarkups()
 						EquipmentTemplate.SetUIStatMarkup(class'XLocalizedData'.default.MobilityLabel, eStat_Mobility, -ItemTable[i].Weight, true);
 
 						//`LOG ("Adding Weight to" @ EquipmentTemplate.DataName);

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GearAbilities.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Ability_LW_GearAbilities.uc
@@ -591,27 +591,39 @@ static function X2AbilityTemplate CreateNeurowhipAbility()
 
 static function X2AbilityTemplate CreateSmallItemWeightAbility()
 {
-	local X2AbilityTemplate								Template;	
-	local X2Effect_ItemWeight							WeightEffect;
+	local X2AbilityTemplate         Template;
+	// local X2Effect_ItemWeight       WeightEffect;
+	local X2Effect_ItemWeight2		WeightEffect2;
+	local X2Condition_UnitIsXCOM    TeamCondition;
 	
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'SmallItemWeight');
 	Template.AbilitySourceName = 'eAbilitySource_Item';
 	Template.eAbilityIconBehaviorHUD = EAbilityIconBehavior_NeverShow;
 	Template.Hostility = eHostility_Neutral;
 	Template.bDisplayInUITacticalText = false;
+	Template.bUniqueSource = true;
 
 	Template.AbilityToHitCalc = default.DeadEye;
 	Template.AbilityTargetStyle = default.SelfTarget;
 	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
 	//Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_ammo_stiletto";
 
-	WeightEffect = new class'X2Effect_ItemWeight';
-	WeightEffect.EffectName = 'SmallItemWeight';
-	WeightEffect.BuildPersistentEffect (1, true, false, false);
-	//WeightEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false, , Template.AbilitySourceName);
-	WeightEffect.bUniqueTarget = true;
-	WeightEffect.DuplicateResponse = eDupe_Allow;
-	Template.AddTargetEffect(WeightEffect);
+	TeamCondition = new class'X2Condition_UnitIsXCOM';
+	TeamCondition.bCheckCanEverBeValid = true;
+	Template.AbilityShooterConditions.AddItem(TeamCondition);
+
+	WeightEffect2 = new class'X2Effect_ItemWeight2';
+	WeightEffect2.BuildPersistentEffect(1, true, false);
+	WeightEffect2.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage, false,, Template.AbilitySourceName);
+	Template.AddTargetEffect(WeightEffect2);
+
+	// WeightEffect = new class'X2Effect_ItemWeight';
+	// WeightEffect.EffectName = 'SmallItemWeight';
+	// WeightEffect.BuildPersistentEffect (1, true, false, false);
+	// WeightEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, false, , Template.AbilitySourceName);
+	// WeightEffect.bUniqueTarget = true;
+	// WeightEffect.DuplicateResponse = eDupe_Allow;
+	// Template.AddTargetEffect(WeightEffect);
 
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
 

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Condition_UnitIsXCOM.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Condition_UnitIsXCOM.uc
@@ -1,0 +1,37 @@
+class X2Condition_UnitIsXCOM extends X2Condition;
+
+var bool bCheckCanEverBeValid;
+
+event name CallMeetsCondition(XComGameState_BaseObject kTarget) 
+{
+    local XComGameState_Unit UnitState;
+    
+    UnitState = XComGameState_Unit(kTarget);
+    
+    if (UnitState == none)
+        return 'AA_NotAUnit';
+        
+    if (UnitState.GetPreviousTeam() == eTeam_XCom)
+        return 'AA_Success'; 
+
+    return 'AA_AbilityUnavailable';
+}
+
+function bool CanEverBeValid(XComGameState_Unit SourceUnit, bool bStrategyCheck)
+{
+    if (!bCheckCanEverBeValid)
+        return true;
+
+    if (bStrategyCheck)
+        return true;
+
+    if (SourceUnit.GetPreviousTeam() == eTeam_XCom)
+        return true;
+
+    return false;
+}
+
+defaultproperties
+{
+    bCheckCanEverBeValid = false
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
@@ -8143,3 +8143,14 @@ exec function TedTest_ClearUnitInventories()
 
 	`GAMERULES.SubmitGameState(NewGameState);
 }
+
+// static function bool AddArmoryUIStatMarkups(const ECharStatType Stat, out int Result, const array<SoldierClassAbilityType> SoldierAbilities, const XComGameState_Unit UnitState)
+// {
+// 	if (Stat == eStat_Mobility)
+// 	{
+// 		Result = -1 * class'X2Effect_ItemWeight2'.static.GetItemWeightForUnit(UnitState);
+// 		return true;
+// 	}
+
+// 	return false;
+// }

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_ItemWeight2.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2Effect_ItemWeight2.uc
@@ -1,0 +1,63 @@
+class X2Effect_ItemWeight2 extends X2Effect_ModifyStats config(LW_Overhaul);
+
+var config array<EInventorySlot> SlotsToSkip;
+var privatewrite name WeightAbilityName;
+
+simulated protected function OnEffectAdded(const out EffectAppliedData ApplyEffectParameters, XComGameState_BaseObject kNewTargetState, XComGameState NewGameState, XComGameState_Effect NewEffectState)
+{
+    local XComGameState_Unit TargetUnit;
+    local StatChange Change;
+
+    TargetUnit = XComGameState_Unit(kNewTargetState);
+
+    Change.StatType = eStat_Mobility;
+    if (TargetUnit != none)
+    {
+        Change.StatAmount = -1 * GetItemWeightForUnit(TargetUnit, NewGameState);
+    }
+    NewEffectState.StatChanges.AddItem(Change);
+
+    super.OnEffectAdded(ApplyEffectParameters, kNewTargetState, NewGameState, NewEffectState);
+}
+
+static function int GetItemWeightForUnit(XComGameState_Unit UnitState, optional XComGameState CheckGameState)
+{
+    local array<XComGameState_Item> CurrentInventory;
+    local XComGameState_Item        InventoryItem;
+    local X2EquipmentTemplate       EquipmentTemplate;
+    local int                       Weight, Index;
+
+    CurrentInventory = UnitState.GetAllInventoryItems(CheckGameState);
+    foreach CurrentInventory(InventoryItem)
+    {
+        if (default.SlotsToSkip.Find(InventoryItem.InventorySlot) == INDEX_NONE)
+        {
+            EquipmentTemplate = X2EquipmentTemplate(InventoryItem.GetMyTemplate());
+            if (EquipmentTemplate != none)
+            {
+                if (EquipmentTemplate.Abilities.Find(default.WeightAbilityName) != INDEX_NONE)
+                {
+                    Index = class'LWTemplateMods'.default.ItemTable.Find('ItemTemplateName', EquipmentTemplate.DataName);
+                    if (Index != INDEX_NONE)
+                    {
+                        Weight += class'LWTemplateMods'.default.ItemTable[Index].Weight;
+                    }
+                    else
+                    {
+                        Weight++;
+                    }
+                }
+            }
+        }
+    }
+
+    return Weight;
+}
+
+defaultproperties
+{
+    EffectName = "SmallItemWeight"
+    DuplicateResponse = eDupe_Ignore
+
+    WeightAbilityName = "SmallItemWeight"
+}


### PR DESCRIPTION
1. Combine item weight penalty into a single effect.
2. Make weight penalty only apply to XCOM team.
3. Add config array for inventory slots that ignore weight penalty.