### PR TITLE
Update Traverse Fire

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_SoldierSkills.ini
+++ b/LongWarOfTheChosen/Config/XComLW_SoldierSkills.ini
@@ -1038,11 +1038,20 @@ LONEWOLF_DEF_BONUS=12
 LONEWOLF_CRIT_BONUS=0
 LONEWOLF_MIN_DIST_TILES=7  ; The minimum tile distance to get the maximum Lone Wolf bonus
 
+[LW_PerkPack_Integrated.X2Effect_RefundActionPoints]
+; If CBAC is enabled and the effect is set to give actions, only
+; actions of these types will be allow the abilities to be shown as NTE
++CBAC_AllowedTypes = "standard"
++CBAC_AllowedTypes = "runandgun"
+
 [LW_PerkPack_Integrated.X2Effect_TraverseFire]
 TF_USES_PER_TURN=1
 +TF_ABILITYNAMES=StandardShot
 +TF_ABILITYNAMES=SniperStandardFire
 +TF_ABILITYNAMES=SnapShot
+
+TF_ALLOW_CBAC_OVERRIDE = FALSE
+TF_CBAC_OVERRIDE_COLOR = ""
 
 ; Additional standard shot abilities from Zelfana:
 ; Primary only standard shots

--- a/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_PerkPack_Integrated/XComGame.int
@@ -240,9 +240,9 @@ LocPromotionPopupText="<Bullet/> Double Tap allows you to take two shots at the 
 [TraverseFire X2AbilityTemplate]
 LocFriendlyName="Traverse Fire"
 LocFlyOverText="Traverse Fire"
