### PR TITLE
Update markup for item weight

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWTemplateMods.uc
@@ -3476,8 +3476,8 @@ function ReconfigGear(X2ItemTemplate Template, int Difficulty)
 					if (ItemTable[i].Weight > 0)
 					{
 						EquipmentTemplate.Abilities.AddItem('SmallItemWeight');
-						// TODO: Move mobility penalty display from item weight to AddArmoryUIStatMarkups()
-						EquipmentTemplate.SetUIStatMarkup(class'XLocalizedData'.default.MobilityLabel, eStat_Mobility, -ItemTable[i].Weight, true);
+						// The mobility penalty display has been moved to AddArmoryUIStatMarkups()
+						// EquipmentTemplate.SetUIStatMarkup(class'XLocalizedData'.default.MobilityLabel, eStat_Mobility, -ItemTable[i].Weight, true);
 
 						//`LOG ("Adding Weight to" @ EquipmentTemplate.DataName);
 					}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2DownloadableContentInfo_LongWarOfTheChosen.uc
@@ -8144,13 +8144,14 @@ exec function TedTest_ClearUnitInventories()
 	`GAMERULES.SubmitGameState(NewGameState);
 }
 
-// static function bool AddArmoryUIStatMarkups(const ECharStatType Stat, out int Result, const array<SoldierClassAbilityType> SoldierAbilities, const XComGameState_Unit UnitState)
-// {
-// 	if (Stat == eStat_Mobility)
-// 	{
-// 		Result = -1 * class'X2Effect_ItemWeight2'.static.GetItemWeightForUnit(UnitState);
-// 		return true;
-// 	}
+static function bool AddArmoryUIStatMarkups(const ECharStatType Stat, out int Result, const array<SoldierClassAbilityType> SoldierAbilities, const XComGameState_Unit UnitState)
+{
+	// Handles mobility penalty display for item weight
+	if (Stat == eStat_Mobility)
+	{
+		Result = -1 * class'X2Effect_ItemWeight2'.static.GetItemWeightForUnit(UnitState);
+		return true;
+	}
 
-// 	return false;
-// }
+	return false;
+}


### PR DESCRIPTION
Move mobility penalty display for item weight to the new DLCInfo hook.

Continuation of #1982 