### PR TITLE
updates Zone Of Control's localization tag

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -6648,8 +6648,8 @@ LocPromotionPopupText="<Bullet/> By cleverly combining the effects of Brutality 
 
 [ZoneOfControl_LW X2AbilityTemplate]
 LocFriendlyName = "Zone of Control"
-LocHelpText = "All enemies within the <Ability:ClassName/>'s <Ability:ZONE_CONTROL_RADIUS/> tile radius suffer penalties of <Ability:ZONE_CONTROL_AIM_PENALTY/> Aim and <Ability:ZONE_CONTROL_MOBILITY_PENALTY/> Mobility."
-LocLongDescription = "All enemies within the <Ability:ClassName/>'s <Ability:ZONE_CONTROL_RADIUS/> tile radius suffer penalties to Aim and Mobility."
+LocHelpText = "All enemies within the <Ability:ClassName_Source/>'s <Ability:ZONE_CONTROL_RADIUS/> tile radius suffer penalties of <Ability:ZONE_CONTROL_AIM_PENALTY/> Aim and <Ability:ZONE_CONTROL_MOBILITY_PENALTY/> Mobility."
+LocLongDescription = "All enemies within the <Ability:ClassName_Source/>'s <Ability:ZONE_CONTROL_RADIUS/> tile radius suffer penalties to Aim and Mobility."
 ; LWOTC Needs Translation (2)
 LocPromotionPopupText = "<Bullet/> All enemies within the <Ability:ClassName/>'s <Ability:ZONE_CONTROL_RADIUS/> tile radius suffer penalties of <Ability:ZONE_CONTROL_AIM_PENALTY/> Aim and <Ability:ZONE_CONTROL_MOBILITY_PENALTY/> Mobility.<br/>"
 ; End Translation (2)

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2DownloadableContentInfo_LWPerkPack.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2DownloadableContentInfo_LWPerkPack.uc
@@ -116,6 +116,7 @@ static function bool AbilityTagExpandHandler_CH(string InString, out string OutS
 {
 	local XComGameState_Ability AbilityState;
 	local XComGameState_Effect EffectState;
+	local XComGameState_Unit UnitState;
 	local X2AbilityTemplate AbilityTemplate;
 	local X2ItemTemplate ItemTemplate;
 	local name Type;
@@ -657,6 +658,42 @@ static function bool AbilityTagExpandHandler_CH(string InString, out string OutS
 			return true;
 		case 'SensorOverlays_CritBonus_LW':
 			OutString = string(class'X2Ability_XMBPerkAbilitySet'.default.SensorOverlaysCritBonus);
+			return true;
+		case 'ClassName_Source':
+			if (StrategyParseObj != none)
+			{
+				OutString = XComGameState_Unit(StrategyParseObj).GetSoldierClassTemplate().DisplayName;
+				return true;
+			}
+			else
+			{
+				AbilityState = XComGameState_Ability(ParseObj);
+				if (AbilityState != none)
+				{
+					UnitState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(AbilityState.OwnerStateObject.ObjectID));
+				}
+				else
+				{
+					EffectState = XComGameState_Effect(ParseObj);
+					if (EffectState != none)
+					{
+						UnitState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(EffectState.ApplyEffectParameters.SourceStateObjectRef.ObjectID));
+					}
+				}
+				if (UnitState != none)
+				{
+					if (UnitState.GetSoldierClassTemplate() != none)
+					{
+						OutString = UnitState.GetSoldierClassTemplate().DisplayName;
+					}
+					else
+					{
+						OutString = UnitState.GetMyTemplate().strCharacterName;
+					}
+					return true;
+				}
+			}
+			OutString = class'XGLocalizedData'.default.StaffTypeNames[eStaff_Soldier];
 			return true;
 		default:
 			return false;


### PR DESCRIPTION
The old tag could fail when the ability was on enemy units (as they don't have a SoldierClass set) or when seeing the debuff's description on enemies (for the same reason).