-LocLongDescription="After taking a standard shot with your primary weapon with your first action, you may take an additional non-movement action."
-LocHelpText="After taking a standard shot with your primary weapon with your first action, you may take an additional non-movement action."
-LocPromotionPopupText="<Bullet/> After taking a standard shot with your primary weapon with your first action, you may take an additional non-movement action.<br/>"
+LocLongDescription="After taking a standard shot with your <Ability:BoundWeaponName> with your first action, you may take an additional non-movement action."
+LocHelpText="After taking a standard shot with your <Ability:BoundWeaponName> with your first action, you may take an additional non-movement action."
+LocPromotionPopupText="<Bullet> Can only activate once per turn.<br><Bullet> Free non-offensive actions can be used without invalidating Traverse Fire."
 
 ; LWOTC needs translation
 [WalkFire X2AbilityTemplate]

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Ability_PerkPackAbilitySet.uc
@@ -1212,25 +1212,49 @@ Static function X2AbilityTemplate DoubleTap2ndShot()
 
 static function X2AbilityTemplate AddTraverseFireAbility()
 {
-	local X2AbilityTemplate						Template;
-	local X2Effect_TraverseFire					ActionEffect;
-	
-	`CREATE_X2ABILITY_TEMPLATE (Template, 'TraverseFire');
+	local X2AbilityTemplate         Template;
+	local X2Effect_Persistent       PersistentEffect;
+	local X2Effect_TraverseFire     Effect;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'TraverseFire');
+
 	Template.IconImage = "img:///UILibrary_LW_PerkPack.LW_AbilityTraverseFire";
 	Template.AbilitySourceName = 'eAbilitySource_Perk';
-	Template.eAbilityIconBehaviorHUD = EAbilityIconBehavior_NeverShow;
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
 	Template.Hostility = eHostility_Neutral;
+	Template.bIsPassive = true;
+	Template.bUniqueSource = true;
+
+	Template.bCrossClassEligible = false;
+
 	Template.AbilityToHitCalc = default.DeadEye;
 	Template.AbilityTargetStyle = default.SelfTarget;
 	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
-	Template.bIsPassive = true;
-	ActionEffect = new class 'X2Effect_TraverseFire';
-	ActionEffect.SetDisplayInfo (ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true,,Template.AbilitySourceName);
-	ActionEffect.BuildPersistentEffect(1, true, false);
-	Template.AddTargetEffect(ActionEffect);
-	Template.bCrossClassEligible = false;
+
+	// Separate effects for the passive and the refund
+	PersistentEffect = new class'X2Effect_Persistent';
+	PersistentEffect.EffectName = 'TraverseFire_LW_Passive';
+	PersistentEffect.DuplicateResponse = eDupe_Ignore;
+	PersistentEffect.BuildPersistentEffect(1, true, false);
+	PersistentEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage,,, Template.AbilitySourceName);
+	Template.AddTargetEffect(PersistentEffect);
+
+	Effect = new class'X2Effect_TraverseFire';
+	Effect.EffectName = 'TraverseFire_LW';
+	Effect.bRefundAll = false;
+	Effect.ActionPointType = class'X2CharacterTemplateManager'.default.RunAndGunActionPoint;
+	Effect.AllowedAbilities = class'X2Effect_TraverseFire'.default.TF_ABILITYNAMES;
+	Effect.ActivationsPerTurn = class'X2Effect_TraverseFire'.default.TF_USES_PER_TURN;
+	Effect.bMatchSourceWeapon = true;
+	Effect.bShowFlyover = true;
+	Effect.bAllowCBACOverride = class'X2Effect_TraverseFire'.default.TF_ALLOW_CBAC_OVERRIDE;
+	Effect.strCBACOverrideColor = class'X2Effect_TraverseFire'.default.TF_CBAC_OVERRIDE_COLOR;
+	Effect.BuildPersistentEffect(1, true, false);
+	Effect.SetDisplayInfo(ePerkBuff_Bonus, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage, false);
+	Template.AddTargetEffect(Effect);
+
 	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
-	// Visualization handled in Effect
+
 	return Template;
 }
 

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_RefundActionPoints.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_RefundActionPoints.uc
@@ -1,0 +1,358 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Effect_RefundActionPoints.uc
+//  AUTHOR:  Merist
+//  PURPOSE: Adding or refunding action points when an ability is activatied
+//---------------------------------------------------------------------------------------
+class X2Effect_RefundActionPoints extends X2Effect_Persistent config(LW_SoldierSkills);
+
+var array<name> AllowedAbilities;
+
+// If `true`, PostAbilityCostPaid will be used to return the action point array to the previous state
+// If `false`, OnAbilityActivated will be used to add an action point
+var bool bRefundAll;
+// The of the action point to add if `bRefundAll = false`
+var name ActionPointType;
+
+// Require the source weapon of the effect and the ability to match
+var bool bMatchSourceWeapon;
+
+// Name of the value to count activations
+var name CountValueName;
+// Max number of activations per turn
+var int ActivationsPerTurn;
+
+// Add effect flyover visualization
+var bool bShowFlyover;
+// EventID to use for a flyover if `bRefundAll = true`
+var name FlyoverEventName;
+
+// Allow using Cost-Based Ability Colors' tuple to adjust the color
+// Cannot rely on ability context
+var bool bAllowCBACOverride;
+var string strCBACOverrideColor;
+var config array<name> CBAC_AllowedTypes;
+
+function RegisterForEvents(XComGameState_Effect EffectGameState)
+{
+    local X2EventManager EventMgr;
+    local XComGameState_Unit TargetUnit;
+    local Object EffectObj;
+
+    EventMgr = `XEVENTMGR;
+
+    EffectObj = EffectGameState;
+    TargetUnit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(EffectGameState.ApplyEffectParameters.TargetStateObjectRef.ObjectID));
+
+    if (bRefundAll && bShowFlyover && FlyoverEventName != '')
+    {
+        EventMgr.RegisterForEvent(EffectObj, FlyoverEventName, EffectGameState.TriggerAbilityFlyover, ELD_OnStateSubmitted,, TargetUnit);
+    }
+
+    if (!bRefundAll)
+    {
+        EventMgr.RegisterForEvent(EffectObj, 'AbilityActivated', OnAbilityActivated, ELD_OnStateSubmitted,, TargetUnit,, EffectObj);
+    }
+
+    /// ```event
+    /// EventID: OverrideAbilityIconColorCBAC,
+    /// EventData: [
+    ///     in XComGameState AbilityState,
+    ///     out bool bOverride,
+    ///     inout string EventOverrideColor,
+    ///     inout int PointCost,
+    ///     inout int TurnEnding
+    /// ],
+    /// EventSource: XComGameState_Unit (UnitState)
+    /// NewGameState: none
+    /// ```
+    if (bAllowCBACOverride)
+    {
+        EventMgr.RegisterForEvent(EffectObj, 'OverrideAbilityIconColorCBAC', OnOverrideAbilityIconColor, ELD_Immediate,, TargetUnit,, EffectObj);
+    }
+}
+
+static function EventListenerReturn OnOverrideAbilityIconColor(Object EventData, Object EventSource, XComGameState GameState, Name EventID, Object CallbackData)
+{
+    local XComLWTuple                   Tuple;
+    local bool                          bOverride;
+    local XComGameState_Unit            UnitState;
+    local XComGameState_Ability         AbilityState;
+    local XComGameState_Effect          EffectState;
+    local X2Effect_RefundActionPoints   Effect;
+    local string                        strOverrideColor;
+    local int                           PointCost;
+    local bool                          bIsTurnEnding;
+
+    Tuple = XComLWTuple(EventData);
+
+    `assert(Tuple != none);
+    `assert(Tuple.Id == 'OverrideAbilityIconColorCBAC');
+
+    bOverride = Tuple.Data[1].b;
+    strOverrideColor = Tuple.Data[2].s;
+    PointCost = Tuple.Data[3].i;
+    bIsTurnEnding = bool(Tuple.Data[4].i);
+
+    if (PointCost > 0)
+    {
+        UnitState = XComGameState_Unit(EventSource);
+        AbilityState = XComGameState_Ability(Tuple.Data[0].o);
+        EffectState = XComGameState_Effect(CallbackData);
+        if (UnitState != none && AbilityState != none && EffectState != none)
+        {
+            Effect = X2Effect_RefundActionPoints(EffectState.GetX2Effect());
+            if (Effect != none)
+            {
+                if (Effect.IsEffectCurrentlyRelevant(EffectState, UnitState))
+                {
+                    if (Effect.IsAbilityRelevant(AbilityState, UnitState, EffectState))
+                    {
+                        if (Effect.bRefundAll)
+                        {
+                            bOverride = true;
+                            PointCost = 0;
+                            bIsTurnEnding = false;
+                        }
+                        else
+                        {
+                            if (bIsTurnEnding)
+                            {
+                                if (default.CBAC_AllowedTypes.Find(Effect.ActionPointType) != INDEX_NONE)
+                                {
+                                    bOverride = true;
+                                    PointCost = Max(0, UnitState.ActionPoints.Length - 1);
+                                    bIsTurnEnding = false;
+                                }
+                            }
+                            else
+                            {
+                                bOverride = true;
+                                PointCost = Max(0, PointCost - 1);
+                            }
+                        }
+
+                        if (bOverride)
+                        {
+                            if (strOverrideColor == "")
+                            {
+                                strOverrideColor = Effect.strCBACOverrideColor;
+                            }
+                            Tuple.Data[1].b = bOverride;
+                            Tuple.Data[2].s = strOverrideColor;
+                            Tuple.Data[3].i = PointCost;
+                            Tuple.Data[4].i = int(bIsTurnEnding);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnAbilityActivated(Object EventData, Object EventSource, XComGameState GameState, Name EventID, Object CallbackData)
+{
+    local XComGameStateContext_Ability  AbilityContext;
+    local XComGameState_Unit            SourceUnit;
+    local XComGameState_Ability         AbilityState;
+    local XComGameState_Effect          EffectState;
+    local X2Effect_RefundActionPoints   Effect;
+    local XComGameState                 NewGameState;
+    local UnitValue                     CountUnitValue;
+
+    AbilityContext = XComGameStateContext_Ability(GameState.GetContext());
+
+    if (AbilityContext != none && AbilityContext.InterruptionStatus != eInterruptionStatus_Interrupt)
+    {
+        SourceUnit = XComGameState_Unit(EventSource);
+        AbilityState = XComGameState_Ability(EventData);
+        EffectState = XComGameState_Effect(CallbackData);
+
+        if (SourceUnit != none && AbilityState != none && EffectState != none)
+        {
+            Effect = X2Effect_RefundActionPoints(EffectState.GetX2Effect());
+
+            if (Effect != none)
+            {
+                if (Effect.IsEffectCurrentlyRelevant(EffectState, SourceUnit))
+                {
+                    if (Effect.IsAbilityRelevant(AbilityState, SourceUnit, EffectState))
+                    {
+                        if (!WasAbilityFree(AbilityState, SourceUnit, GameState.HistoryIndex - 1))
+                        {
+                            NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState(string(GetFuncName()));
+                            SourceUnit = XComGameState_Unit(NewGameState.ModifyStateObject(SourceUnit.Class, SourceUnit.ObjectID));
+
+                            if (Effect.CountValueName != '')
+                            {
+                                SourceUnit.GetUnitValue(Effect.CountValueName, CountUnitValue);
+                                SourceUnit.SetUnitFloatValue(Effect.CountValueName, CountUnitValue.fValue + 1, eCleanup_BeginTurn);
+                            }
+
+                            if (Effect.bShowFlyover)
+                            {
+                                NewGameState.ModifyStateObject(class'XComGameState_Ability', EffectState.ApplyEffectParameters.AbilityStateObjectRef.ObjectID);
+                                XComGameStateContext_ChangeContainer(NewGameState.GetContext()).BuildVisualizationFn = EffectState.TriggerAbilityFlyoverVisualizationFn;
+                            }
+
+                            SourceUnit.ActionPoints.AddItem(Effect.GetActionPointType());
+
+                            `TACTICALRULES.SubmitGameState(NewGameState);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return ELR_NoInterrupt;
+}
+
+function bool PostAbilityCostPaid(
+    XComGameState_Effect EffectState,
+    XComGameStateContext_Ability AbilityContext,
+    XComGameState_Ability kAbility,
+    XComGameState_Unit SourceUnit,
+    XComGameState_Item AffectWeapon,
+    XComGameState NewGameState,
+    const array<name> PreCostActionPoints,
+    const array<name> PreCostReservePoints)
+{
+    local XComGameState_Ability EffectAbilityState;
+    local UnitValue             CountUnitValue;
+
+    if (bRefundAll)
+    {
+        if (IsEffectCurrentlyRelevant(EffectState, SourceUnit))
+        {
+            if (IsAbilityRelevant(kAbility, SourceUnit, EffectState))
+            {
+                if (!WasAbilityFree(kAbility, SourceUnit))
+                {
+                    if (CountValueName != '')
+                    {
+                        SourceUnit.GetUnitValue(CountValueName, CountUnitValue);
+                        SourceUnit.SetUnitFloatValue(CountValueName, CountUnitValue.fValue + 1, eCleanup_BeginTurn);
+                    }
+
+                    if (bShowFlyover && FlyoverEventName != '')
+                    {
+                        EffectAbilityState = XComGameState_Ability(`XCOMHISTORY.GetGameStateForObjectID(EffectState.ApplyEffectParameters.AbilityStateObjectRef.ObjectID));
+                        `XEVENTMGR.TriggerEvent(FlyoverEventName, EffectAbilityState, SourceUnit, NewGameState);
+                    }
+
+                    SourceUnit.ActionPoints = PreCostActionPoints;
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+function bool IsAbilityRelevant(XComGameState_Ability AbilityState, XComGameState_Unit SourceUnit, XComGameState_Effect EffectState)
+{
+    if (AllowedAbilities.Length > 0 && AllowedAbilities.Find(AbilityState.GetMyTemplateName()) == INDEX_NONE)
+    {
+        return false;
+    }
+
+    if (bMatchSourceWeapon)
+    {
+        if (AbilityState.SourceWeapon.ObjectID > 0)
+        {
+            if (AbilityState.SourceWeapon != EffectState.ApplyEffectParameters.ItemStateObjectRef)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function bool IsEffectCurrentlyRelevant(XComGameState_Effect EffectGameState, XComGameState_Unit TargetUnit)
+{
+    local UnitValue CountUnitValue;
+
+    if (class'Helpers_LW'.static.IsUnitInterruptingEnemyTurn(TargetUnit))
+    {
+        return false;
+    }
+
+    if (CountValueName != '')
+    {
+        TargetUnit.GetUnitValue(CountValueName, CountUnitValue);
+        if (ActivationsPerTurn > 0 && CountUnitValue.fValue >= ActivationsPerTurn)
+            return false;
+    }
+    
+    return true;
+}
+
+
+function name GetActionPointType()
+{
+    if (ActionPointType != '')
+    {
+        return ActionPointType;
+    }
+    else
+    {
+        return class'X2CharacterTemplateManager'.default.StandardActionPoint;
+    }
+}
+
+static function bool WasAbilityFree(XComGameState_Ability AbilityState, XComGameState_Unit AbilityOwner, optional int HistoryIndex = -1)
+{
+    local XComGameStateHistory      History;
+    local XComGameState_Ability     OldAbilityState;
+    local XComGameState_Unit        OldAbilityOwner;
+    local X2AbilityTemplate         Template;
+    local X2AbilityCost             Cost;
+    local X2AbilityCost_ActionPoints ActionPointCost;
+
+    History = `XCOMHISTORY;
+
+    Template = AbilityState.GetMyTemplate();
+
+    if (HistoryIndex != -1)
+    {
+        OldAbilityState = XComGameState_Ability(History.GetGameStateForObjectID(AbilityState.ObjectID,, HistoryIndex));
+        OldAbilityOwner = XComGameState_Unit(History.GetGameStateForObjectID(AbilityOwner.ObjectID,, HistoryIndex));
+    }
+    else
+    {
+        OldAbilityState = XComGameState_Ability(History.GetGameStateForObjectID(AbilityState.ObjectID));
+        OldAbilityOwner = XComGameState_Unit(History.GetGameStateForObjectID(AbilityOwner.ObjectID));
+    }
+
+    foreach Template.AbilityCosts(Cost)
+    {
+        ActionPointCost = X2AbilityCost_ActionPoints(Cost);
+        if (ActionPointCost != none)
+        {
+            if (!ActionPointCost.bFreeCost && ActionPointCost.GetPointCost(OldAbilityState, OldAbilityOwner) > 0)
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+defaultproperties
+{
+    EffectName = RefundActionPoints_LW
+    DuplicateResponse = eDupe_Ignore
+    bRefundAll = true
+
+    bAllowCBACOverride = false
+}

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_TraverseFire.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2Effect_TraverseFire.uc
@@ -1,67 +1,140 @@
-class X2Effect_TraverseFire extends X2Effect_Persistent config (LW_SoldierSkills);
+class X2Effect_TraverseFire extends X2Effect_RefundActionPoints config(LW_SoldierSkills);
 
 var config int TF_USES_PER_TURN;
 var config array<name> TF_ABILITYNAMES;
-var name CounterName;
-var name EventName;
+var config bool TF_ALLOW_CBAC_OVERRIDE;
+var config string TF_CBAC_OVERRIDE_COLOR;
 
-function RegisterForEvents(XComGameState_Effect EffectGameState)
+static function EventListenerReturn OnAbilityActivated(Object EventData, Object EventSource, XComGameState GameState, Name EventID, Object CallbackData)
 {
-	local XComGameState_Unit		UnitState;
-	local Object					EffectObj;
+    local XComGameStateContext_Ability  AbilityContext;
+    local XComGameState_Unit            SourceUnit;
+    local XComGameState_Ability         AbilityState;
+    local XComGameState_Effect          EffectState;
+    local X2Effect_RefundActionPoints   Effect;
+    local XComGameState                 NewGameState;
+    local UnitValue                     CountUnitValue;
+    local bool                          bFreeAbility;
 
-	EffectObj = EffectGameState;
-	UnitState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(EffectGameState.ApplyEffectParameters.SourceStateObjectRef.ObjectID));
-	`XEVENTMGR.RegisterForEvent(EffectObj, EventName, EffectGameState.TriggerAbilityFlyover, ELD_OnStateSubmitted, 40, UnitState);
+    AbilityContext = XComGameStateContext_Ability(GameState.GetContext());
+
+    if (AbilityContext != none && AbilityContext.InterruptionStatus != eInterruptionStatus_Interrupt)
+    {
+        SourceUnit = XComGameState_Unit(EventSource);
+        AbilityState = XComGameState_Ability(EventData);
+        EffectState = XComGameState_Effect(CallbackData);
+
+        if (SourceUnit != none && AbilityState != none && EffectState != none)
+        {
+            Effect = X2Effect_RefundActionPoints(EffectState.GetX2Effect());
+            bFreeAbility = WasAbilityFree(AbilityState, SourceUnit);
+
+            if (Effect != none)
+            {
+                if (Effect.IsEffectCurrentlyRelevant(EffectState, SourceUnit))
+                {
+                    if (Effect.IsAbilityRelevant(AbilityState, SourceUnit, EffectState))
+                    {
+                        if (!bFreeAbility)
+                        {
+                            NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState(string(GetFuncName()));
+                            SourceUnit = XComGameState_Unit(NewGameState.ModifyStateObject(SourceUnit.Class, SourceUnit.ObjectID));
+
+                            if (Effect.CountValueName != '')
+                            {
+                                SourceUnit.GetUnitValue(Effect.CountValueName, CountUnitValue);
+                                SourceUnit.SetUnitFloatValue(Effect.CountValueName, CountUnitValue.fValue + 1, eCleanup_BeginTurn);
+                            }
+
+                            if (Effect.bShowFlyover)
+                            {
+                                NewGameState.ModifyStateObject(class'XComGameState_Ability', EffectState.ApplyEffectParameters.AbilityStateObjectRef.ObjectID);
+                                XComGameStateContext_ChangeContainer(NewGameState.GetContext()).BuildVisualizationFn = EffectState.TriggerAbilityFlyoverVisualizationFn;
+                            }
+
+                            SourceUnit.ActionPoints.AddItem(Effect.GetActionPointType());
+
+                            `TACTICALRULES.SubmitGameState(NewGameState);
+                        }
+                    }
+                    else
+                    {
+                        if (AbilityState.IsAbilityInputTriggered())
+                        {
+                            if (AbilityState.GetMyTemplate().Hostility == eHostility_Offensive || !bFreeAbility)
+                            {
+                                NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState(string(GetFuncName()));
+                                SourceUnit = XComGameState_Unit(NewGameState.ModifyStateObject(SourceUnit.Class, SourceUnit.ObjectID));
+                                SourceUnit.SetUnitFloatValue(Effect.CountValueName, Effect.ActivationsPerTurn + 1, eCleanup_BeginTurn);
+                                `TACTICALRULES.SubmitGameState(NewGameState);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return ELR_NoInterrupt;
 }
 
 function bool PostAbilityCostPaid(XComGameState_Effect EffectState, XComGameStateContext_Ability AbilityContext, XComGameState_Ability kAbility, XComGameState_Unit SourceUnit, XComGameState_Item AffectWeapon, XComGameState NewGameState, const array<name> PreCostActionPoints, const array<name> PreCostReservePoints)
 {
-	local XComGameState_Ability					AbilityState;
-	local int									iCounter;
-	local UnitValue								UnitValue;
+    local XComGameState_Ability EffectAbilityState;
+    local UnitValue             CountUnitValue;
+    local bool                  bFreeAbility;
 
-	if (SourceUnit.IsUnitAffectedByEffectName(class'X2Effect_Serial'.default.EffectName))
-		return false;
+    bFreeAbility = WasAbilityFree(kAbility, SourceUnit);
 
-	if (class'Helpers_LW'.static.IsUnitInterruptingEnemyTurn(SourceUnit))
-		return false;
-
-	SourceUnit.GetUnitValue(CounterName, UnitValue);
-	iCounter = int(UnitValue.fValue);
-
-	if (iCounter >= default.TF_USES_PER_TURN)
-		return false;
-
-	AbilityState = XComGameState_Ability(`XCOMHISTORY.GetGameStateForObjectID(EffectState.ApplyEffectParameters.AbilityStateObjectRef.ObjectID));
-
-    if (AbilityState != none)
+    if (bRefundAll)
     {
-        if (default.TF_ABILITYNAMES.Find(kAbility.GetMyTemplateName()) != -1)
+        if (IsEffectCurrentlyRelevant(EffectState, SourceUnit))
         {
-			if (kAbility.SourceWeapon != EffectState.ApplyEffectParameters.ItemStateObjectRef)
-				return false;
+            if (IsAbilityRelevant(kAbility, SourceUnit, EffectState))
+            {
+                if (!bFreeAbility)
+                {
+                    if (CountValueName != '')
+                    {
+                        SourceUnit.GetUnitValue(CountValueName, CountUnitValue);
+                        SourceUnit.SetUnitFloatValue(CountValueName, CountUnitValue.fValue + 1, eCleanup_BeginTurn);
+                    }
 
-			SourceUnit.SetUnitFloatValue(CounterName, iCounter + 1.0, eCleanup_BeginTurn);
-			SourceUnit.ActionPoints.AddItem(class'X2CharacterTemplateManager'.default.RunAndGunActionPoint);
-			`XEVENTMGR.TriggerEvent(EventName, AbilityState, SourceUnit, NewGameState);
-		}
-		else
-		{
-			if (kAbility.IsAbilityInputTriggered()) {
-				if (kAbility.GetMyTemplate().Hostility == eHostility_Offensive || PreCostActionPoints.Length - SourceUnit.ActionPoints.Length > 0) {
-					SourceUnit.SetUnitFloatValue(CounterName, iCounter + 1.0, eCleanup_BeginTurn);
-				}
-			}
-		}
+                    if (bShowFlyover && FlyoverEventName != '')
+                    {
+                        EffectAbilityState = XComGameState_Ability(`XCOMHISTORY.GetGameStateForObjectID(EffectState.ApplyEffectParameters.AbilityStateObjectRef.ObjectID));
+                        `XEVENTMGR.TriggerEvent(FlyoverEventName, EffectAbilityState, SourceUnit, NewGameState);
+                    }
+
+                    SourceUnit.ActionPoints = PreCostActionPoints;
+                    return true;
+                }
+            }
+            else
+            {
+                if (kAbility.IsAbilityInputTriggered())
+                {
+                    if (kAbility.GetMyTemplate().Hostility == eHostility_Offensive || !bFreeAbility)
+                    {
+                        SourceUnit.SetUnitFloatValue(CountValueName, ActivationsPerTurn + 1, eCleanup_BeginTurn);
+                    }
+                }
+            }
+        }
     }
-	return false;
+
+    return false;
 }
 
 defaultproperties
 {
-	DuplicateResponse = eDupe_Ignore
-	EffectName = "LW_TraverseFire"
-    CounterName = LW_TraverseFire
-	EventName = LW_TraverseFire
+    EffectName = TraverseFire_LW
+    DuplicateResponse = eDupe_Ignore
+
+    CountValueName = TraverseFire_LW_Activations
+    FlyoverEventName = TraverseFire_LW_Flyover
+
+    bRefundAll = false
+
+    bMatchSourceWeapon = true
 }


### PR DESCRIPTION
1. Add `X2Effect_RefundActionPoints`.
2. Improve the logic of cost validation.
3. Add configs to allow Cost-Based Ability Colors override.